### PR TITLE
feat: add branch diff mode with cycling key (g)

### DIFF
--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -35,9 +35,21 @@ func (c *Client) Diff(ctx context.Context, opts DiffOpts) ([]FileDiff, error) {
 		if err := ValidateRef(opts.CommitA); err != nil {
 			return nil, fmt.Errorf("diff commitA: %w", err)
 		}
-		args = append(args, opts.CommitA)
-	}
-	if opts.CommitB != "" {
+		if opts.ThreeDot && opts.CommitB != "" {
+			if err := ValidateRef(opts.CommitB); err != nil {
+				return nil, fmt.Errorf("diff commitB: %w", err)
+			}
+			args = append(args, opts.CommitA+"..."+opts.CommitB)
+		} else {
+			args = append(args, opts.CommitA)
+			if opts.CommitB != "" {
+				if err := ValidateRef(opts.CommitB); err != nil {
+					return nil, fmt.Errorf("diff commitB: %w", err)
+				}
+				args = append(args, opts.CommitB)
+			}
+		}
+	} else if opts.CommitB != "" {
 		if err := ValidateRef(opts.CommitB); err != nil {
 			return nil, fmt.Errorf("diff commitB: %w", err)
 		}

--- a/internal/git/types.go
+++ b/internal/git/types.go
@@ -80,6 +80,7 @@ type DiffOpts struct {
 	NameOnly  bool // Only show file names
 	StatOnly  bool // Only show stat summary
 	IgnoreAll bool // Ignore all whitespace changes
+	ThreeDot  bool // Use three-dot notation (CommitA...CommitB) for merge-base comparison
 }
 
 // FileDiff represents the diff output for a single file.

--- a/internal/keymap/keymap_test.go
+++ b/internal/keymap/keymap_test.go
@@ -637,10 +637,10 @@ func TestGitFilterBindingChangedToG(t *testing.T) {
 	bindings, err := LoadScheme("default")
 	require.NoError(t, err)
 
-	// Verify "g" → "toggle_git_filter" in filetree context.
+	// Verify "g" → "cycle_file_filter" in filetree context.
 	found := findBinding(bindings, "g", ModePanel, "filetree")
 	require.NotNil(t, found, "default scheme should have 'g' binding in filetree context")
-	assert.Equal(t, "toggle_git_filter", found.Action)
+	assert.Equal(t, "cycle_file_filter", found.Action)
 }
 
 func TestVimSchemeHasCursorNavBindings(t *testing.T) {

--- a/internal/keymap/schemes/default.toml
+++ b/internal/keymap/schemes/default.toml
@@ -187,6 +187,13 @@ mode = "panel"
 context = "filetree"
 description = "Toggle git-changed files filter"
 
+[[bindings]]
+key = "b"
+action = "toggle_branch_diff_filter"
+mode = "panel"
+context = "filetree"
+description = "Toggle branch diff filter"
+
 # Git status specific
 [[bindings]]
 key = "s"

--- a/internal/keymap/schemes/default.toml
+++ b/internal/keymap/schemes/default.toml
@@ -182,17 +182,10 @@ description = "Toggle hidden files"
 
 [[bindings]]
 key = "g"
-action = "toggle_git_filter"
+action = "cycle_file_filter"
 mode = "panel"
 context = "filetree"
-description = "Toggle git-changed files filter"
-
-[[bindings]]
-key = "b"
-action = "toggle_branch_diff_filter"
-mode = "panel"
-context = "filetree"
-description = "Toggle branch diff filter"
+description = "Cycle filter: all / git changed / branch diff"
 
 # Git status specific
 [[bindings]]

--- a/internal/layout/registry.go
+++ b/internal/layout/registry.go
@@ -121,6 +121,7 @@ func RegisterDefaults(r *Registry, cfg *config.Config, gc git.GitClient, th *the
 		if gc != nil {
 			ft.SetGitClient(gc)
 		}
+		ft.SetBaseBranch(cfg.Git.DefaultBranch)
 		return setActionsCfg(ft)
 	})
 	// Preview panel — real implementation

--- a/internal/panels/filetree/filetree.go
+++ b/internal/panels/filetree/filetree.go
@@ -110,6 +110,8 @@ type FileTree struct {
 	prLabel         string
 	branchName      string   // selected branch name
 	branchLabel     string   // e.g. "branch: feature/auth"
+	branchBaseRef   string   // base ref for branch comparison (e.g., "main")
+	baseBranch      string   // configured default/base branch for "b" toggle
 	visible         []*node  // flattened list of currently visible nodes
 	commitFiles     []string // relative paths from diff-tree
 	branchFiles     []string // relative paths from branch diff
@@ -135,6 +137,8 @@ type FileTree struct {
 	prFilesMode bool
 	// Branch-files mode: shows files changed on a selected branch.
 	branchFilesMode bool
+	// Branch-diff filter: user toggled "b" to see origination diff.
+	branchDiffFilter bool
 }
 
 // Compile-time interface check.
@@ -175,6 +179,12 @@ func (ft *FileTree) SetGitClient(gc git.StatusReader) {
 	if ic, ok := gc.(git.IgnoreChecker); ok {
 		ft.ignoreChecker = ic
 	}
+}
+
+// SetBaseBranch configures the default base branch for the "b" toggle
+// (branch diff filter). Typically set from config.GitConfig.DefaultBranch.
+func (ft *FileTree) SetBaseBranch(branch string) {
+	ft.baseBranch = branch
 }
 
 // handleRepoChanged replaces the git client so git-aware features (file
@@ -490,6 +500,7 @@ func (ft *FileTree) KeyBindings() []panels.KeyBinding {
 		{Key: ".", Description: "Toggle hidden files", Action: "toggle_hidden"},
 		{Key: "G", Description: "Go to bottom", Action: "go_bottom"},
 		{Key: "g", Description: "Toggle git-changed filter", Action: "toggle_git_filter"},
+		{Key: "b", Description: "Toggle branch diff filter", Action: "toggle_branch_diff_filter"},
 		{Key: "space", Description: "Toggle selection", Action: "toggle_select"},
 		{Key: "n", Description: "Create new file", Action: "item_create"},
 		{Key: "d", Description: "Delete file(s)", Action: "item_delete"},
@@ -558,9 +569,11 @@ func (ft *FileTree) handleCommitFilesLoaded(msg commitFilesLoadedMsg) (panels.Pa
 	// Exit branch-files mode if active.
 	if ft.branchFilesMode {
 		ft.branchFilesMode = false
+		ft.branchDiffFilter = false
 		ft.branchFiles = nil
 		ft.branchName = ""
 		ft.branchLabel = ""
+		ft.branchBaseRef = ""
 		ft.branchChangedPaths = nil
 		ft.branchChangedDirs = nil
 	}
@@ -616,9 +629,11 @@ func (ft *FileTree) handlePRFilesLoaded(msg panels.PRFilesLoadedMsg) (panels.Pan
 	// Exit branch-files mode if active.
 	if ft.branchFilesMode {
 		ft.branchFilesMode = false
+		ft.branchDiffFilter = false
 		ft.branchFiles = nil
 		ft.branchName = ""
 		ft.branchLabel = ""
+		ft.branchBaseRef = ""
 		ft.branchChangedPaths = nil
 		ft.branchChangedDirs = nil
 	}
@@ -673,7 +688,7 @@ func (ft *FileTree) handleBranchSelected(msg panels.BranchSelectedMsg) (panels.P
 	ctx := ft.ctx
 	name := msg.Name
 	return ft, func() tea.Msg {
-		files, err := gc.DiffFileNames(ctx, "HEAD", name)
+		files, err := gc.DiffFileNames(ctx, name, "HEAD")
 		return branchFilesLoadedMsg{files: files, branch: name, err: err}
 	}
 }
@@ -689,7 +704,12 @@ func (ft *FileTree) handleBranchFilesLoaded(msg branchFilesLoadedMsg) (panels.Pa
 	ft.branchFilesMode = true
 	ft.branchFiles = msg.files
 	ft.branchName = msg.branch
-	ft.branchLabel = "branch: " + msg.branch
+	ft.branchBaseRef = msg.branch
+	if ft.branchDiffFilter {
+		ft.branchLabel = "diff vs " + msg.branch
+	} else {
+		ft.branchLabel = "branch: " + msg.branch
+	}
 	// Exit commit-files mode if active.
 	if ft.commitFilesMode {
 		ft.commitFilesMode = false
@@ -721,20 +741,68 @@ func (ft *FileTree) handleBranchFilesLoaded(msg branchFilesLoadedMsg) (panels.Pa
 	ft.rebuildVisible()
 	ft.cursor = 0
 	ft.offset = 0
-	return ft, ft.emitCursorFileSelected()
+	cmds := []tea.Cmd{ft.emitCursorFileSelected()}
+	if ft.branchDiffFilter {
+		baseBranch := ft.branchBaseRef
+		cmds = append(cmds, func() tea.Msg {
+			return panels.BranchDiffFilterActiveMsg{Active: true, BaseBranch: baseBranch}
+		})
+	}
+	return ft, tea.Batch(cmds...)
 }
 
 // exitBranchFilesMode restores the normal file tree view.
 func (ft *FileTree) exitBranchFilesMode() {
 	ft.branchFilesMode = false
+	ft.branchDiffFilter = false
 	ft.branchFiles = nil
 	ft.branchName = ""
 	ft.branchLabel = ""
+	ft.branchBaseRef = ""
 	ft.branchChangedPaths = nil
 	ft.branchChangedDirs = nil
 	ft.rebuildVisible()
 	ft.restoreCursorToPath(ft.savedCursorPath)
 	ft.savedCursorPath = ""
+}
+
+// toggleBranchDiffFilter toggles the "b" mode: shows only files that differ
+// from the configured base branch (e.g., main). Uses three-dot diff to show
+// changes introduced on the current branch since it diverged.
+func (ft *FileTree) toggleBranchDiffFilter() (panels.Panel, tea.Cmd) {
+	if ft.gitClient == nil {
+		return ft, nil
+	}
+	// If already in branch-diff filter mode, turn it off.
+	if ft.branchDiffFilter {
+		return ft.exitBranchDiffWithCmd()
+	}
+	base := ft.baseBranch
+	if base == "" {
+		base = "main"
+	}
+	ft.branchDiffFilter = true
+	gc := ft.gitClient
+	ctx := ft.ctx
+	return ft, func() tea.Msg {
+		files, err := gc.DiffFileNames(ctx, base, "HEAD")
+		return branchFilesLoadedMsg{files: files, branch: base, err: err}
+	}
+}
+
+// exitBranchDiffWithCmd exits branch-files mode and emits the appropriate
+// deactivation messages.
+func (ft *FileTree) exitBranchDiffWithCmd() (panels.Panel, tea.Cmd) {
+	wasDiffFilter := ft.branchDiffFilter
+	ft.exitBranchFilesMode()
+	var cmds []tea.Cmd
+	cmds = append(cmds, ft.emitCursorFileSelected())
+	if wasDiffFilter {
+		cmds = append(cmds, func() tea.Msg {
+			return panels.BranchDiffFilterActiveMsg{Active: false}
+		})
+	}
+	return ft, tea.Batch(cmds...)
 }
 
 // ---------------------------------------------------------------------------
@@ -756,8 +824,7 @@ func (ft *FileTree) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 	}
 	// In branch-files mode, Escape returns to normal tree view.
 	if ft.branchFilesMode && msg.String() == keyEsc {
-		ft.exitBranchFilesMode()
-		return ft, ft.emitCursorFileSelected()
+		return ft.exitBranchDiffWithCmd()
 	}
 	switch msg.String() {
 	case "j", "down":
@@ -774,6 +841,8 @@ func (ft *FileTree) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		ft.toggleHidden()
 	case "g":
 		return ft.toggleGitFilter()
+	case "b":
+		return ft.toggleBranchDiffFilter()
 	case "G":
 		ft.goToBottom()
 	case "d":
@@ -941,6 +1010,8 @@ func (ft *FileTree) moveCursorUp() {
 
 // emitCursorFileSelected returns a cmd that sends FileSelectedMsg for the
 // currently focused node, so the preview panel updates on every cursor move.
+// In branch-files mode, it emits ShowDiffMsg with ref comparison context so
+// the diff panel shows the branch comparison instead of working tree diff.
 func (ft *FileTree) emitCursorFileSelected() tea.Cmd {
 	if ft.cursor < 0 || ft.cursor >= len(ft.visible) {
 		return nil
@@ -951,6 +1022,27 @@ func (ft *FileTree) emitCursorFileSelected() tea.Cmd {
 		return func() tea.Msg { return panels.FolderSelectedMsg{Path: path} }
 	}
 	path := n.path
+	// In branch-files mode, emit ShowDiffMsg with ref comparison context
+	// so the diff panel shows the branch diff, not the working tree diff.
+	if ft.branchFilesMode && ft.branchBaseRef != "" {
+		relPath, err := filepath.Rel(ft.rootPath, path)
+		if err != nil {
+			relPath = path
+		}
+		relPath = filepath.ToSlash(relPath)
+		baseRef := ft.branchBaseRef
+		return tea.Batch(
+			func() tea.Msg { return panels.FileSelectedMsg{Path: path} },
+			func() tea.Msg {
+				return panels.ShowDiffMsg{
+					Path:     relPath,
+					CommitA:  baseRef,
+					CommitB:  "HEAD",
+					ThreeDot: true,
+				}
+			},
+		)
+	}
 	return func() tea.Msg { return panels.FileSelectedMsg{Path: path} }
 }
 

--- a/internal/panels/filetree/filetree.go
+++ b/internal/panels/filetree/filetree.go
@@ -499,8 +499,7 @@ func (ft *FileTree) KeyBindings() []panels.KeyBinding {
 		{Key: "h/←", Description: "Collapse dir / go to parent", Action: "collapse"},
 		{Key: ".", Description: "Toggle hidden files", Action: "toggle_hidden"},
 		{Key: "G", Description: "Go to bottom", Action: "go_bottom"},
-		{Key: "g", Description: "Toggle git-changed filter", Action: "toggle_git_filter"},
-		{Key: "b", Description: "Toggle branch diff filter", Action: "toggle_branch_diff_filter"},
+		{Key: "g", Description: "Cycle filter: all → git changed → branch diff", Action: "cycle_file_filter"},
 		{Key: "space", Description: "Toggle selection", Action: "toggle_select"},
 		{Key: "n", Description: "Create new file", Action: "item_create"},
 		{Key: "d", Description: "Delete file(s)", Action: "item_delete"},
@@ -766,17 +765,10 @@ func (ft *FileTree) exitBranchFilesMode() {
 	ft.savedCursorPath = ""
 }
 
-// toggleBranchDiffFilter toggles the "b" mode: shows only files that differ
-// from the configured base branch (e.g., main). Uses three-dot diff to show
-// changes introduced on the current branch since it diverged.
-func (ft *FileTree) toggleBranchDiffFilter() (panels.Panel, tea.Cmd) {
-	if ft.gitClient == nil {
-		return ft, nil
-	}
-	// If already in branch-diff filter mode, turn it off.
-	if ft.branchDiffFilter {
-		return ft.exitBranchDiffWithCmd()
-	}
+// activateBranchDiffFilter enters branch-diff mode: shows only files that
+// differ from the configured base branch (e.g., main). Uses three-dot diff
+// to show changes introduced on the current branch since it diverged.
+func (ft *FileTree) activateBranchDiffFilter() (panels.Panel, tea.Cmd) {
 	base := ft.baseBranch
 	if base == "" {
 		base = "main"
@@ -788,6 +780,45 @@ func (ft *FileTree) toggleBranchDiffFilter() (panels.Panel, tea.Cmd) {
 		files, err := gc.DiffFileNames(ctx, base, "HEAD")
 		return branchFilesLoadedMsg{files: files, branch: base, err: err}
 	}
+}
+
+// cycleFileFilter cycles through file filter modes:
+//
+//	all files → git changed → branch diff → all files
+//
+// If a non-cycle filter mode is active (e.g., branch selected from gitinfo
+// panel), pressing the cycle key exits to "all files" first.
+func (ft *FileTree) cycleFileFilter() (panels.Panel, tea.Cmd) {
+	if ft.gitClient == nil {
+		return ft, nil
+	}
+	// If in a panel-driven branch mode (not from our cycle), exit first.
+	if ft.branchFilesMode && !ft.branchDiffFilter {
+		return ft.exitBranchDiffWithCmd()
+	}
+	// Cycle: branchDiff → all
+	if ft.branchDiffFilter {
+		return ft.exitBranchDiffWithCmd()
+	}
+	// Cycle: gitFilter → branchDiff
+	if ft.gitFilter {
+		cursorPath := ft.cursorPath()
+		ft.gitFilter = false
+		ft.gitChangedPaths = nil
+		ft.gitChangedDirs = nil
+		ft.rebuildVisible()
+		ft.restoreCursorToPath(cursorPath)
+		cmds := []tea.Cmd{
+			func() tea.Msg { return panels.GitFilterActiveMsg{Active: false} },
+		}
+		_, branchCmd := ft.activateBranchDiffFilter()
+		if branchCmd != nil {
+			cmds = append(cmds, branchCmd)
+		}
+		return ft, tea.Batch(cmds...)
+	}
+	// Cycle: all → gitFilter (reuse existing logic)
+	return ft.toggleGitFilter()
 }
 
 // exitBranchDiffWithCmd exits branch-files mode and emits the appropriate
@@ -840,9 +871,7 @@ func (ft *FileTree) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 	case ".":
 		ft.toggleHidden()
 	case "g":
-		return ft.toggleGitFilter()
-	case "b":
-		return ft.toggleBranchDiffFilter()
+		return ft.cycleFileFilter()
 	case "G":
 		ft.goToBottom()
 	case "d":

--- a/internal/panels/gitdiff/gitdiff.go
+++ b/internal/panels/gitdiff/gitdiff.go
@@ -44,6 +44,11 @@ type GitDiff struct {
 	theme *theme.Theme
 	// Request state
 	path string // file path being diffed
+	// Ref comparison state (for branch/tag diff mode)
+	compareCommitA string // base ref (e.g., "main")
+	compareCommitB string // head ref (e.g., "HEAD")
+	compareMode    bool   // when true, use ref comparison instead of working tree
+	compareThree   bool   // use three-dot notation
 	// Diff data
 	diffs []git.FileDiff // all file diffs returned by git
 	// Pre-rendered content (rebuilt on data/mode/size change)
@@ -103,10 +108,42 @@ func (d *GitDiff) Init(ctx context.Context) tea.Cmd {
 func (d *GitDiff) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case panels.ShowDiffMsg:
+		if msg.CommitA != "" && msg.CommitB != "" {
+			d.compareMode = true
+			d.compareCommitA = msg.CommitA
+			d.compareCommitB = msg.CommitB
+			d.compareThree = msg.ThreeDot
+			return d, d.startRefDiffLoad(msg.Path, msg.CommitA, msg.CommitB, msg.ThreeDot)
+		}
+		d.compareMode = false
 		return d, d.startDiffLoad(msg.Path, msg.Staged)
 	case panels.FileSelectedMsg:
-		// When a file is selected (e.g., from filetree), show its unstaged diff.
+		if d.compareMode {
+			// In compare mode, ShowDiffMsg handles diff loading with proper
+			// ref comparison context. Ignore FileSelectedMsg to avoid
+			// overwriting with a working tree diff.
+			return d, nil
+		}
 		return d, d.startDiffLoad(msg.Path, false)
+	case panels.BranchDiffFilterActiveMsg:
+		if !msg.Active {
+			d.compareMode = false
+			d.compareCommitA = ""
+			d.compareCommitB = ""
+			d.compareThree = false
+		}
+		return d, nil
+	case panels.BranchDeselectedMsg:
+		d.compareMode = false
+		d.compareCommitA = ""
+		d.compareCommitB = ""
+		d.compareThree = false
+		return d, nil
+	case panels.GitFilterActiveMsg:
+		if msg.Active {
+			d.compareMode = false
+		}
+		return d, nil
 	case panels.AIReviewReadyMsg:
 		d.reviewFindings = d.filterFindingsForFile(msg.Findings)
 		d.rebuildLines()
@@ -159,6 +196,10 @@ func (d *GitDiff) handleRepoChanged(msg panels.RepoChangedMsg) (panels.Panel, te
 	d.loading = false
 	d.reviewFindings = nil
 	d.showReviewAnnotations = false
+	d.compareMode = false
+	d.compareCommitA = ""
+	d.compareCommitB = ""
+	d.compareThree = false
 	return d, nil
 }
 
@@ -175,6 +216,43 @@ func (d *GitDiff) startDiffLoad(path string, staged bool) tea.Cmd {
 	d.fileStarts = nil
 	d.loading = true
 	return d.loadDiffCmd(path, staged)
+}
+
+// startRefDiffLoad loads a diff between two refs (branch comparison mode).
+func (d *GitDiff) startRefDiffLoad(path, commitA, commitB string, threeDot bool) tea.Cmd {
+	d.path = path
+	d.staged = false
+	d.scrollY = 0
+	d.fileIdx = 0
+	d.err = nil
+	d.diffs = nil
+	d.lines = nil
+	d.hunkStarts = nil
+	d.fileStarts = nil
+	d.loading = true
+	d.diffGen++
+	gen := d.diffGen
+	gitClient := d.gitClient
+	ctx := d.ctx
+	return func() tea.Msg {
+		result := diffLoadedMsg{path: path, generation: gen}
+		if gitClient == nil {
+			result.err = fmt.Errorf("no git client configured")
+			return result
+		}
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		diffs, err := gitClient.Diff(ctx, git.DiffOpts{
+			CommitA:  commitA,
+			CommitB:  commitB,
+			ThreeDot: threeDot,
+			Path:     path,
+		})
+		result.diffs = diffs
+		result.err = err
+		return result
+	}
 }
 
 // handleKey processes keyboard input when the panel is focused.

--- a/internal/panels/messages.go
+++ b/internal/panels/messages.go
@@ -116,9 +116,13 @@ type CherryPickMsg struct {
 
 // ShowDiffMsg requests showing a diff for the specified file path.
 // Staged indicates whether to show the staged (index vs HEAD) diff.
+// When CommitA and CommitB are set, shows a ref comparison diff instead.
 type ShowDiffMsg struct {
-	Path   string
-	Staged bool
+	Path     string
+	CommitA  string // base ref for comparison (e.g., "main")
+	CommitB  string // head ref for comparison (e.g., "HEAD")
+	Staged   bool
+	ThreeDot bool // use three-dot (merge-base) comparison
 }
 
 // UndoMsg is sent when the user requests an undo operation (ctrl+z).
@@ -161,6 +165,14 @@ type GitChangedFilesMsg struct {
 // When active, the preview panel shows diff-only instead of file content.
 type GitFilterActiveMsg struct {
 	Active bool
+}
+
+// BranchDiffFilterActiveMsg notifies panels whether branch-diff filter mode
+// is active (the "b" toggle). When active, the filetree shows only files
+// that differ from the base branch.
+type BranchDiffFilterActiveMsg struct {
+	Active     bool
+	BaseBranch string // e.g., "main"
 }
 
 // PreviewScrollMsg requests the preview panel to scroll by Delta lines.


### PR DESCRIPTION
Adds branch diff mode to show origination diffs. Merges the git filter and branch diff toggles into a single cycling key \g\.

**Changes:**
- Add branch diff mode showing diff from branch origination point
- Merge git filter and branch diff into single cycling key (g)
- Clean integration with existing diff panel