### PR TITLE
fix: add missing keymap bindings for delete branch on github panel

### DIFF
--- a/internal/keymap/keymap_test.go
+++ b/internal/keymap/keymap_test.go
@@ -469,6 +469,12 @@ func TestCRUDBindingsExistInAllSchemes(t *testing.T) {
 		{"F2", "item_edit", "gitinfo"},
 		{"o", "item_open", "gitinfo"},
 		{"y", "item_copy", "gitinfo"},
+		{"n", "item_create", "github"},
+		{"x", "item_delete", "github"},
+		{"e", "item_edit", "github"},
+		{"F2", "item_edit", "github"},
+		{"o", "item_open", "github"},
+		{"y", "item_copy", "github"},
 		{"n", "item_create", "branches"},
 		{"x", "item_delete", "branches"},
 		{"e", "item_edit", "branches"},
@@ -513,6 +519,11 @@ func TestCRUDContextOverridesVimSearchNext(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "item_create", action)
 
+	// In github context, "n" should be item_create.
+	action, ok = km.Dispatch("n", "github")
+	assert.True(t, ok)
+	assert.Equal(t, "item_create", action)
+
 	// In branches context, "n" should be item_create.
 	action, ok = km.Dispatch("n", "branches")
 	assert.True(t, ok)
@@ -534,9 +545,34 @@ func TestCRUDOpenKeyAvailableEverywhere(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "item_open", action)
 
+	// "o" should resolve to item_open in github context.
+	action, ok = km.Dispatch("o", "github")
+	assert.True(t, ok)
+	assert.Equal(t, "item_open", action)
+
 	// "o" should not be bound in panels without CRUD context.
 	_, ok = km.Dispatch("o", "preview")
 	assert.False(t, ok)
+}
+
+func TestGitHubPanelDeleteDispatch(t *testing.T) {
+	for _, scheme := range []string{"default", "vim", "classic"} {
+		t.Run(scheme, func(t *testing.T) {
+			km, err := NewKeymap(scheme)
+			require.NoError(t, err)
+			km.SetMode(ModePanel)
+
+			// "x" in github context should dispatch to item_delete.
+			action, ok := km.Dispatch("x", "github")
+			assert.True(t, ok, "scheme %q: 'x' should be bound in github context", scheme)
+			assert.Equal(t, "item_delete", action, "scheme %q: 'x' in github should be item_delete", scheme)
+
+			// "x" in gitinfo context should also dispatch to item_delete.
+			action, ok = km.Dispatch("x", "gitinfo")
+			assert.True(t, ok, "scheme %q: 'x' should be bound in gitinfo context", scheme)
+			assert.Equal(t, "item_delete", action)
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/keymap/schemes/classic.toml
+++ b/internal/keymap/schemes/classic.toml
@@ -256,6 +256,49 @@ mode = "panel"
 context = "gitinfo"
 description = "Copy identifier to clipboard"
 
+# CRUD shortcuts — github panel
+[[bindings]]
+key = "n"
+action = "item_create"
+mode = "panel"
+context = "github"
+description = "Create new item"
+
+[[bindings]]
+key = "x"
+action = "item_delete"
+mode = "panel"
+context = "github"
+description = "Delete selected item"
+
+[[bindings]]
+key = "e"
+action = "item_edit"
+mode = "panel"
+context = "github"
+description = "Edit/rename selected item"
+
+[[bindings]]
+key = "F2"
+action = "item_edit"
+mode = "panel"
+context = "github"
+description = "Edit/rename selected item"
+
+[[bindings]]
+key = "o"
+action = "item_open"
+mode = "panel"
+context = "github"
+description = "Open in browser"
+
+[[bindings]]
+key = "y"
+action = "item_copy"
+mode = "panel"
+context = "github"
+description = "Copy identifier to clipboard"
+
 # CRUD shortcuts — branches panel
 [[bindings]]
 key = "n"

--- a/internal/keymap/schemes/default.toml
+++ b/internal/keymap/schemes/default.toml
@@ -286,6 +286,34 @@ description = "Copy identifier to clipboard"
 
 # CRUD shortcuts — github panel
 [[bindings]]
+key = "n"
+action = "item_create"
+mode = "panel"
+context = "github"
+description = "Create new item"
+
+[[bindings]]
+key = "x"
+action = "item_delete"
+mode = "panel"
+context = "github"
+description = "Delete selected item"
+
+[[bindings]]
+key = "e"
+action = "item_edit"
+mode = "panel"
+context = "github"
+description = "Edit/rename selected item"
+
+[[bindings]]
+key = "F2"
+action = "item_edit"
+mode = "panel"
+context = "github"
+description = "Edit/rename selected item"
+
+[[bindings]]
 key = "o"
 action = "item_open"
 mode = "panel"

--- a/internal/keymap/schemes/vim.toml
+++ b/internal/keymap/schemes/vim.toml
@@ -280,6 +280,49 @@ mode = "panel"
 context = "gitinfo"
 description = "Copy identifier to clipboard"
 
+# CRUD shortcuts — github panel
+[[bindings]]
+key = "n"
+action = "item_create"
+mode = "panel"
+context = "github"
+description = "Create new item"
+
+[[bindings]]
+key = "x"
+action = "item_delete"
+mode = "panel"
+context = "github"
+description = "Delete selected item"
+
+[[bindings]]
+key = "e"
+action = "item_edit"
+mode = "panel"
+context = "github"
+description = "Edit/rename selected item"
+
+[[bindings]]
+key = "F2"
+action = "item_edit"
+mode = "panel"
+context = "github"
+description = "Edit/rename selected item"
+
+[[bindings]]
+key = "o"
+action = "item_open"
+mode = "panel"
+context = "github"
+description = "Open in browser"
+
+[[bindings]]
+key = "y"
+action = "item_copy"
+mode = "panel"
+context = "github"
+description = "Copy identifier to clipboard"
+
 # CRUD shortcuts — branches panel
 [[bindings]]
 key = "n"

--- a/internal/panels/branches/branches.go
+++ b/internal/panels/branches/branches.go
@@ -261,7 +261,7 @@ func (p *Panel) KeyBindings() []panels.KeyBinding {
 		{Key: "k/↑", Description: "Move cursor up", Action: "cursor_up"},
 		{Key: "enter", Description: "Checkout branch", Action: "checkout"},
 		{Key: "n", Description: "Create new branch", Action: "item_create"},
-		{Key: "d", Description: "Delete branch", Action: "item_delete"},
+		{Key: "x", Description: "Delete branch", Action: "item_delete"},
 		{Key: "e/F2", Description: "Rename branch", Action: "item_edit"},
 		{Key: "o", Description: "Open in browser", Action: "item_open"},
 		{Key: "y", Description: "Copy branch name", Action: "item_copy"},
@@ -333,7 +333,7 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		return p.requestCheckout()
 	case "n":
 		return p.requestCreate()
-	case "d":
+	case "d", "x":
 		return p.requestDelete()
 	case "e", "F2":
 		return p.requestRename()

--- a/internal/panels/branches/branches_test.go
+++ b/internal/panels/branches/branches_test.go
@@ -573,6 +573,44 @@ func TestDeleteBranch(t *testing.T) {
 	assert.False(t, mock.lastDeleteForce)
 }
 
+func TestDeleteBranch_XKeyTriggersDelete(t *testing.T) {
+	mock := &mockGitOps{branches: sampleBranches()}
+	p := newTestPanel(t, mock, defaultCfg())
+	p.Focus()
+
+	// Move to "feature/auth" (non-current local branch).
+	p.Update(keyMsg('j'))
+
+	// Press "x" directly — should trigger delete confirmation.
+	_, cmd := p.Update(keyMsg('x'))
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	modal, ok := msg.(notify.ShowModalMsg)
+	require.True(t, ok)
+	assert.Equal(t, "Delete Branch", modal.Title)
+	assert.Contains(t, modal.Message, "feature/auth")
+}
+
+func TestDeleteBranch_DKeyTriggersDelete(t *testing.T) {
+	mock := &mockGitOps{branches: sampleBranches()}
+	p := newTestPanel(t, mock, defaultCfg())
+	p.Focus()
+
+	// Move to "feature/auth" (non-current local branch).
+	p.Update(keyMsg('j'))
+
+	// Press "d" directly — should also trigger delete confirmation (legacy key).
+	_, cmd := p.Update(keyMsg('d'))
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	modal, ok := msg.(notify.ShowModalMsg)
+	require.True(t, ok)
+	assert.Equal(t, "Delete Branch", modal.Title)
+	assert.Contains(t, modal.Message, "feature/auth")
+}
+
 func TestDeleteBranch_CurrentBlocked(t *testing.T) {
 	mock := &mockGitOps{branches: sampleBranches()}
 	p := newTestPanel(t, mock, defaultCfg())


### PR DESCRIPTION
## Problem

The delete branch feature (and other CRUD operations) did not work on the **github** panel because the keymap schemes only defined CRUD bindings for the `gitinfo` context — not the `github` context. Pressing `x` to delete a branch on the github pane bypassed the keymap dispatcher entirely, falling through to the raw key handler.

Additionally, the **branches** panel advertised `d` as the delete key in its help text, but the keymap standard across all panels is `x`.

## Changes

**Keymap schemes** (`default.toml`, `vim.toml`, `classic.toml`):
- Added full CRUD bindings (`n`, `x`, `e`, `F2`, `o`, `y`) for `context = "github"`, matching the existing `gitinfo` bindings.

**Branches panel** (`branches.go`):
- Updated `KeyBindings()` help text from `d` to `x` to match the keymap standard.
- `handleKey` now accepts both `x` (standard) and `d` (legacy) for delete.

**Tests**:
- `TestGitHubPanelDeleteDispatch`: verifies `x` dispatches `item_delete` in the `github` context across all 3 schemes.
- `TestDeleteBranch_XKeyTriggersDelete` / `TestDeleteBranch_DKeyTriggersDelete`: verifies both keys trigger delete confirmation on the branches panel.
- Extended `TestCRUDBindingsExistInAllSchemes` and `TestCRUDContextOverridesVimSearchNext` to cover the `github` context.

## Testing

- `go build ./...` — clean
- `go test ./... -count=1` — all packages pass
- `mage install` — deployed successfully