### PR TITLE
fix: Git Bash MinTTY detection with actionable error message

### DIFF
--- a/cmd/compat_other.go
+++ b/cmd/compat_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package cmd
+
+// checkTerminalCompat detects terminal environments where the TUI cannot
+// render correctly. On non-Windows platforms this is a no-op — MSYS/MinTTY
+// compatibility issues are Windows-specific.
+func checkTerminalCompat() string { return "" }

--- a/cmd/compat_windows.go
+++ b/cmd/compat_windows.go
@@ -1,0 +1,78 @@
+//go:build windows
+
+package cmd
+
+import (
+	"os"
+	"strings"
+)
+
+// checkTerminalCompat detects MSYS/Git Bash environments where the TUI
+// cannot render correctly. MinTTY (the default Git Bash terminal) uses
+// MSYS pseudo-TTYs that Go sees as pipes at the POSIX layer, but the
+// Windows standard handles (GetStdHandle) still point at the original
+// console — so GetConsoleMode misleadingly succeeds. We therefore use
+// environment variables to detect MinTTY vs ConPTY-capable terminals.
+//
+// Returns a non-empty diagnostic message when the terminal is known to be
+// incompatible; returns "" when the environment is safe or the caller has
+// set GRUT_FORCE_TERMINAL to a non-empty value to bypass the check.
+func checkTerminalCompat() string {
+	// Allow users to bypass the check when they know their terminal
+	// supports ConPTY but is not in the built-in allowlist
+	// (e.g. Alacritty, WezTerm).
+	if os.Getenv("GRUT_FORCE_TERMINAL") != "" {
+		return ""
+	}
+
+	if os.Getenv("MSYSTEM") == "" {
+		return "" // not running under MSYS/Git Bash
+	}
+
+	// ConPTY-capable terminals provide genuine console I/O even when
+	// running a Git Bash shell. Detect them by their env vars.
+	if isConPTYTerminal() {
+		return ""
+	}
+
+	// MSYSTEM is set but we are not in a ConPTY terminal — almost
+	// certainly MinTTY (standalone Git Bash). The TUI will render a
+	// blank screen.
+	return `grut does not work in Git Bash (MinTTY).
+
+WHY: Git Bash uses MinTTY as its terminal, which communicates with programs
+through MSYS2 pseudo-TTYs (POSIX-style pipes). Go programs on Windows use the
+Win32 console API for terminal I/O (raw mode, alternate screen, key events).
+These two layers are incompatible — Go reads from the Windows console handle
+while MinTTY writes to its own pipe, resulting in a blank screen.
+
+This affects all Go TUI applications (Bubble Tea, tview, tcell), not just
+grut. It is a known limitation of MinTTY with native Windows programs.
+
+ALTERNATIVES (any of these will work):
+  - PowerShell:        grut
+  - Command Prompt:    grut
+  - Windows Terminal:  Add a Git Bash profile — grut works via ConPTY
+  - winpty wrapper:    winpty grut
+  - Override:          GRUT_FORCE_TERMINAL=1 grut
+
+MORE INFO: https://www.msys2.org/docs/terminals/`
+}
+
+// isConPTYTerminal returns true when the process is running inside a
+// terminal that provides ConPTY (real Windows console) even for MSYS shells.
+func isConPTYTerminal() bool {
+	// Windows Terminal
+	if os.Getenv("WT_SESSION") != "" {
+		return true
+	}
+	// VS Code integrated terminal
+	if strings.EqualFold(os.Getenv("TERM_PROGRAM"), "vscode") {
+		return true
+	}
+	// ConEmu / Cmder
+	if os.Getenv("ConEmuPID") != "" {
+		return true
+	}
+	return false
+}

--- a/cmd/compat_windows_test.go
+++ b/cmd/compat_windows_test.go
@@ -1,0 +1,267 @@
+//go:build windows
+
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckTerminalCompat_NoMSYSTEM(t *testing.T) {
+	// When MSYSTEM is not set (PowerShell, cmd, etc.), the check should pass.
+	t.Setenv("MSYSTEM", "")
+	assert.Empty(t, checkTerminalCompat(), "should return empty when MSYSTEM is unset")
+}
+
+func TestCheckTerminalCompat_MinTTY(t *testing.T) {
+	// Simulate standalone Git Bash (MinTTY): MSYSTEM is set but no
+	// ConPTY terminal env vars are present.
+	t.Setenv("MSYSTEM", "MINGW64")
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("ConEmuPID", "")
+	t.Setenv("GRUT_FORCE_TERMINAL", "")
+
+	msg := checkTerminalCompat()
+	require.NotEmpty(t, msg, "should return error message for MinTTY")
+
+	// Verify the message contains key information.
+	for _, want := range []string{
+		"MinTTY",
+		"MSYS2 pseudo-TTY",
+		"PowerShell",
+		"Windows Terminal",
+		"winpty",
+		"https://www.msys2.org/docs/terminals/",
+	} {
+		assert.Contains(t, msg, want)
+	}
+}
+
+func TestCheckTerminalCompat_WindowsTerminal(t *testing.T) {
+	// Git Bash shell inside Windows Terminal — WT_SESSION is set.
+	t.Setenv("MSYSTEM", "MINGW64")
+	t.Setenv("WT_SESSION", "some-guid")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("ConEmuPID", "")
+
+	assert.Empty(t, checkTerminalCompat(), "should pass for Windows Terminal")
+}
+
+func TestCheckTerminalCompat_VSCode(t *testing.T) {
+	// Git Bash shell inside VS Code integrated terminal.
+	t.Setenv("MSYSTEM", "MINGW64")
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("TERM_PROGRAM", "vscode")
+	t.Setenv("ConEmuPID", "")
+
+	assert.Empty(t, checkTerminalCompat(), "should pass for VS Code terminal")
+}
+
+func TestCheckTerminalCompat_VSCodeCaseInsensitive(t *testing.T) {
+	// TERM_PROGRAM comparison should be case-insensitive.
+	t.Setenv("MSYSTEM", "MINGW64")
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("TERM_PROGRAM", "VSCode")
+	t.Setenv("ConEmuPID", "")
+
+	assert.Empty(t, checkTerminalCompat(), "should be case-insensitive for TERM_PROGRAM=VSCode")
+}
+
+func TestCheckTerminalCompat_ConEmu(t *testing.T) {
+	// Git Bash shell inside ConEmu/Cmder.
+	t.Setenv("MSYSTEM", "MINGW64")
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("ConEmuPID", "12345")
+
+	assert.Empty(t, checkTerminalCompat(), "should pass for ConEmu")
+}
+
+func TestCheckTerminalCompat_UnlistedTerminal(t *testing.T) {
+	// MSYSTEM set with a TERM_PROGRAM not in the ConPTY allowlist.
+	// The check blocks because it cannot confirm ConPTY support.
+	//
+	// NOTE: this is a known limitation — ConPTY-capable terminals like
+	// Alacritty or WezTerm that set TERM_PROGRAM but are not in the
+	// allowlist will be falsely blocked. Users can work around this by
+	// setting GRUT_FORCE_TERMINAL=1 (see TestCheckTerminalCompat_ForceTerminalBypass).
+	t.Setenv("MSYSTEM", "MINGW64")
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("TERM_PROGRAM", "some-unlisted-terminal")
+	t.Setenv("ConEmuPID", "")
+
+	assert.NotEmpty(t, checkTerminalCompat(), "should block for TERM_PROGRAM not in ConPTY allowlist")
+}
+
+func TestIsConPTYTerminal_AllUnset(t *testing.T) {
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("ConEmuPID", "")
+
+	assert.False(t, isConPTYTerminal(), "should return false when no ConPTY env vars are set")
+}
+
+func TestIsConPTYTerminal_WTSession(t *testing.T) {
+	t.Setenv("WT_SESSION", "abc-123")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("ConEmuPID", "")
+
+	assert.True(t, isConPTYTerminal(), "should return true when WT_SESSION is set")
+}
+
+func TestIsConPTYTerminal_VSCode(t *testing.T) {
+	// Direct test for TERM_PROGRAM=vscode in isConPTYTerminal.
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("TERM_PROGRAM", "vscode")
+	t.Setenv("ConEmuPID", "")
+
+	assert.True(t, isConPTYTerminal(), "should return true when TERM_PROGRAM=vscode")
+}
+
+func TestIsConPTYTerminal_ConEmuPID(t *testing.T) {
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("ConEmuPID", "9999")
+
+	assert.True(t, isConPTYTerminal(), "should return true when ConEmuPID is set")
+}
+
+// TestCheckTerminalCompat_MSYSTEMVariants ensures detection works for
+// different MSYSTEM values (MINGW32, MINGW64, UCRT64, CLANG64, etc.)
+func TestCheckTerminalCompat_MSYSTEMVariants(t *testing.T) {
+	variants := []string{"MINGW32", "MINGW64", "UCRT64", "CLANG64", "MSYS"}
+	for _, v := range variants {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("MSYSTEM", v)
+			t.Setenv("WT_SESSION", "")
+			t.Setenv("TERM_PROGRAM", "")
+			t.Setenv("ConEmuPID", "")
+
+			assert.NotEmpty(t, checkTerminalCompat(), "should block for MSYSTEM=%s without ConPTY", v)
+		})
+	}
+}
+
+// TestCheckTerminalCompat_MessageMentionsGrut ensures the error message
+// references grut (not dispatch or another tool).
+func TestCheckTerminalCompat_MessageMentionsGrut(t *testing.T) {
+	t.Setenv("MSYSTEM", "MINGW64")
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("ConEmuPID", "")
+	t.Setenv("GRUT_FORCE_TERMINAL", "")
+
+	msg := checkTerminalCompat()
+	assert.Contains(t, msg, "grut")
+	assert.Contains(t, msg, "GRUT_FORCE_TERMINAL")
+}
+
+// TestCheckTerminalCompat_ForceTerminalBypass verifies the escape hatch:
+// GRUT_FORCE_TERMINAL set to any non-empty value bypasses the MinTTY check,
+// allowing users with ConPTY-capable terminals not in the allowlist
+// (e.g. Alacritty, WezTerm) to run grut.
+func TestCheckTerminalCompat_ForceTerminalBypass(t *testing.T) {
+	t.Setenv("MSYSTEM", "MINGW64")
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("ConEmuPID", "")
+	t.Setenv("GRUT_FORCE_TERMINAL", "1")
+
+	assert.Empty(t, checkTerminalCompat(), "GRUT_FORCE_TERMINAL=1 should bypass MinTTY check")
+}
+
+// ---------------------------------------------------------------------------
+// isConPTYTerminal — additional direct unit tests
+// ---------------------------------------------------------------------------
+
+// TestIsConPTYTerminal_CaseInsensitive verifies that every capitalisation of
+// "vscode" is accepted by isConPTYTerminal directly. strings.EqualFold must
+// handle all variants.
+func TestIsConPTYTerminal_CaseInsensitive(t *testing.T) {
+	variants := []string{"vscode", "VSCODE", "VSCode", "VsCode", "vSCODE"}
+	for _, v := range variants {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("WT_SESSION", "")
+			t.Setenv("TERM_PROGRAM", v)
+			t.Setenv("ConEmuPID", "")
+
+			assert.True(t, isConPTYTerminal(), "isConPTYTerminal() should return true for TERM_PROGRAM=%q", v)
+		})
+	}
+}
+
+// TestIsConPTYTerminal_MultipleSignals verifies correct behaviour when more
+// than one ConPTY indicator is present simultaneously (e.g. VS Code inside
+// Windows Terminal with ConEmu integration active). Any single indicator is
+// sufficient; this confirms the OR logic holds across all three branches.
+func TestIsConPTYTerminal_MultipleSignals(t *testing.T) {
+	t.Setenv("WT_SESSION", "some-guid")
+	t.Setenv("TERM_PROGRAM", "vscode")
+	t.Setenv("ConEmuPID", "1234")
+
+	assert.True(t, isConPTYTerminal(), "isConPTYTerminal() should return true when multiple ConPTY env vars are set")
+}
+
+// ---------------------------------------------------------------------------
+// Integration wiring: root.go RunE — subprocess test
+// ---------------------------------------------------------------------------
+
+// TestRootCmd_MinTTYRejected_Subprocess spawns a child "go run ." process
+// with MSYSTEM=MINGW64 and no ConPTY vars, then asserts the process exits
+// non-zero and emits the MinTTY diagnostic.
+//
+// A subprocess is required because root.go's RunE calls redirectStderr() which
+// invokes windows.SetStdHandle(STD_ERROR_HANDLE, ...) — a process-wide mutation
+// that would corrupt the test runner's own output capture if done in-process.
+func TestRootCmd_MinTTYRejected_Subprocess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess integration test skipped with -short")
+	}
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolve project root: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "main.go")); statErr != nil {
+		t.Skipf("cannot locate main.go at %s: %v", root, statErr)
+	}
+
+	// Inherit env, but strip and override the four compat vars.
+	env := make([]string, 0, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		key := kv
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			key = kv[:i]
+		}
+		switch key {
+		case "MSYSTEM", "WT_SESSION", "TERM_PROGRAM", "ConEmuPID":
+		// stripped — set explicitly below
+		default:
+			env = append(env, kv)
+		}
+	}
+	env = append(env,
+		"MSYSTEM=MINGW64",
+		"WT_SESSION=",
+		"TERM_PROGRAM=",
+		"ConEmuPID=",
+	)
+
+	cmd := exec.Command("go", "run", ".")
+	cmd.Dir = root
+	cmd.Env = env
+	out, runErr := cmd.CombinedOutput()
+
+	require.Error(t, runErr, "grut should exit non-zero in MinTTY environment")
+	assert.Contains(t, string(out), "MinTTY",
+		"expected MinTTY diagnostic in combined output; got:\n%s", out)
+	assert.Contains(t, string(out), "ALTERNATIVES",
+		"expected ALTERNATIVES section in combined output; got:\n%s", out)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,9 @@ Features include a tree-view file explorer with git status markers, full git cli
 operations, tmux-like panes, AI agent integration via MCP, and worktree-first workflows.
 
 Environment:
-  GRUT_LOG            Path to a log file (enables debug logging)`,
+  GRUT_LOG              Path to a log file (enables debug logging)
+  GRUT_FORCE_TERMINAL   Bypass the MinTTY/MSYS compatibility check (set to any
+                        non-empty value, e.g. GRUT_FORCE_TERMINAL=1)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Handle --reset-welcome: reset first-run state and exit.
 			if resetWelcome, _ := cmd.Flags().GetBool("reset-welcome"); resetWelcome {
@@ -108,6 +110,14 @@ Environment:
 			slog.SetDefault(slog.New(slog.NewTextHandler(logWriter, &slog.HandlerOptions{
 				Level: slog.LevelDebug,
 			})))
+
+			// Detect incompatible terminal environments (e.g. MSYS/Git Bash
+			// without a real Windows console handle) and bail out with a
+			// helpful message rather than showing a blank screen.
+			if msg := checkTerminalCompat(); msg != "" {
+				fmt.Fprintln(origStderr, msg)
+				return fmt.Errorf("incompatible terminal")
+			}
 
 			// Load configuration
 			cfg, err := config.Load()

--- a/magefile.go
+++ b/magefile.go
@@ -82,6 +82,11 @@ var deadcodeAllowlist = []string{
 	"MCPRuntime.SendRequest",
 	"resolveCommand",
 	"filterEnvForSubprocess",
+	// mcp_procattr_windows.go — build-tag no-op stubs; called from Load/Close
+	// but unreachable under deadcode's Windows call-graph analysis because
+	// MCPRuntime.Load itself is factory-dispatched (also allowlisted above).
+	"setProcGroup",
+	"killProcGroup",
 
 	// extension/runtime/wasm — loaded via runtime factory; interface impls
 	"NewWASMRuntime",
@@ -306,7 +311,10 @@ func TestWSL() error {
 	}
 
 	// Convert the Windows project directory to a WSL-compatible path.
-	wslPath, err := cmdOutput("wsl", "wslpath", "-u", projectDir())
+	// filepath.ToSlash converts backslashes to forward slashes, which is
+	// required for wslpath on WSL 1 — passing single-backslash Windows paths
+	// causes wslpath to strip the backslashes and return exit status 1.
+	wslPath, err := cmdOutput("wsl", "wslpath", "-u", filepath.ToSlash(projectDir()))
 	if err != nil {
 		return fmt.Errorf("wslpath: %w", err)
 	}
@@ -318,13 +326,51 @@ func TestWSL() error {
 	// containing $(), backticks, or other shell metacharacters.
 	escapedPath := "'" + strings.ReplaceAll(wslPath, "'", "'\\''") + "'"
 
+	// In a git worktree the .git entry is a file containing a Windows-format
+	// "gitdir: <path>" pointer.  WSL cannot resolve that Windows path, which
+	// causes any git command (and tests that call git) to fail with "not a git
+	// repository".  Detect this case, temporarily rewrite .git with the
+	// WSL-compatible path, run the tests, then restore the original file.
+	// This avoids setting GIT_DIR globally (which would break tests that
+	// create their own temporary git repos and inherit the env var).
+	gitFile := filepath.Join(projectDir(), ".git")
+	var origGitContent []byte
+	needsRestore := false
+	if content, readErr := os.ReadFile(gitFile); readErr == nil {
+		line := strings.TrimSpace(string(content))
+		if strings.HasPrefix(line, "gitdir:") {
+			winGitDir := strings.TrimSpace(strings.TrimPrefix(line, "gitdir:"))
+			wslGitDir, convErr := cmdOutput("wsl", "wslpath", "-u", filepath.ToSlash(winGitDir))
+			if convErr == nil {
+				wslGitDir = strings.TrimSpace(wslGitDir)
+				newContent := "gitdir: " + wslGitDir + "\n"
+				if writeErr := os.WriteFile(gitFile, []byte(newContent), 0o644); writeErr == nil {
+					origGitContent = content
+					needsRestore = true
+					fmt.Printf("   .git patched:   gitdir: %s\n", wslGitDir)
+				}
+			}
+		}
+	}
+
 	cmd := exec.Command("wsl", "bash", "-lc",
 		fmt.Sprintf("cd %s && go test ./... -count=1", escapedPath))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Dir = projectDir()
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("wsl test: %w", err)
+	runErr := cmd.Run()
+
+	// Always restore the original .git file, even on test failure.
+	if needsRestore {
+		if restoreErr := os.WriteFile(gitFile, origGitContent, 0o644); restoreErr != nil {
+			fmt.Printf("   WARNING: failed to restore .git: %v\n", restoreErr)
+		} else {
+			fmt.Println("   .git restored")
+		}
+	}
+
+	if runErr != nil {
+		return fmt.Errorf("wsl test: %w", runErr)
 	}
 
 	fmt.Println("   WSL tests passed")


### PR DESCRIPTION
Detect MSYS2/MinTTY terminals on Windows and show a clear error with alternatives instead of a blank screen. ConPTY-capable terminals (Windows Terminal, VS Code, ConEmu) are automatically allowed through.

## Problem

Git Bash uses MinTTY, which communicates via MSYS2 pseudo-TTYs (POSIX pipes). Go TUI apps (Bubble Tea) use Win32 console API. These are incompatible — Go reads from Windows console handle while MinTTY writes to its own pipe, resulting in a blank screen with no error.

## Solution

- Detect MSYS2/MinTTY via \MSYSTEM\ env var
- Allow ConPTY-capable terminals through: Windows Terminal (\WT_SESSION\), VS Code (\TERM_PROGRAM\), ConEmu (\ConEmuPID\)
- Show actionable error message with alternatives (\winpty\, Windows Terminal, \GRUT_FORCE_TERMINAL=1\)
- \GRUT_FORCE_TERMINAL=1\ escape hatch for unlisted ConPTY terminals (Alacritty, WezTerm, etc.)

## Changes

| File | Description |
|------|-------------|
| \cmd/compat_windows.go\ | MinTTY detection + ConPTY bypass + GRUT_FORCE_TERMINAL escape hatch |
| \cmd/compat_other.go\ | Non-Windows no-op stub |
| \cmd/compat_windows_test.go\ | 20+ tests, 100% coverage |
| \cmd/root.go\ | Wire compat check into startup, env var docs |
| \magefile.go\ | Fix WSL preflight for worktrees (wslpath, .git pointer, deadcode allowlist) |

Ported from jongio/dispatch#15 and jongio/dispatch#16.