### PR TITLE
fix: correct modal content width for mouse click detection (#40)

### DIFF
--- a/internal/notify/modal.go
+++ b/internal/notify/modal.go
@@ -305,7 +305,7 @@ func (ms *modalState) handleMouseClick(mgr *Manager, mouseX, mouseY, screenWidth
 	if boxWidth < 20 {
 		boxWidth = 20
 	}
-	cw := boxWidth - 4 // text/content width (padding 2 left + 2 right)
+	cw := boxWidth - 6 // text/content width: boxWidth minus border (1+1) minus padding (2+2)
 	// Measure the title and message heights using the same styles as
 	// view() so the line offsets match exactly.
 	titleStyle := lipgloss.NewStyle().
@@ -502,57 +502,61 @@ func (ms *modalState) view(width, height int) string {
 	if boxWidth < 20 {
 		boxWidth = 20
 	}
-	// Build the modal content
+	// Build the modal content.
+	// Content width = boxWidth minus border (1+1) minus padding (2+2).
+	// In lipgloss v2, Width(n) sets the total rendered width including
+	// border and padding, so the usable content area is n-6.
+	cw := boxWidth - 6
 	var content strings.Builder
 	// Title
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
 		Foreground(lipgloss.Color("#FFFFFF")).
-		Width(boxWidth - 4).
+		Width(cw).
 		Align(lipgloss.Center)
 	content.WriteString(titleStyle.Render(ms.title))
 	content.WriteString("\n\n")
 	// Message
 	msgStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#CCCCCC")).
-		Width(boxWidth - 4)
+		Width(cw)
 	content.WriteString(msgStyle.Render(ms.message))
 	content.WriteString("\n\n")
 	// Kind-specific content
 	switch ms.kind {
 	case ModalConfirm:
-		content.WriteString(ms.renderConfirmButtons(boxWidth - 4))
+		content.WriteString(ms.renderConfirmButtons(cw))
 	case ModalInput:
-		content.WriteString(ms.renderInputField(boxWidth - 4))
+		content.WriteString(ms.renderInputField(cw))
 	case ModalConfirmWithCheckbox:
-		content.WriteString(ms.renderCheckbox(boxWidth - 4))
+		content.WriteString(ms.renderCheckbox(cw))
 		content.WriteString("\n")
 		hintStyle := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#666666")).
 			Italic(true).
-			Width(boxWidth - 4).
+			Width(cw).
 			Align(lipgloss.Center)
 		content.WriteString(hintStyle.Render("tab cycle • space toggle • settings (,)"))
 		content.WriteString("\n\n")
-		content.WriteString(ms.renderConfirmButtons(boxWidth - 4))
+		content.WriteString(ms.renderConfirmButtons(cw))
 	case ModalActionPicker:
-		content.WriteString(ms.renderActionPicker(boxWidth - 4))
+		content.WriteString(ms.renderActionPicker(cw))
 		content.WriteString("\n\n")
 		hintStyle := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#666666")).
 			Italic(true).
-			Width(boxWidth - 4).
+			Width(cw).
 			Align(lipgloss.Center)
 		content.WriteString(hintStyle.Render("↑↓ navigate • enter select • esc cancel"))
 	case ModalActionPickerWithCheckbox:
-		content.WriteString(ms.renderActionPicker(boxWidth - 4))
+		content.WriteString(ms.renderActionPicker(cw))
 		content.WriteString("\n")
-		content.WriteString(ms.renderActionPickerCheckbox(boxWidth - 4))
+		content.WriteString(ms.renderActionPickerCheckbox(cw))
 		content.WriteString("\n")
 		hintStyle := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#666666")).
 			Italic(true).
-			Width(boxWidth - 4).
+			Width(cw).
 			Align(lipgloss.Center)
 		content.WriteString(hintStyle.Render("↑↓ navigate • tab checkbox • space toggle • esc cancel"))
 		content.WriteString("\n")

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1234,6 +1234,60 @@ func TestModalConfirmMouseClickNo(t *testing.T) {
 	assert.False(t, m.HasModal())
 }
 
+// TestModalConfirmMouseClickYes_LongMessage verifies that clicking Yes works
+// when the message wraps to multiple lines. This reproduces the bug where long
+// merge confirm messages like 'Merge PR #35 "feat: ..." using squash and merge?'
+// caused button clicks to miss because the content width was computed incorrectly
+// (boxWidth-4 instead of boxWidth-6), and the message was re-wrapped inside the
+// box, shifting the button row down.
+func TestModalConfirmMouseClickYes_LongMessage(t *testing.T) {
+	m := NewManager()
+	m.SetSize(80, 24)
+	m.Update(ShowModalMsg{
+		Title:   "Confirm Merge",
+		Message: `Merge PR #35 "feat: gitinfo enhancements, contributor recognition, and deadcode cleanup" using squash and merge?`,
+		Kind:    ModalConfirm,
+	})
+
+	// The long message wraps to 3 lines at cw=44 (boxWidth 50 minus
+	// border 2 minus padding 4). Box layout:
+	//   titleH=1, msgH=3, headerLines = 1+1+3+1 = 6.
+	//   Content lines: 6(header) + 1(buttons) = 7.
+	//   bh = 7 + 2(padding) + 2(border) = 11.
+	//   padTop = (24-11)/2 = 6.
+	//   padLeft = (80-50)/2 = 15.
+	//   Button row Y = 6(padTop) + 2(border+padding) + 6(headerLines) = 14.
+	//   Content X starts at 15 + 3 = 18, midpoint at 18 + 22 = 40.
+	//   Click at X=23 (left half) → Yes.
+	cmd := m.Update(tea.MouseClickMsg{X: 23, Y: 14, Button: tea.MouseLeft})
+	require.NotNil(t, cmd, "click on Yes button should produce a command")
+
+	result := cmd().(ModalResultMsg)
+	assert.True(t, result.Accept, "clicking left half (Yes) should accept")
+	assert.False(t, m.HasModal(), "modal should be dismissed")
+}
+
+// TestModalConfirmMouseClickNo_LongMessage verifies that clicking No works
+// when the message wraps to multiple lines.
+func TestModalConfirmMouseClickNo_LongMessage(t *testing.T) {
+	m := NewManager()
+	m.SetSize(80, 24)
+	m.Update(ShowModalMsg{
+		Title:   "Confirm Merge",
+		Message: `Merge PR #35 "feat: gitinfo enhancements, contributor recognition, and deadcode cleanup" using squash and merge?`,
+		Kind:    ModalConfirm,
+	})
+
+	// Same geometry as TestModalConfirmMouseClickYes_LongMessage.
+	// Click at X=57 (right half, well past midpoint 40) → No.
+	cmd := m.Update(tea.MouseClickMsg{X: 57, Y: 14, Button: tea.MouseLeft})
+	require.NotNil(t, cmd, "click on No button should produce a command")
+
+	result := cmd().(ModalResultMsg)
+	assert.False(t, result.Accept, "clicking right half (No) should reject")
+	assert.False(t, m.HasModal(), "modal should be dismissed")
+}
+
 func TestModalConfirmMouseClickOutside(t *testing.T) {
 	m := NewManager()
 	m.SetSize(80, 24)


### PR DESCRIPTION
Fixes #40

## Problem

The Yes/No buttons in modal confirm dialogs (e.g., "Confirm Merge") did not respond to mouse clicks when the message was long enough to wrap across multiple lines. Short single-line messages worked fine.

## Root Cause

In lipgloss v2, `Width(n)` on a style sets the **total rendered width** including border and padding. The content width calculation used `boxWidth - 4` (subtracting only padding), but should have been `boxWidth - 6` (border 1+1 + padding 2+2 = 6).

This caused `handleMouseClick()` to measure message height at width 46, while the box only had 44 chars of content space. Long messages re-wrapped inside the box, shifting the button row down by 1+ lines — so the click coordinate check (`relY == headerLines`) never matched.

## Fix

Changed `boxWidth - 4` to `boxWidth - 6` in both `view()` and `handleMouseClick()` in `internal/notify/modal.go`, with a clear comment explaining the derivation. All 12 occurrences updated consistently.

## Tests

Added `TestModalConfirmMouseClickYes_LongMessage` and `TestModalConfirmMouseClickNo_LongMessage` using the actual merge confirm message format that triggers the bug. All 107 notify tests pass.