### PR TITLE
fix: resolve x-key delete failing after first use (#45)

### DIFF
--- a/internal/keymap/schemes/classic.toml
+++ b/internal/keymap/schemes/classic.toml
@@ -407,6 +407,28 @@ mode = "panel"
 context = "stash"
 description = "Copy stash reference"
 
+# CRUD shortcuts — worktrees panel
+[[bindings]]
+key = "n"
+action = "item_create"
+mode = "panel"
+context = "worktrees"
+description = "Create new worktree"
+
+[[bindings]]
+key = "x"
+action = "item_delete"
+mode = "panel"
+context = "worktrees"
+description = "Remove worktree"
+
+[[bindings]]
+key = "y"
+action = "item_copy"
+mode = "panel"
+context = "worktrees"
+description = "Copy worktree path"
+
 # Input mode bindings
 [[bindings]]
 key = "escape"

--- a/internal/keymap/schemes/default.toml
+++ b/internal/keymap/schemes/default.toml
@@ -435,6 +435,28 @@ mode = "panel"
 context = "stash"
 description = "Copy stash reference"
 
+# CRUD shortcuts — worktrees panel
+[[bindings]]
+key = "n"
+action = "item_create"
+mode = "panel"
+context = "worktrees"
+description = "Create new worktree"
+
+[[bindings]]
+key = "x"
+action = "item_delete"
+mode = "panel"
+context = "worktrees"
+description = "Remove worktree"
+
+[[bindings]]
+key = "y"
+action = "item_copy"
+mode = "panel"
+context = "worktrees"
+description = "Copy worktree path"
+
 # Input mode bindings
 [[bindings]]
 key = "escape"

--- a/internal/keymap/schemes/vim.toml
+++ b/internal/keymap/schemes/vim.toml
@@ -431,6 +431,28 @@ mode = "panel"
 context = "stash"
 description = "Copy stash reference"
 
+# CRUD shortcuts — worktrees panel
+[[bindings]]
+key = "n"
+action = "item_create"
+mode = "panel"
+context = "worktrees"
+description = "Create new worktree"
+
+[[bindings]]
+key = "x"
+action = "item_delete"
+mode = "panel"
+context = "worktrees"
+description = "Remove worktree"
+
+[[bindings]]
+key = "y"
+action = "item_copy"
+mode = "panel"
+context = "worktrees"
+description = "Copy worktree path"
+
 # Input mode bindings
 [[bindings]]
 key = "escape"

--- a/internal/panels/branches/branches.go
+++ b/internal/panels/branches/branches.go
@@ -113,6 +113,7 @@ type Panel struct {
 	offset          int       // viewport scroll offset
 	pending         pendingOp // operation awaiting modal result
 	showAnnotations bool      // whether to display annotations next to branch names
+	preserveCursor  bool      // when true, buildItems preserves cursor position instead of jumping to current branch
 }
 
 // Compile-time interface check.
@@ -261,7 +262,7 @@ func (p *Panel) KeyBindings() []panels.KeyBinding {
 		{Key: "k/↑", Description: "Move cursor up", Action: "cursor_up"},
 		{Key: "enter", Description: "Checkout branch", Action: "checkout"},
 		{Key: "n", Description: "Create new branch", Action: "item_create"},
-		{Key: "x", Description: "Delete branch", Action: "item_delete"},
+		{Key: "d/x", Description: "Delete branch", Action: "item_delete"},
 		{Key: "e/F2", Description: "Rename branch", Action: "item_edit"},
 		{Key: "o", Description: "Open in browser", Action: "item_open"},
 		{Key: "y", Description: "Copy branch name", Action: "item_copy"},
@@ -295,6 +296,7 @@ func (p *Panel) handleOpResult(msg branchOpResultMsg) (panels.Panel, tea.Cmd) {
 	// Refresh branches after a successful operation.
 	op := msg.op
 	name := msg.name
+	p.preserveCursor = true
 	cmds := []tea.Cmd{p.loadBranches()}
 	switch op {
 	case "checkout":
@@ -717,6 +719,10 @@ func (p *Panel) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, tea.
 // buildItems constructs the flat display list from branch data and
 // positions the cursor on the current branch (if any).
 func (p *Panel) buildItems(branches []git.Branch) {
+	prevCursor := p.cursor
+	shouldPreserve := p.preserveCursor
+	p.preserveCursor = false
+
 	var local, remote []git.Branch
 	for _, b := range branches {
 		if b.IsRemote {
@@ -738,21 +744,54 @@ func (p *Panel) buildItems(branches []git.Branch) {
 			p.items = append(p.items, listItem{branch: b})
 		}
 	}
-	// Default cursor to first selectable item.
-	p.cursor = 0
-	for i, item := range p.items {
-		if !item.isHeader {
-			p.cursor = i
-			break
+
+	if shouldPreserve && len(p.items) > 0 {
+		// After an operation (delete/rename/create): preserve cursor
+		// position so the user can repeat operations on adjacent items.
+		p.cursor = prevCursor
+		if p.cursor >= len(p.items) {
+			p.cursor = len(p.items) - 1
+		}
+		if p.cursor < 0 {
+			p.cursor = 0
+		}
+		// If the cursor landed on a header, move to the nearest branch.
+		if p.items[p.cursor].isHeader {
+			moved := false
+			for i := p.cursor + 1; i < len(p.items); i++ {
+				if !p.items[i].isHeader {
+					p.cursor = i
+					moved = true
+					break
+				}
+			}
+			if !moved {
+				for i := p.cursor - 1; i >= 0; i-- {
+					if !p.items[i].isHeader {
+						p.cursor = i
+						break
+					}
+				}
+			}
+		}
+	} else {
+		// Initial load or explicit refresh: position on current branch.
+		p.cursor = 0
+		for i, item := range p.items {
+			if !item.isHeader {
+				p.cursor = i
+				break
+			}
+		}
+		// Prefer placing cursor on the current branch.
+		for i, item := range p.items {
+			if !item.isHeader && item.branch.IsCurrent {
+				p.cursor = i
+				break
+			}
 		}
 	}
-	// Prefer placing cursor on the current branch.
-	for i, item := range p.items {
-		if !item.isHeader && item.branch.IsCurrent {
-			p.cursor = i
-			break
-		}
-	}
+
 	p.offset = 0
 	p.ensureCursorVisible()
 	p.computeAnnotations(branches)

--- a/internal/panels/branches/branches_test.go
+++ b/internal/panels/branches/branches_test.go
@@ -647,6 +647,161 @@ func TestDeleteBranch_RemoteBlocked(t *testing.T) {
 	assert.Contains(t, toast.Message, "Cannot delete remote")
 }
 
+func TestDeleteBranch_RepeatedDeletePreservesCursor(t *testing.T) {
+	// Regression test for #45: after a successful delete, the cursor should
+	// stay near the deleted item instead of jumping to the current branch,
+	// enabling sequential deletes without manual re-navigation.
+	branches := []git.Branch{
+		{Name: "main", IsCurrent: true, Hash: "aaa"},
+		{Name: "feat-a", Hash: "bbb"},
+		{Name: "feat-b", Hash: "ccc"},
+		{Name: "feat-c", Hash: "ddd"},
+	}
+	mock := &mockGitOps{branches: branches}
+	p := newTestPanel(t, mock, defaultCfg())
+	p.Focus()
+
+	// Cursor starts on "main" (current). Move to "feat-a" (index 2, after header).
+	p.Update(keyMsg('j'))
+	assert.Equal(t, "feat-a", p.items[p.cursor].branch.Name)
+	cursorBefore := p.cursor
+
+	// Initiate delete → confirm.
+	_, cmd := p.Update(keyMsg('d'))
+	require.NotNil(t, cmd)
+	cmd() // run ShowConfirm
+	_, cmd = p.Update(notify.ModalResultMsg{Accept: true})
+	require.NotNil(t, cmd)
+	result := cmd()
+	opResult, ok := result.(branchOpResultMsg)
+	require.True(t, ok)
+	assert.Equal(t, "deleted", opResult.op)
+
+	// Process opResult — sets preserveCursor flag and returns batch cmd.
+	p.Update(opResult)
+
+	// Simulate reload with feat-a removed.
+	mock.branches = []git.Branch{
+		{Name: "main", IsCurrent: true, Hash: "aaa"},
+		{Name: "feat-b", Hash: "ccc"},
+		{Name: "feat-c", Hash: "ddd"},
+	}
+	reloadCmd := p.loadBranches()
+	reloadMsg := reloadCmd()
+	p.Update(reloadMsg)
+
+	// Cursor should be near the old position, NOT on "main".
+	assert.Equal(t, cursorBefore, p.cursor, "cursor should be preserved near deleted item")
+	assert.False(t, p.items[p.cursor].branch.IsCurrent, "cursor should not jump to current branch")
+	assert.Equal(t, "feat-b", p.items[p.cursor].branch.Name, "cursor should land on next item")
+
+	// Second delete should work without re-navigation.
+	_, cmd = p.Update(keyMsg('x'))
+	require.NotNil(t, cmd)
+	msg := cmd()
+	modal, ok := msg.(notify.ShowModalMsg)
+	require.True(t, ok)
+	assert.Equal(t, "Delete Branch", modal.Title)
+	assert.Contains(t, modal.Message, "feat-b")
+}
+
+func TestDeleteBranch_CursorClampsOnLastItem(t *testing.T) {
+	// When the last item is deleted, cursor should clamp to the new last item.
+	branches := []git.Branch{
+		{Name: "main", IsCurrent: true, Hash: "aaa"},
+		{Name: "feat-a", Hash: "bbb"},
+	}
+	mock := &mockGitOps{branches: branches}
+	p := newTestPanel(t, mock, defaultCfg())
+	p.Focus()
+
+	// Move to feat-a (last selectable item).
+	p.Update(keyMsg('j'))
+	assert.Equal(t, "feat-a", p.items[p.cursor].branch.Name)
+
+	// Delete feat-a.
+	_, cmd := p.Update(keyMsg('d'))
+	require.NotNil(t, cmd)
+	cmd()
+	_, cmd = p.Update(notify.ModalResultMsg{Accept: true})
+	require.NotNil(t, cmd)
+	result := cmd()
+	opResult := result.(branchOpResultMsg)
+
+	// Process opResult — sets preserveCursor flag.
+	p.Update(opResult)
+
+	// Reload with only main remaining.
+	mock.branches = []git.Branch{
+		{Name: "main", IsCurrent: true, Hash: "aaa"},
+	}
+	reloadCmd := p.loadBranches()
+	reloadMsg := reloadCmd()
+	p.Update(reloadMsg)
+
+	// Cursor should clamp to valid range and land on a non-header item.
+	assert.GreaterOrEqual(t, p.cursor, 0)
+	assert.Less(t, p.cursor, len(p.items))
+	assert.False(t, p.items[p.cursor].isHeader)
+}
+
+func TestDeleteBranch_CursorSkipsHeaderAfterDelete(t *testing.T) {
+	// When deletion causes cursor to land on a section header, it should
+	// move to the nearest selectable branch.
+	branches := []git.Branch{
+		{Name: "main", IsCurrent: true, Hash: "aaa"},
+		{Name: "feat-a", Hash: "bbb"},
+		{Name: "origin/main", IsRemote: true, Hash: "aaa"},
+	}
+	mock := &mockGitOps{branches: branches}
+	p := newTestPanel(t, mock, defaultCfg())
+	p.Focus()
+
+	// Items: [Local Header, main, feat-a, Remote Header, origin/main]
+	// Move to feat-a (index 2).
+	p.Update(keyMsg('j'))
+	assert.Equal(t, "feat-a", p.items[p.cursor].branch.Name)
+
+	// Delete feat-a.
+	_, cmd := p.Update(keyMsg('d'))
+	require.NotNil(t, cmd)
+	cmd()
+	_, cmd = p.Update(notify.ModalResultMsg{Accept: true})
+	require.NotNil(t, cmd)
+	result := cmd()
+	opResult := result.(branchOpResultMsg)
+
+	// Process opResult — sets preserveCursor flag.
+	p.Update(opResult)
+
+	// Reload without feat-a.
+	// Items: [Local Header, main, Remote Header, origin/main]
+	mock.branches = []git.Branch{
+		{Name: "main", IsCurrent: true, Hash: "aaa"},
+		{Name: "origin/main", IsRemote: true, Hash: "aaa"},
+	}
+	reloadCmd := p.loadBranches()
+	reloadMsg := reloadCmd()
+	p.Update(reloadMsg)
+
+	// Cursor was at index 2, which is now "Remote Header". Should skip to
+	// the next selectable item.
+	assert.False(t, p.items[p.cursor].isHeader, "cursor should not be on a header")
+}
+
+func TestDeleteBranch_InitialLoadCursorOnCurrentBranch(t *testing.T) {
+	// On initial load (no prior items), cursor should still land on current branch.
+	branches := []git.Branch{
+		{Name: "feat-a", Hash: "bbb"},
+		{Name: "main", IsCurrent: true, Hash: "aaa"},
+		{Name: "feat-b", Hash: "ccc"},
+	}
+	mock := &mockGitOps{branches: branches}
+	p := newTestPanel(t, mock, defaultCfg())
+
+	assert.Equal(t, "main", p.items[p.cursor].branch.Name, "initial load should position cursor on current branch")
+}
+
 // ---------------------------------------------------------------------------
 // Rename branch
 // ---------------------------------------------------------------------------

--- a/internal/panels/stash/stash.go
+++ b/internal/panels/stash/stash.go
@@ -280,7 +280,7 @@ func (p *Panel) KeyBindings() []panels.KeyBinding {
 		{Key: "enter/a", Description: "Apply stash entry", Action: "apply"},
 		{Key: "p", Description: "Pop stash entry", Action: "pop"},
 		{Key: "n/s", Description: "Push new stash", Action: "item_create"},
-		{Key: "d", Description: "Drop stash entry", Action: "item_delete"},
+		{Key: "d/x", Description: "Drop stash entry", Action: "item_delete"},
 		{Key: "y", Description: "Copy stash reference", Action: "item_copy"},
 		{Key: "D", Description: "Drop all stash entries", Action: "drop_all"},
 	}
@@ -441,7 +441,7 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		return p.executeApply()
 	case "p":
 		return p.executePop()
-	case "d":
+	case "d", "x":
 		return p.requestDrop()
 	case "n", "s":
 		return p.requestPush()

--- a/internal/panels/worktrees/worktrees.go
+++ b/internal/panels/worktrees/worktrees.go
@@ -193,6 +193,17 @@ func (p *Panel) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 		return p, p.loadWorktrees()
 	case panels.RepoChangedMsg:
 		return p.handleRepoChanged(msg)
+	// CRUD actions dispatched via keymap.
+	case panels.ItemDeleteMsg:
+		if !p.Focused {
+			return p, nil
+		}
+		return p.requestDelete()
+	case panels.ItemCreateMsg:
+		if !p.Focused {
+			return p, nil
+		}
+		return p.requestCreate()
 	}
 	return p, nil
 }
@@ -232,7 +243,7 @@ func (p *Panel) KeyBindings() []panels.KeyBinding {
 		{Key: "k/↑", Description: "Move cursor up", Action: "cursor_up"},
 		{Key: "enter", Description: "Switch to worktree", Action: "switch"},
 		{Key: "n", Description: "New worktree", Action: "create"},
-		{Key: "d", Description: "Remove worktree", Action: "remove"},
+		{Key: "d/x", Description: "Remove worktree", Action: "item_delete"},
 		{Key: "R", Description: "Refresh", Action: "refresh"},
 		{Key: "p", Description: "Prune missing", Action: "prune"},
 	}
@@ -304,7 +315,7 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		return p.requestSwitch()
 	case "n":
 		return p.requestCreate()
-	case "d":
+	case "d", "x":
 		return p.requestDelete()
 	case "R":
 		return p, p.loadWorktrees()

--- a/internal/panels/worktrees/worktrees_test.go
+++ b/internal/panels/worktrees/worktrees_test.go
@@ -544,6 +544,126 @@ func TestRemoveWorktree_Cancelled(t *testing.T) {
 	assert.Nil(t, cmd, "cancelled modal should not trigger remove")
 }
 
+func TestRemoveWorktree_XKeyTriggersDelete(t *testing.T) {
+	mock := &mockGitOps{worktrees: sampleWorktrees()}
+	p := newTestPanel(t, mock, alwaysExists)
+	p.Focus()
+
+	// Move to second worktree (not main).
+	p.Update(keyMsg('j'))
+	assert.Equal(t, 1, p.cursor)
+	assert.False(t, p.items[1].isMain)
+
+	// Press "x" — should trigger delete confirmation.
+	_, cmd := p.Update(keyMsg('x'))
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	modal, ok := msg.(notify.ShowModalMsg)
+	require.True(t, ok)
+	assert.Equal(t, "Remove Worktree", modal.Title)
+	assert.Equal(t, notify.ModalConfirm, modal.Kind)
+}
+
+func TestRemoveWorktree_ItemDeleteMsgTriggersDelete(t *testing.T) {
+	mock := &mockGitOps{worktrees: sampleWorktrees()}
+	p := newTestPanel(t, mock, alwaysExists)
+	p.Focus()
+
+	// Move to second worktree (not main).
+	p.Update(keyMsg('j'))
+
+	// Send ItemDeleteMsg (dispatched by keymap for "x" → "item_delete" action).
+	_, cmd := p.Update(panels.ItemDeleteMsg{})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	modal, ok := msg.(notify.ShowModalMsg)
+	require.True(t, ok)
+	assert.Equal(t, "Remove Worktree", modal.Title)
+}
+
+func TestRemoveWorktree_ItemDeleteMsgNotFocused(t *testing.T) {
+	mock := &mockGitOps{worktrees: sampleWorktrees()}
+	p := newTestPanel(t, mock, alwaysExists)
+	// Panel is NOT focused.
+	p.Update(keyMsg('j'))
+
+	_, cmd := p.Update(panels.ItemDeleteMsg{})
+	assert.Nil(t, cmd, "unfocused panel should ignore ItemDeleteMsg")
+}
+
+func TestRemoveWorktree_RepeatedDeleteWorks(t *testing.T) {
+	// Regression test for #45: repeated deletes should work without
+	// manual re-navigation because cursor is preserved after deletion.
+	wts := []git.Worktree{
+		{Path: "/wt/main", Branch: "main", Head: "aaa"},
+		{Path: "/wt/feat-a", Branch: "feat-a", Head: "bbb"},
+		{Path: "/wt/feat-b", Branch: "feat-b", Head: "ccc"},
+		{Path: "/wt/feat-c", Branch: "feat-c", Head: "ddd"},
+	}
+	mock := &mockGitOps{worktrees: wts}
+	p := newTestPanel(t, mock, alwaysExists)
+	p.Focus()
+
+	// Move to feat-a (index 1).
+	p.Update(keyMsg('j'))
+	assert.Equal(t, 1, p.cursor)
+
+	// Delete feat-a.
+	_, cmd := p.Update(keyMsg('d'))
+	require.NotNil(t, cmd)
+	cmd()
+	_, cmd = p.Update(notify.ModalResultMsg{Accept: true})
+	require.NotNil(t, cmd)
+	result := cmd()
+	opResult, ok := result.(worktreeOpResultMsg)
+	require.True(t, ok)
+	assert.Equal(t, "removed", opResult.op)
+
+	// Process opResult (returns batch cmd with reload + notifications).
+	p.Update(opResult)
+
+	// Simulate reload with feat-a removed.
+	mock.worktrees = []git.Worktree{
+		{Path: "/wt/main", Branch: "main", Head: "aaa"},
+		{Path: "/wt/feat-b", Branch: "feat-b", Head: "ccc"},
+		{Path: "/wt/feat-c", Branch: "feat-c", Head: "ddd"},
+	}
+	reloadCmd := p.loadWorktrees()
+	reloadMsg := reloadCmd()
+	p.Update(reloadMsg)
+
+	// Cursor should still be at index 1 (now feat-b), enabling second delete.
+	assert.Equal(t, 1, p.cursor)
+	assert.Equal(t, "feat-b", p.items[p.cursor].worktree.Branch)
+
+	// Second delete should work immediately.
+	_, cmd = p.Update(keyMsg('x'))
+	require.NotNil(t, cmd)
+	msg := cmd()
+	modal, ok := msg.(notify.ShowModalMsg)
+	require.True(t, ok)
+	assert.Equal(t, "Remove Worktree", modal.Title)
+	assert.Contains(t, modal.Message, "feat-b")
+}
+
+func TestCreateWorktree_ItemCreateMsgTriggersCreate(t *testing.T) {
+	mock := &mockGitOps{worktrees: sampleWorktrees()}
+	p := newTestPanel(t, mock, alwaysExists)
+	p.Focus()
+
+	// Send ItemCreateMsg (dispatched by keymap for "n" → "item_create" action).
+	_, cmd := p.Update(panels.ItemCreateMsg{})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	modal, ok := msg.(notify.ShowModalMsg)
+	require.True(t, ok)
+	assert.Equal(t, "New Worktree", modal.Title)
+	assert.Equal(t, notify.ModalInput, modal.Kind)
+}
+
 // ---------------------------------------------------------------------------
 // Prune missing worktrees
 // ---------------------------------------------------------------------------
@@ -634,7 +754,7 @@ func TestKeyBindings(t *testing.T) {
 	assert.True(t, actions["cursor_up"])
 	assert.True(t, actions["switch"])
 	assert.True(t, actions["create"])
-	assert.True(t, actions["remove"])
+	assert.True(t, actions["item_delete"])
 	assert.True(t, actions["refresh"])
 	assert.True(t, actions["prune"])
 }


### PR DESCRIPTION
Closes #45

## Root Cause
After deleting a branch, `buildItems()` always snapped the cursor back to the current branch. Since the current branch can't be deleted, subsequent d/x presses silently showed "Cannot delete current branch" — appearing as if delete was broken.

## Fix
- Added `preserveCursor` flag to branches panel — after delete, cursor stays at logical position instead of jumping to current branch
- Added `x` key alias to branches, worktrees, and stash panels
- Added `ItemDeleteMsg`/`ItemCreateMsg` handlers to worktrees panel
- Added missing worktrees CRUD keybindings to all 3 keymap schemes

## Changes (8 files, +409/-18)
- `branches.go` — preserveCursor logic + x alias
- `branches_test.go` — 5 new tests (repeated delete, cursor clamp)
- `worktrees.go` — x alias + delete/create msg handlers
- `worktrees_test.go` — 6 new tests
- `stash.go` — x alias
- `default.toml`, `classic.toml`, `vim.toml` — worktrees CRUD bindings

## Testing
- All 50+ packages pass, 11 new tests added