### PR TITLE
fix: prevent tests from spawning real OS processes

### DIFF
--- a/internal/ai/provider_copilot_test.go
+++ b/internal/ai/provider_copilot_test.go
@@ -364,15 +364,19 @@ func TestSerializeGitContext_FullContext(t *testing.T) {
 func TestEnsureStarted_SetsStartedFlag(t *testing.T) {
 	// We cannot call ensureStarted without a real CLI server, but we
 	// can verify the initial state and the mutex-protected flag.
+	// Use a fake CLIPath so the SDK fails immediately without
+	// spawning a real Copilot CLI process.
 	p := &CopilotProvider{
-		client: copilot.NewClient(nil),
+		client: copilot.NewClient(&copilot.ClientOptions{
+			CLIPath: "/nonexistent/copilot-cli",
+		}),
 	}
 
 	// Calling ensureStarted will fail (no CLI installed in test env).
 	// sync.Once ensures Start is called exactly once.
 	_ = p.ensureStarted(context.Background())
-	// If Start failed, startErr should be non-nil.
-	// Either way is valid — the important thing is no panic.
+	// Start failed, so startErr should be non-nil.
+	assert.Error(t, p.startErr)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/panels/open.go
+++ b/internal/panels/open.go
@@ -67,9 +67,10 @@ func ValidateBrowserURL(rawURL string) error {
 	return nil
 }
 
-// startDetached starts a command and reaps it in the background to prevent
+// startDetachedFn starts a command and reaps it in the background to prevent
 // zombie processes. The caller does not wait for the process to exit.
-func startDetached(cmd *exec.Cmd) error {
+// It is a variable so tests can replace it with a no-op stub.
+var startDetachedFn = func(cmd *exec.Cmd) error {
 	if err := cmd.Start(); err != nil {
 		return err
 	}
@@ -86,26 +87,26 @@ func OpenInEditor(path string) error {
 	}
 	// Check VISUAL first (GUI editor preference).
 	if editor := os.Getenv("VISUAL"); editor != "" {
-		return startDetached(exec.CommandContext(context.Background(), editor, path))
+		return startDetachedFn(exec.CommandContext(context.Background(), editor, path))
 	}
 	// Check EDITOR (terminal editor preference).
 	if editor := os.Getenv("EDITOR"); editor != "" {
-		return startDetached(exec.CommandContext(context.Background(), editor, path))
+		return startDetachedFn(exec.CommandContext(context.Background(), editor, path))
 	}
 	// Try common developer editors in preference order.
 	for _, editor := range []string{"code", "code-insiders", "cursor"} {
 		if _, err := exec.LookPath(editor); err == nil {
-			return startDetached(exec.CommandContext(context.Background(), editor, path))
+			return startDetachedFn(exec.CommandContext(context.Background(), editor, path))
 		}
 	}
 	// Platform defaults.
 	switch runtime.GOOS {
 	case "windows":
-		return startDetached(exec.CommandContext(context.Background(), "cmd", "/c", "start", "", path))
+		return startDetachedFn(exec.CommandContext(context.Background(), "cmd", "/c", "start", "", path))
 	case "darwin":
-		return startDetached(exec.CommandContext(context.Background(), "open", path))
+		return startDetachedFn(exec.CommandContext(context.Background(), "open", path))
 	default:
-		return startDetached(exec.CommandContext(context.Background(), "xdg-open", path))
+		return startDetachedFn(exec.CommandContext(context.Background(), "xdg-open", path))
 	}
 }
 
@@ -116,11 +117,11 @@ func OpenInBrowser(rawURL string) error {
 	}
 	switch runtime.GOOS {
 	case "windows":
-		return startDetached(exec.CommandContext(context.Background(), "rundll32", "url.dll,FileProtocolHandler", rawURL))
+		return startDetachedFn(exec.CommandContext(context.Background(), "rundll32", "url.dll,FileProtocolHandler", rawURL))
 	case "darwin":
-		return startDetached(exec.CommandContext(context.Background(), "open", rawURL))
+		return startDetachedFn(exec.CommandContext(context.Background(), "open", rawURL))
 	default:
-		return startDetached(exec.CommandContext(context.Background(), "xdg-open", rawURL))
+		return startDetachedFn(exec.CommandContext(context.Background(), "xdg-open", rawURL))
 	}
 }
 
@@ -152,5 +153,5 @@ func OpenInTerminal(dir string) error {
 	if cmd == nil {
 		return fmt.Errorf("no terminal emulator found")
 	}
-	return startDetached(cmd)
+	return startDetachedFn(cmd)
 }

--- a/internal/panels/open_platform_test.go
+++ b/internal/panels/open_platform_test.go
@@ -2,30 +2,43 @@ package panels
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// stubStartDetachedCapture replaces startDetachedFn with a no-op that captures
+// that retrieves the captured command after the test exercises the code path.
+func stubStartDetachedCapture(t *testing.T) func() *exec.Cmd {
+	t.Helper()
+	var captured *exec.Cmd
+	orig := startDetachedFn
+	startDetachedFn = func(cmd *exec.Cmd) error {
+		captured = cmd
+		return nil
+	}
+	t.Cleanup(func() { startDetachedFn = orig })
+	return func() *exec.Cmd { return captured }
+}
+
 // ---------------------------------------------------------------------------
 // OpenInEditor — exercise LookPath loop body (common-editor discovery)
 // ---------------------------------------------------------------------------
 
-// TestOpenInEditor_CommonEditorLookPath exercises the for-loop that searches
-// for common developer editors (code, code-insiders, cursor) via LookPath.
-// A dummy "code" script is placed on PATH so the inner loop body executes,
-// covering the startDetached call from within the LookPath hit path.
 func TestOpenInEditor_CommonEditorLookPath(t *testing.T) {
+	getCaptured := stubStartDetachedCapture(t)
+
 	t.Setenv("VISUAL", "")
 	t.Setenv("EDITOR", "")
 
 	dir := t.TempDir()
 
 	if runtime.GOOS == "windows" {
-		// Windows resolves .bat via PATHEXT; create a no-op batch file.
 		err := os.WriteFile(filepath.Join(dir, "code.bat"), []byte("@exit /b 0\r\n"), 0o755)
 		require.NoError(t, err)
 	} else {
@@ -33,30 +46,30 @@ func TestOpenInEditor_CommonEditorLookPath(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Prepend dir so LookPath("code") finds our dummy.
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	err := OpenInEditor("somefile.txt")
 	assert.NoError(t, err)
+
+	cmd := getCaptured()
+	require.NotNil(t, cmd, "startDetachedFn should have been called")
+	assert.Contains(t, cmd.Args[0], "code")
 }
 
 // ---------------------------------------------------------------------------
 // OpenInEditor — exercise platform-default fallback (Windows)
 // ---------------------------------------------------------------------------
 
-// TestOpenInEditor_PlatformDefaultWindows covers the platform-specific
-// fallback when VISUAL, EDITOR, and all common editors are absent.
-// On Windows this executes: cmd /c start "" <path>.
 func TestOpenInEditor_PlatformDefaultWindows(t *testing.T) {
 	if runtime.GOOS != "windows" {
-		// Non-Windows default is covered by TestOpenInEditorFallsThroughToDefault.
 		t.Skip("Windows-only platform-default test")
 	}
+
+	getCaptured := stubStartDetachedCapture(t)
 
 	t.Setenv("VISUAL", "")
 	t.Setenv("EDITOR", "")
 
-	// Minimal PATH — only system32, so code/code-insiders/cursor are absent.
 	sysRoot := os.Getenv("SystemRoot")
 	if sysRoot == "" {
 		sysRoot = `C:\Windows`
@@ -67,43 +80,51 @@ func TestOpenInEditor_PlatformDefaultWindows(t *testing.T) {
 	require.NoError(t, err)
 	_ = f.Close()
 
-	// startDetached returns nil after Start() succeeds; the window spawned
-	// by "cmd /c start" is cleaned up when the CI runner terminates.
 	err = OpenInEditor(f.Name())
 	assert.NoError(t, err)
+
+	cmd := getCaptured()
+	require.NotNil(t, cmd, "startDetachedFn should have been called")
+	assert.Equal(t, "cmd", cmd.Args[0])
+	assert.Contains(t, strings.Join(cmd.Args, " "), "start")
 }
 
 // ---------------------------------------------------------------------------
 // OpenInBrowser — exercise Windows platform branch
 // ---------------------------------------------------------------------------
 
-// TestOpenInBrowser_WindowsPlatform exercises the rundll32 code path that is
-// only reached when validation passes on Windows.
 func TestOpenInBrowser_WindowsPlatform(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows-only platform test")
 	}
 
-	// Use loopback address with unlikely port — rundll32 starts but the
-	// URL goes nowhere. startDetached returns nil after Start() succeeds.
+	getCaptured := stubStartDetachedCapture(t)
+
 	err := OpenInBrowser("https://127.0.0.1:1")
 	assert.NoError(t, err)
+
+	cmd := getCaptured()
+	require.NotNil(t, cmd, "startDetachedFn should have been called")
+	assert.Equal(t, "rundll32", cmd.Args[0])
 }
 
 // ---------------------------------------------------------------------------
 // OpenInTerminal — exercise Windows platform branch
 // ---------------------------------------------------------------------------
 
-// TestOpenInTerminal_WindowsPlatform exercises the Windows cmd.exe code path
-// including the var declaration, switch, assignment, nil-check, and
-// startDetached return.
 func TestOpenInTerminal_WindowsPlatform(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows-only platform test")
 	}
 
+	getCaptured := stubStartDetachedCapture(t)
+
 	dir := t.TempDir()
 	err := OpenInTerminal(dir)
-	// cmd.exe /c start cmd /k ... — Start() succeeds, returns nil.
 	assert.NoError(t, err)
+
+	cmd := getCaptured()
+	require.NotNil(t, cmd, "startDetachedFn should have been called")
+	assert.Equal(t, "cmd", cmd.Args[0])
+	assert.Contains(t, strings.Join(cmd.Args, " "), "/k")
 }

--- a/internal/panels/panels_extra_test.go
+++ b/internal/panels/panels_extra_test.go
@@ -52,10 +52,10 @@ func TestCopyToClipboard_UnicodeText(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// startDetached — 40% coverage, background process launcher
+// startDetachedFn — 40% coverage, background process launcher
 // ---------------------------------------------------------------------------
 
-func TestStartDetached_ValidCommand(t *testing.T) {
+func TestStartDetachedFn_ValidCommand(t *testing.T) {
 	t.Parallel()
 
 	var cmd *exec.Cmd
@@ -66,15 +66,15 @@ func TestStartDetached_ValidCommand(t *testing.T) {
 		cmd = exec.Command("echo", "test")
 	}
 
-	err := startDetached(cmd)
+	err := startDetachedFn(cmd)
 	assert.NoError(t, err)
 }
 
-func TestStartDetached_InvalidCommand(t *testing.T) {
+func TestStartDetachedFn_InvalidCommand(t *testing.T) {
 	t.Parallel()
 
 	cmd := exec.Command("this_binary_does_not_exist_12345")
-	err := startDetached(cmd)
+	err := startDetachedFn(cmd)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
## Problem

Running `go test ./...` caused real OS-level side effects on Windows:

1. **Copilot CLI terminal window** — `TestEnsureStarted_SetsStartedFlag` used `copilot.NewClient(nil)` which launches the real Copilot CLI process
2. **Windows error dialog** ("Windows cannot find...") — `TestOpenInEditor_PlatformDefaultWindows` spawns `cmd /c start`
3. **cmd.exe terminal window** — `TestOpenInTerminal_WindowsPlatform` spawns `cmd /c start cmd /k`
4. **Browser tab** to 127.0.0.1:1 — `TestOpenInBrowser_WindowsPlatform` spawns `rundll32`

## Fix

### Copilot provider test (`internal/ai/provider_copilot_test.go`)
- Use `copilot.NewClient(&copilot.ClientOptions{CLIPath: "/nonexistent/copilot-cli"})` so the SDK fails immediately without spawning a real process
- Added `assert.Error` to verify the expected failure

### Platform tests (`internal/panels/`)
- Converted `startDetached` from a function to a package-level `var startDetachedFn` — standard Go pattern for test dependency injection
- Updated all 10+ call sites from `startDetached(` to `startDetachedFn(`
- Rewrote platform tests to use `stubStartDetachedCapture(t)` helper that captures the `*exec.Cmd` without launching it
- Tests now assert on captured command args (e.g., contains "rundll32", "start", "cmd")
- `t.Cleanup` restores the original function after each test

## Verification

- All 49 test packages pass with zero side effects
- `go build ./...` clean
- `go vet ./...` clean
