### PR TITLE
fix: stub browser launcher in TestOpenRepoInBrowser to prevent real browser open (#41)

### DIFF
--- a/internal/panels/gitinfo/gitinfo_test.go
+++ b/internal/panels/gitinfo/gitinfo_test.go
@@ -3,6 +3,7 @@ package gitinfo
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -521,10 +522,13 @@ func TestOpenRepoInBrowser_ConstructsCorrectURL(t *testing.T) {
 	p.ghOwner = "jongio"
 	p.ghRepo = "grut"
 
+	// Stub the browser launcher so the test never opens a real browser tab.
+	orig := panels.StartDetachedFn
+	panels.StartDetachedFn = func(*exec.Cmd) error { return nil }
+	t.Cleanup(func() { panels.StartDetachedFn = orig })
+
 	_, cmd := p.openRepoInBrowser()
 	require.NotNil(t, cmd)
-	// Execute the command — the underlying OpenInBrowser may fail in CI
-	// (no display), but the toast message will contain the URL label.
 	msg := cmd()
 	toast, ok := msg.(notify.ShowToastMsg)
 	require.True(t, ok)

--- a/internal/panels/open.go
+++ b/internal/panels/open.go
@@ -67,10 +67,10 @@ func ValidateBrowserURL(rawURL string) error {
 	return nil
 }
 
-// startDetachedFn starts a command and reaps it in the background to prevent
+// StartDetachedFn starts a command and reaps it in the background to prevent
 // zombie processes. The caller does not wait for the process to exit.
 // It is a variable so tests can replace it with a no-op stub.
-var startDetachedFn = func(cmd *exec.Cmd) error {
+var StartDetachedFn = func(cmd *exec.Cmd) error {
 	if err := cmd.Start(); err != nil {
 		return err
 	}
@@ -87,26 +87,26 @@ func OpenInEditor(path string) error {
 	}
 	// Check VISUAL first (GUI editor preference).
 	if editor := os.Getenv("VISUAL"); editor != "" {
-		return startDetachedFn(exec.CommandContext(context.Background(), editor, path))
+		return StartDetachedFn(exec.CommandContext(context.Background(), editor, path))
 	}
 	// Check EDITOR (terminal editor preference).
 	if editor := os.Getenv("EDITOR"); editor != "" {
-		return startDetachedFn(exec.CommandContext(context.Background(), editor, path))
+		return StartDetachedFn(exec.CommandContext(context.Background(), editor, path))
 	}
 	// Try common developer editors in preference order.
 	for _, editor := range []string{"code", "code-insiders", "cursor"} {
 		if _, err := exec.LookPath(editor); err == nil {
-			return startDetachedFn(exec.CommandContext(context.Background(), editor, path))
+			return StartDetachedFn(exec.CommandContext(context.Background(), editor, path))
 		}
 	}
 	// Platform defaults.
 	switch runtime.GOOS {
 	case "windows":
-		return startDetachedFn(exec.CommandContext(context.Background(), "cmd", "/c", "start", "", path))
+		return StartDetachedFn(exec.CommandContext(context.Background(), "cmd", "/c", "start", "", path))
 	case "darwin":
-		return startDetachedFn(exec.CommandContext(context.Background(), "open", path))
+		return StartDetachedFn(exec.CommandContext(context.Background(), "open", path))
 	default:
-		return startDetachedFn(exec.CommandContext(context.Background(), "xdg-open", path))
+		return StartDetachedFn(exec.CommandContext(context.Background(), "xdg-open", path))
 	}
 }
 
@@ -117,11 +117,11 @@ func OpenInBrowser(rawURL string) error {
 	}
 	switch runtime.GOOS {
 	case "windows":
-		return startDetachedFn(exec.CommandContext(context.Background(), "rundll32", "url.dll,FileProtocolHandler", rawURL))
+		return StartDetachedFn(exec.CommandContext(context.Background(), "rundll32", "url.dll,FileProtocolHandler", rawURL))
 	case "darwin":
-		return startDetachedFn(exec.CommandContext(context.Background(), "open", rawURL))
+		return StartDetachedFn(exec.CommandContext(context.Background(), "open", rawURL))
 	default:
-		return startDetachedFn(exec.CommandContext(context.Background(), "xdg-open", rawURL))
+		return StartDetachedFn(exec.CommandContext(context.Background(), "xdg-open", rawURL))
 	}
 }
 
@@ -153,5 +153,5 @@ func OpenInTerminal(dir string) error {
 	if cmd == nil {
 		return fmt.Errorf("no terminal emulator found")
 	}
-	return startDetachedFn(cmd)
+	return StartDetachedFn(cmd)
 }

--- a/internal/panels/open_platform_test.go
+++ b/internal/panels/open_platform_test.go
@@ -12,17 +12,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// stubStartDetachedCapture replaces startDetachedFn with a no-op that captures
+// stubStartDetachedCapture replaces StartDetachedFn with a no-op that captures
 // that retrieves the captured command after the test exercises the code path.
 func stubStartDetachedCapture(t *testing.T) func() *exec.Cmd {
 	t.Helper()
 	var captured *exec.Cmd
-	orig := startDetachedFn
-	startDetachedFn = func(cmd *exec.Cmd) error {
+	orig := StartDetachedFn
+	StartDetachedFn = func(cmd *exec.Cmd) error {
 		captured = cmd
 		return nil
 	}
-	t.Cleanup(func() { startDetachedFn = orig })
+	t.Cleanup(func() { StartDetachedFn = orig })
 	return func() *exec.Cmd { return captured }
 }
 
@@ -52,7 +52,7 @@ func TestOpenInEditor_CommonEditorLookPath(t *testing.T) {
 	assert.NoError(t, err)
 
 	cmd := getCaptured()
-	require.NotNil(t, cmd, "startDetachedFn should have been called")
+	require.NotNil(t, cmd, "StartDetachedFn should have been called")
 	assert.Contains(t, cmd.Args[0], "code")
 }
 
@@ -84,7 +84,7 @@ func TestOpenInEditor_PlatformDefaultWindows(t *testing.T) {
 	assert.NoError(t, err)
 
 	cmd := getCaptured()
-	require.NotNil(t, cmd, "startDetachedFn should have been called")
+	require.NotNil(t, cmd, "StartDetachedFn should have been called")
 	assert.Equal(t, "cmd", cmd.Args[0])
 	assert.Contains(t, strings.Join(cmd.Args, " "), "start")
 }
@@ -104,7 +104,7 @@ func TestOpenInBrowser_WindowsPlatform(t *testing.T) {
 	assert.NoError(t, err)
 
 	cmd := getCaptured()
-	require.NotNil(t, cmd, "startDetachedFn should have been called")
+	require.NotNil(t, cmd, "StartDetachedFn should have been called")
 	assert.Equal(t, "rundll32", cmd.Args[0])
 }
 
@@ -124,7 +124,7 @@ func TestOpenInTerminal_WindowsPlatform(t *testing.T) {
 	assert.NoError(t, err)
 
 	cmd := getCaptured()
-	require.NotNil(t, cmd, "startDetachedFn should have been called")
+	require.NotNil(t, cmd, "StartDetachedFn should have been called")
 	assert.Equal(t, "cmd", cmd.Args[0])
 	assert.Contains(t, strings.Join(cmd.Args, " "), "/k")
 }

--- a/internal/panels/panels_extra_test.go
+++ b/internal/panels/panels_extra_test.go
@@ -52,7 +52,7 @@ func TestCopyToClipboard_UnicodeText(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// startDetachedFn — 40% coverage, background process launcher
+// StartDetachedFn — 40% coverage, background process launcher
 // ---------------------------------------------------------------------------
 
 func TestStartDetachedFn_ValidCommand(t *testing.T) {
@@ -66,7 +66,7 @@ func TestStartDetachedFn_ValidCommand(t *testing.T) {
 		cmd = exec.Command("echo", "test")
 	}
 
-	err := startDetachedFn(cmd)
+	err := StartDetachedFn(cmd)
 	assert.NoError(t, err)
 }
 
@@ -74,7 +74,7 @@ func TestStartDetachedFn_InvalidCommand(t *testing.T) {
 	t.Parallel()
 
 	cmd := exec.Command("this_binary_does_not_exist_12345")
-	err := startDetachedFn(cmd)
+	err := StartDetachedFn(cmd)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
## Summary

Fixes #41 — \TestOpenRepoInBrowser_ConstructsCorrectURL\ was opening a real browser tab on Windows dev machines during every test run.

## Root Cause

\openURLAndToast\ returns a \	ea.Cmd\ closure that calls \panels.OpenInBrowser\. The test executed that closure directly, which on Windows with a display successfully launched \undll32\ and opened a browser tab.

## Fix

Export \startDetachedFn\ → \StartDetachedFn\ in \internal/panels/open.go\. The variable already had a doc comment saying it was designed for test replacement; exporting it makes it accessible from cross-package tests like \gitinfo\.

The test now stubs \panels.StartDetachedFn\ with a no-op before executing the \	ea.Cmd\, restores it via \	.Cleanup\, and retains the original toast-message assertion.

## Changed Files

| File | Change |
|------|--------|
| \internal/panels/open.go\ | Export \StartDetachedFn\ (rename + 12 call-site updates) |
| \internal/panels/open_platform_test.go\ | Update \stubStartDetachedCapture\ helper to use \StartDetachedFn\ |
| \internal/panels/panels_extra_test.go\ | Update 2 direct call-sites + comment to \StartDetachedFn\ |
| \internal/panels/gitinfo/gitinfo_test.go\ | Stub \panels.StartDetachedFn\ before executing \cmd()\; remove stale CI comment |

## Verification

- \go build ./...\ — zero errors
- \go test ./...\ — all packages pass
- \go test -race ./internal/panels/...\ — all pass (race-clean)
- Running the specific test no longer opens a browser window