### PR TITLE
fix: store pendingPath in double-click first-use flow to survive async modal delay

### DIFF
--- a/internal/panels/worktrees/worktrees.go
+++ b/internal/panels/worktrees/worktrees.go
@@ -328,7 +328,7 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		p.moveCursorUp()
 		return p, p.worktreeSelectedCmd()
 	case "enter":
-		return p.requestSwitch()
+		return p.requestSwitch("")
 	case "n":
 		return p.requestCreate()
 	case "d", "x":
@@ -367,36 +367,45 @@ func (p *Panel) handleMouseDoubleClick(msg panels.PanelMouseDoubleClickMsg) (pan
 	if !p.actionsCfg.IsConfirmed(string(itemType)) {
 		p.pending = opFirstUseConfirm
 		p.pendingName = string(itemType)
+		p.pendingPath = p.items[idx].worktree.Path
 		return p, rightclick.FirstUseCmd(itemType)
 	}
 	action := actions.ActionID(p.actionsCfg.GetDoubleClickAction(string(itemType)))
-	return p.executeRightClickAction(action)
+	return p.executeRightClickAction(action, "")
 }
 
 // SetActionsCfg injects the actions configuration for right-click menus.
 func (p *Panel) SetActionsCfg(cfg config.ActionsConfig) { p.actionsCfg = cfg }
 
-// executeRightClickAction dispatches a right-click action to the appropriate method.
-func (p *Panel) executeRightClickAction(action actions.ActionID) (panels.Panel, tea.Cmd) {
+// executeRightClickAction dispatches a right-click action to the appropriate
+// method. When pathOverride is non-empty it is used directly instead of
+// looking up the item via p.cursor, which may have become stale during an
+// async modal delay.
+func (p *Panel) executeRightClickAction(action actions.ActionID, pathOverride string) (panels.Panel, tea.Cmd) {
 	switch action { //nolint:exhaustive // only relevant cases handled
 	case actions.ActionSwitch:
-		return p.requestSwitch()
+		return p.requestSwitch(pathOverride)
 	case actions.ActionChangeDirectory:
-		return p.changeDirectory()
+		return p.changeDirectory(pathOverride)
 	case actions.ActionOpenTerminal:
-		return p.openTerminal()
+		return p.openTerminal(pathOverride)
 	case actions.ActionCopyPath:
-		return p.copyPath()
+		return p.copyPath(pathOverride)
 	}
 	return p, nil
 }
 
 // openTerminal opens a terminal at the worktree's path.
-func (p *Panel) openTerminal() (panels.Panel, tea.Cmd) {
-	if p.cursor < 0 || p.cursor >= len(p.items) {
-		return p, nil
+func (p *Panel) openTerminal(pathOverride string) (panels.Panel, tea.Cmd) {
+	var wtPath string
+	if pathOverride != "" {
+		wtPath = pathOverride
+	} else {
+		if p.cursor < 0 || p.cursor >= len(p.items) {
+			return p, nil
+		}
+		wtPath = p.items[p.cursor].worktree.Path
 	}
-	wtPath := p.items[p.cursor].worktree.Path
 	return p, func() tea.Msg {
 		if err := panels.OpenInTerminal(wtPath); err != nil {
 			return notify.ShowToastMsg{Message: "Terminal failed: " + err.Error(), Level: notify.Error}
@@ -406,11 +415,16 @@ func (p *Panel) openTerminal() (panels.Panel, tea.Cmd) {
 }
 
 // copyPath copies the worktree path to the clipboard.
-func (p *Panel) copyPath() (panels.Panel, tea.Cmd) {
-	if p.cursor < 0 || p.cursor >= len(p.items) {
-		return p, nil
+func (p *Panel) copyPath(pathOverride string) (panels.Panel, tea.Cmd) {
+	var wtPath string
+	if pathOverride != "" {
+		wtPath = pathOverride
+	} else {
+		if p.cursor < 0 || p.cursor >= len(p.items) {
+			return p, nil
+		}
+		wtPath = p.items[p.cursor].worktree.Path
 	}
-	wtPath := p.items[p.cursor].worktree.Path
 	return p, func() tea.Msg {
 		if err := panels.CopyToClipboard(p.ctx, wtPath); err != nil {
 			return notify.ShowToastMsg{Message: "Copy failed: " + err.Error(), Level: notify.Error}
@@ -421,17 +435,22 @@ func (p *Panel) copyPath() (panels.Panel, tea.Cmd) {
 
 // changeDirectory emits a ChangeDirectoryMsg so the app re-roots into
 // the selected worktree.
-func (p *Panel) changeDirectory() (panels.Panel, tea.Cmd) {
-	item := p.selectedWorktree()
-	if item == nil {
-		return p, nil
-	}
-	if item.isMissing {
-		return p, func() tea.Msg {
-			return notify.ShowToastMsg{Message: "Cannot cd: path missing", Level: notify.Warn}
+func (p *Panel) changeDirectory(pathOverride string) (panels.Panel, tea.Cmd) {
+	var path string
+	if pathOverride != "" {
+		path = pathOverride
+	} else {
+		item := p.selectedWorktree()
+		if item == nil {
+			return p, nil
 		}
+		if item.isMissing {
+			return p, func() tea.Msg {
+				return notify.ShowToastMsg{Message: "Cannot cd: path missing", Level: notify.Warn}
+			}
+		}
+		path = item.worktree.Path
 	}
-	path := item.worktree.Path
 	return p, func() tea.Msg {
 		return panels.ChangeDirectoryMsg{Path: path}
 	}
@@ -515,17 +534,22 @@ func (p *Panel) worktreeSelectedCmd() tea.Cmd {
 // ---------------------------------------------------------------------------
 // Worktree operations
 // ---------------------------------------------------------------------------
-func (p *Panel) requestSwitch() (panels.Panel, tea.Cmd) {
-	item := p.selectedWorktree()
-	if item == nil {
-		return p, nil
-	}
-	if item.isMissing {
-		return p, func() tea.Msg {
-			return notify.ShowToastMsg{Message: "Cannot switch: path missing", Level: notify.Warn}
+func (p *Panel) requestSwitch(pathOverride string) (panels.Panel, tea.Cmd) {
+	var path string
+	if pathOverride != "" {
+		path = pathOverride
+	} else {
+		item := p.selectedWorktree()
+		if item == nil {
+			return p, nil
 		}
+		if item.isMissing {
+			return p, func() tea.Msg {
+				return notify.ShowToastMsg{Message: "Cannot switch: path missing", Level: notify.Warn}
+			}
+		}
+		path = item.worktree.Path
 	}
-	path := item.worktree.Path
 	if p.cfg.WorktreeOpenMode == "new_terminal" {
 		return p, func() tea.Msg {
 			if err := panels.OpenInTerminal(path); err != nil {
@@ -616,9 +640,9 @@ func (p *Panel) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, tea.
 		if msg.Remember {
 			config.SaveDoubleClickChoice(&p.actionsCfg, pendingName, msg.Value)
 		}
-		return p.executeRightClickAction(actions.ActionID(msg.Value))
+		return p.executeRightClickAction(actions.ActionID(msg.Value), pendingPath)
 	case opRightClickPick:
-		return p.executeRightClickAction(actions.ActionID(msg.Value))
+		return p.executeRightClickAction(actions.ActionID(msg.Value), pendingPath)
 	}
 	return p, nil
 }

--- a/internal/panels/worktrees/worktrees_extra_test.go
+++ b/internal/panels/worktrees/worktrees_extra_test.go
@@ -87,7 +87,7 @@ func TestExecuteRightClickAction_Switch(t *testing.T) {
 	p := newTestPanel(t, &mockGitOps{worktrees: sampleWorktrees()}, alwaysExists)
 	p.cursor = 1
 
-	_, cmd := p.executeRightClickAction(actions.ActionSwitch)
+	_, cmd := p.executeRightClickAction(actions.ActionSwitch, "")
 	assert.NotNil(t, cmd)
 	msg := cmd()
 	_, ok := msg.(panels.SwitchWorktreeMsg)
@@ -98,7 +98,7 @@ func TestExecuteRightClickAction_CopyPath(t *testing.T) {
 	p := newTestPanel(t, &mockGitOps{worktrees: sampleWorktrees()}, alwaysExists)
 	p.cursor = 0
 
-	_, cmd := p.executeRightClickAction(actions.ActionCopyPath)
+	_, cmd := p.executeRightClickAction(actions.ActionCopyPath, "")
 	// cmd invokes clipboard; just ensure it's non-nil
 	assert.NotNil(t, cmd)
 }
@@ -107,13 +107,13 @@ func TestExecuteRightClickAction_OpenTerminal(t *testing.T) {
 	p := newTestPanel(t, &mockGitOps{worktrees: sampleWorktrees()}, alwaysExists)
 	p.cursor = 0
 
-	_, cmd := p.executeRightClickAction(actions.ActionOpenTerminal)
+	_, cmd := p.executeRightClickAction(actions.ActionOpenTerminal, "")
 	assert.NotNil(t, cmd)
 }
 
 func TestExecuteRightClickAction_UnknownAction(t *testing.T) {
 	p := newTestPanel(t, &mockGitOps{worktrees: sampleWorktrees()}, alwaysExists)
-	_, cmd := p.executeRightClickAction(actions.ActionID("unknown"))
+	_, cmd := p.executeRightClickAction(actions.ActionID("unknown"), "")
 	assert.Nil(t, cmd)
 }
 
@@ -125,7 +125,7 @@ func TestCopyPath_OutOfBounds(t *testing.T) {
 	p := newTestPanel(t, &mockGitOps{worktrees: sampleWorktrees()}, alwaysExists)
 	p.cursor = -1
 
-	_, cmd := p.copyPath()
+	_, cmd := p.copyPath("")
 	assert.Nil(t, cmd)
 }
 
@@ -133,7 +133,7 @@ func TestCopyPath_ValidCursor(t *testing.T) {
 	p := newTestPanel(t, &mockGitOps{worktrees: sampleWorktrees()}, alwaysExists)
 	p.cursor = 0
 
-	_, cmd := p.copyPath()
+	_, cmd := p.copyPath("")
 	assert.NotNil(t, cmd)
 }
 
@@ -145,7 +145,7 @@ func TestOpenTerminal_OutOfBounds(t *testing.T) {
 	p := newTestPanel(t, &mockGitOps{worktrees: sampleWorktrees()}, alwaysExists)
 	p.cursor = 99
 
-	_, cmd := p.openTerminal()
+	_, cmd := p.openTerminal("")
 	assert.Nil(t, cmd)
 }
 
@@ -158,7 +158,7 @@ func TestRequestSwitch_MissingPath(t *testing.T) {
 	p.items[1].isMissing = true
 	p.cursor = 1
 
-	_, cmd := p.requestSwitch()
+	_, cmd := p.requestSwitch("")
 	assert.NotNil(t, cmd)
 	msg := cmd()
 	toast, ok := msg.(notify.ShowToastMsg)
@@ -171,13 +171,13 @@ func TestRequestSwitch_NewTerminalMode(t *testing.T) {
 	p.cfg.WorktreeOpenMode = "new_terminal"
 	p.cursor = 1
 
-	_, cmd := p.requestSwitch()
+	_, cmd := p.requestSwitch("")
 	assert.NotNil(t, cmd, "should emit terminal open command")
 }
 
 func TestRequestSwitch_NoItems(t *testing.T) {
 	p := newTestPanel(t, &mockGitOps{worktrees: []git.Worktree{}}, alwaysExists)
-	_, cmd := p.requestSwitch()
+	_, cmd := p.requestSwitch("")
 	assert.Nil(t, cmd)
 }
 
@@ -188,6 +188,7 @@ func TestRequestSwitch_NoItems(t *testing.T) {
 func TestHandleModalResult_RightClickPick(t *testing.T) {
 	p := newTestPanel(t, &mockGitOps{worktrees: sampleWorktrees()}, alwaysExists)
 	p.pending = opRightClickPick
+	p.pendingPath = "/home/user/grut-feat"
 	p.cursor = 1
 
 	_, cmd := p.handleModalResult(notify.ModalResultMsg{
@@ -209,6 +210,7 @@ func TestHandleModalResult_FirstUseConfirm(t *testing.T) {
 	p := newTestPanel(t, &mockGitOps{worktrees: sampleWorktrees()}, alwaysExists)
 	p.pending = opFirstUseConfirm
 	p.pendingName = "worktree"
+	p.pendingPath = "/home/user/grut-feat"
 	p.cursor = 1
 
 	_, cmd := p.handleModalResult(notify.ModalResultMsg{
@@ -217,6 +219,73 @@ func TestHandleModalResult_FirstUseConfirm(t *testing.T) {
 		Remember: true,
 	})
 	assert.NotNil(t, cmd)
+}
+
+func TestHandleModalResult_FirstUseConfirm_UsesPendingPath(t *testing.T) {
+	// Regression test: after double-click triggers first-use confirmation,
+	// the cursor may become stale before the modal result arrives.
+	// The fix stores pendingPath at double-click time and threads it through
+	// to requestSwitch, so even if the cursor is invalidated the correct
+	// worktree path is used.
+	p := newTestPanel(t, &mockGitOps{worktrees: sampleWorktrees()}, alwaysExists)
+	p.pending = opFirstUseConfirm
+	p.pendingName = "worktree"
+	p.pendingPath = "/home/user/grut-feat"
+
+	// Simulate cursor becoming stale (pointing beyond items).
+	p.cursor = 999
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{
+		Accept:   true,
+		Value:    string(actions.ActionSwitch),
+		Remember: false,
+	})
+	require.NotNil(t, cmd, "should produce SwitchWorktreeMsg even with stale cursor")
+	msg := cmd()
+	switchMsg, ok := msg.(panels.SwitchWorktreeMsg)
+	require.True(t, ok, "expected SwitchWorktreeMsg, got %T", msg)
+	assert.Equal(t, "/home/user/grut-feat", switchMsg.Path)
+}
+
+func TestHandleModalResult_FirstUseConfirm_ChangeDirectory_UsesPendingPath(t *testing.T) {
+	// Same regression test but for the change-directory action.
+	p := newTestPanel(t, &mockGitOps{worktrees: sampleWorktrees()}, alwaysExists)
+	p.pending = opFirstUseConfirm
+	p.pendingName = "worktree"
+	p.pendingPath = "/home/user/grut-fix"
+
+	// Stale cursor.
+	p.cursor = 999
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{
+		Accept:   true,
+		Value:    string(actions.ActionChangeDirectory),
+		Remember: false,
+	})
+	require.NotNil(t, cmd, "should produce ChangeDirectoryMsg even with stale cursor")
+	msg := cmd()
+	cdMsg, ok := msg.(panels.ChangeDirectoryMsg)
+	require.True(t, ok, "expected ChangeDirectoryMsg, got %T", msg)
+	assert.Equal(t, "/home/user/grut-fix", cdMsg.Path)
+}
+
+func TestMouseDoubleClick_FirstUse_StoresPendingPath(t *testing.T) {
+	// Verify that handleMouseDoubleClick stores pendingPath when showing
+	// the first-use confirmation dialog.
+	mock := &mockGitOps{worktrees: sampleWorktrees()}
+	p := newTestPanel(t, mock, alwaysExists)
+	p.SetSize(80, 20)
+	p.Focus()
+
+	// Ensure IsConfirmed returns false so the first-use flow is triggered.
+	p.actionsCfg = config.ActionsConfig{}
+
+	_, cmd := p.Update(panels.PanelMouseDoubleClickMsg{ContentRow: 1, ContentCol: 5})
+
+	// The first-use flow should have stored the pendingPath.
+	assert.Equal(t, opFirstUseConfirm, p.pending)
+	assert.Equal(t, "/home/user/grut-feat", p.pendingPath)
+	assert.NotNil(t, cmd, "should emit FirstUseCmd")
 }
 
 // ---------------------------------------------------------------------------
@@ -240,7 +309,7 @@ func TestChangeDirectory_EmitsChangeDirectoryMsg(t *testing.T) {
 	p := newTestPanel(t, &mockGitOps{worktrees: sampleWorktrees()}, alwaysExists)
 	p.cursor = 1
 
-	_, cmd := p.changeDirectory()
+	_, cmd := p.changeDirectory("")
 	require.NotNil(t, cmd)
 	msg := cmd()
 	cdMsg, ok := msg.(panels.ChangeDirectoryMsg)
@@ -253,7 +322,7 @@ func TestChangeDirectory_MissingPath(t *testing.T) {
 	p.items[1].isMissing = true
 	p.cursor = 1
 
-	_, cmd := p.changeDirectory()
+	_, cmd := p.changeDirectory("")
 	require.NotNil(t, cmd)
 	msg := cmd()
 	toast, ok := msg.(notify.ShowToastMsg)
@@ -264,7 +333,7 @@ func TestChangeDirectory_MissingPath(t *testing.T) {
 
 func TestChangeDirectory_NoItems(t *testing.T) {
 	p := newTestPanel(t, &mockGitOps{worktrees: []git.Worktree{}}, alwaysExists)
-	_, cmd := p.changeDirectory()
+	_, cmd := p.changeDirectory("")
 	assert.Nil(t, cmd)
 }
 
@@ -272,7 +341,7 @@ func TestExecuteRightClickAction_ChangeDirectory(t *testing.T) {
 	p := newTestPanel(t, &mockGitOps{worktrees: sampleWorktrees()}, alwaysExists)
 	p.cursor = 1
 
-	_, cmd := p.executeRightClickAction(actions.ActionChangeDirectory)
+	_, cmd := p.executeRightClickAction(actions.ActionChangeDirectory, "")
 	require.NotNil(t, cmd)
 	msg := cmd()
 	_, ok := msg.(panels.ChangeDirectoryMsg)


### PR DESCRIPTION
Fixes the worktree switch pending path issue where double-click first-use flow lost the target path during async modal delay.

**Changes:**
- Store pendingPath before showing modal so it survives async delay
- Ensures worktree switch completes correctly after user confirms