### PR TITLE
fix: default confirm modal to Yes so Enter confirms actions

### DIFF
--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -154,7 +154,7 @@ func (m *Manager) Update(msg tea.Msg) tea.Cmd {
 			kind:          msg.Kind,
 			input:         msg.Value,
 			cursor:        len([]rune(msg.Value)),
-			selected:      msg.Kind == ModalConfirmWithCheckbox,
+			selected:      msg.Kind == ModalConfirm || msg.Kind == ModalConfirmWithCheckbox,
 			checkboxLabel: msg.CheckboxLabel,
 			actions:       msg.Actions,
 			actionCursor:  0,

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -381,14 +381,14 @@ func TestModalConfirmEnterDefault(t *testing.T) {
 		Kind:  ModalConfirm,
 	})
 
-	// Default selection is false (No), so enter should reject
+	// Default selection is true (Yes), so enter should accept
 	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	require.NotNil(t, cmd)
 
 	msg := cmd()
 	result, ok := msg.(ModalResultMsg)
 	require.True(t, ok)
-	assert.False(t, result.Accept, "default selection should be No")
+	assert.True(t, result.Accept, "default selection should be Yes")
 }
 
 func TestModalConfirmArrowKeys(t *testing.T) {
@@ -398,7 +398,8 @@ func TestModalConfirmArrowKeys(t *testing.T) {
 		Kind:  ModalConfirm,
 	})
 
-	// Select Yes with left arrow
+	// Default is Yes. Select No with right arrow, then back to Yes with left.
+	m.Update(tea.KeyPressMsg{Code: tea.KeyRight})
 	m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
 
 	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
@@ -1099,14 +1100,14 @@ func TestModalConfirmTab(t *testing.T) {
 		Kind:  ModalConfirm,
 	})
 
-	// Default selection is No (selected = false).
-	// Tab should toggle to Yes.
+	// Default selection is Yes (selected = true).
+	// Tab should toggle to No.
 	m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 
 	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	require.NotNil(t, cmd)
 	result := cmd().(ModalResultMsg)
-	assert.True(t, result.Accept, "Tab should have toggled to Yes")
+	assert.False(t, result.Accept, "Tab should have toggled to No")
 }
 
 func TestModalConfirmTabToggle(t *testing.T) {
@@ -1116,14 +1117,14 @@ func TestModalConfirmTabToggle(t *testing.T) {
 		Kind:  ModalConfirm,
 	})
 
-	// Tab twice should return to original (No).
+	// Tab twice should return to original (Yes).
 	m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 	m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 
 	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	require.NotNil(t, cmd)
 	result := cmd().(ModalResultMsg)
-	assert.False(t, result.Accept, "Two tabs should toggle back to No")
+	assert.True(t, result.Accept, "Two tabs should toggle back to Yes")
 }
 
 func TestModalConfirmWithCheckboxTab(t *testing.T) {
@@ -1506,13 +1507,13 @@ func TestModalConfirmShiftTab(t *testing.T) {
 		Kind:  ModalConfirm,
 	})
 
-	// Default is No. Shift+Tab should toggle to Yes (same as Tab).
+	// Default is Yes. Shift+Tab should toggle to No (same as Tab).
 	m.Update(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
 
 	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	require.NotNil(t, cmd)
 	result := cmd().(ModalResultMsg)
-	assert.True(t, result.Accept, "Shift+Tab should toggle to Yes")
+	assert.False(t, result.Accept, "Shift+Tab should toggle to No")
 }
 
 func TestModalCheckboxMouseClickSetsFocusIdx(t *testing.T) {


### PR DESCRIPTION
## Problem

The ModalConfirm dialog initialized with selected=false (No button highlighted). When users pressed Enter on confirmation dialogs like "Switch to branch X?", the second Enter defaulted to No, silently cancelling the action.

This made branch switching (and any other confirm-dialog action) appear broken -- the dialog would flash and nothing would happen.

## Fix

Changed ModalConfirm to initialize selected=true (Yes), so Enter confirms by default. This matches standard UX expectations where Enter on a confirmation dialog means "Yes".

Users can still press n, N, Esc, or arrow to No + Enter to reject.

## Changes

- internal/notify/notify.go -- default selected=true for ModalConfirm
- internal/notify/notify_test.go -- updated 3 tests to match new default

## Testing

All 100+ notify tests pass. Full suite (go test ./...) passes.
