### PR TITLE
feat: add inline editor mode to preview panel

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	MCP        MCPConfig        `toml:"mcp"`
 	GitHub     GitHubConfig     `toml:"github"`
 	Preview    PreviewConfig    `toml:"preview"`
+	Editor     EditorConfig     `toml:"editor"`
 	Logging    LoggingConfig    `toml:"logging"`
 	FileTree   FileTreeConfig   `toml:"file_tree"`
 	Bookmarks  BookmarksConfig  `toml:"bookmarks"`
@@ -71,6 +72,14 @@ type PreviewConfig struct {
 	LineNumbers        bool   `toml:"line_numbers"`
 	WordWrap           bool   `toml:"word_wrap"`
 	RenderMarkdown     bool   `toml:"render_markdown"`
+}
+
+// EditorConfig controls the inline file editor in the preview panel.
+type EditorConfig struct {
+	TabSize    int  `toml:"tab_size"`
+	InsertTabs bool `toml:"insert_tabs"` // true = hard tabs, false = spaces
+	AutoIndent bool `toml:"auto_indent"`
+	AutoSave   bool `toml:"auto_save"`
 }
 
 // GitConfig holds git integration settings.

--- a/internal/config/defaults.toml
+++ b/internal/config/defaults.toml
@@ -24,6 +24,12 @@ line_numbers = true
 word_wrap = false
 render_markdown = true
 
+[editor]
+tab_size = 4
+insert_tabs = false
+auto_indent = true
+auto_save = false
+
 [git]
 refresh_method = "fsnotify"
 refresh_fallback_interval = "2s"

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -33,6 +33,7 @@ const (
 	maxReviewCategories = 50        // AI review category count
 	maxCustomShortcuts  = 100       // custom shortcut definitions
 	maxBookmarkPaths    = 1000      // bookmark entries
+	maxEditorTabSize    = 16        // editor tab size
 	maxLogSizeMB        = 1000      // log file max size
 	maxLogBackups       = 100       // log file backup count
 )
@@ -69,6 +70,14 @@ func Validate(cfg *Config) error {
 	}
 	if cfg.Preview.MaxFileSize > maxMaxFileSize*1024*1024 {
 		errs = append(errs, fieldErr("preview.max_file_size", "must be <= %d bytes (%d MB), got %d", maxMaxFileSize*1024*1024, maxMaxFileSize, cfg.Preview.MaxFileSize))
+	}
+
+	// --- editor ---
+	if cfg.Editor.TabSize < 1 {
+		errs = append(errs, fieldErr("editor.tab_size", "must be >= 1, got %d", cfg.Editor.TabSize))
+	}
+	if cfg.Editor.TabSize > maxEditorTabSize {
+		errs = append(errs, fieldErr("editor.tab_size", "must be <= %d, got %d", maxEditorTabSize, cfg.Editor.TabSize))
 	}
 
 	// --- git ---

--- a/internal/layout/registry.go
+++ b/internal/layout/registry.go
@@ -126,7 +126,7 @@ func RegisterDefaults(r *Registry, cfg *config.Config, gc git.GitClient, th *the
 	})
 	// Preview panel — real implementation
 	r.Register("preview", func() panels.Panel {
-		p := preview.New(cfg.Preview, th)
+		p := preview.New(cfg.Preview, cfg.Editor, th)
 		if gc != nil {
 			p.SetGitClient(gc)
 		}

--- a/internal/panels/messages.go
+++ b/internal/panels/messages.go
@@ -780,3 +780,26 @@ type ItemOpenMsg struct{}
 // ItemCopyMsg requests the focused panel to copy the selected item's
 // identifier (hash, URL, path, name) to the clipboard.
 type ItemCopyMsg struct{}
+
+// ---------------------------------------------------------------------------
+// Inline editor messages
+// ---------------------------------------------------------------------------
+
+// FileModifiedMsg is broadcast after a file is written to disk by the
+// inline editor. Panels that display file content or git status should
+// refresh their state for the affected path.
+type FileModifiedMsg struct {
+	Path string
+}
+
+// EditModeEnteredMsg notifies other panels that the preview panel
+// entered inline edit mode for a file.
+type EditModeEnteredMsg struct {
+	Path string
+}
+
+// EditModeExitedMsg notifies other panels that the preview panel
+// exited inline edit mode.
+type EditModeExitedMsg struct {
+	Path string
+}

--- a/internal/panels/preview/blame_test.go
+++ b/internal/panels/preview/blame_test.go
@@ -133,7 +133,7 @@ func TestFormatBlameAnnotationShortHash(t *testing.T) {
 // --- Blame toggle tests ---
 
 func TestBlameToggleOn(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.Focus()
 	p.filePath = "test.go"
 	p.lines = []string{"line 1", "line 2"}
@@ -153,7 +153,7 @@ func TestBlameToggleOn(t *testing.T) {
 }
 
 func TestBlameToggleOff(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.Focus()
 	p.filePath = "test.go"
 	p.blameMode = true
@@ -169,7 +169,7 @@ func TestBlameToggleOff(t *testing.T) {
 }
 
 func TestBlameToggleIgnoredWithNoFile(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.Focus()
 	// No file loaded
 
@@ -179,7 +179,7 @@ func TestBlameToggleIgnoredWithNoFile(t *testing.T) {
 }
 
 func TestBlameToggleIgnoredWhenBlurred(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	// Not focused
 	p.filePath = "test.go"
 
@@ -191,7 +191,7 @@ func TestBlameToggleIgnoredWhenBlurred(t *testing.T) {
 // --- BlameLoadedMsg tests ---
 
 func TestBlameLoadedMsgSuccess(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.blameMode = true
 
 	blameData := []git.BlameLine{
@@ -205,7 +205,7 @@ func TestBlameLoadedMsgSuccess(t *testing.T) {
 }
 
 func TestBlameLoadedMsgError(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.blameMode = true
 
 	p.Update(panels.BlameLoadedMsg{Err: fmt.Errorf("not a tracked file")})
@@ -216,7 +216,7 @@ func TestBlameLoadedMsgError(t *testing.T) {
 // --- Blame rendering tests ---
 
 func TestBlameRendering(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 10)
 	p.filePath = "test.go"
 	p.blameMode = true
@@ -237,7 +237,7 @@ func TestBlameRendering(t *testing.T) {
 }
 
 func TestBlameRenderingEmptyBlameLines(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 10)
 	p.filePath = "test.go"
 	p.blameMode = true
@@ -250,7 +250,7 @@ func TestBlameRenderingEmptyBlameLines(t *testing.T) {
 }
 
 func TestBlameRenderingNarrowWidth(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(40, 5)
 	p.filePath = "test.go"
 	p.blameMode = true
@@ -266,7 +266,7 @@ func TestBlameRenderingNarrowWidth(t *testing.T) {
 // --- Blame reset on file change ---
 
 func TestBlameResetOnFileChange(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.blameMode = true
 	p.blameLines = []git.BlameLine{
 		{Hash: "abc", Author: "A", Date: time.Now(), LineNo: 1, Content: "x"},
@@ -280,14 +280,14 @@ func TestBlameResetOnFileChange(t *testing.T) {
 // --- Content line count tests ---
 
 func TestContentLineCountNormalMode(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.lines = []string{"a", "b", "c"}
 
 	assert.Equal(t, 3, p.contentLineCount())
 }
 
 func TestContentLineCountBlameMode(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.lines = []string{"a", "b", "c"}
 	p.blameMode = true
 	p.blameLines = []git.BlameLine{
@@ -299,7 +299,7 @@ func TestContentLineCountBlameMode(t *testing.T) {
 }
 
 func TestContentLineCountBlameModeEmptyLines(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.lines = []string{"a", "b"}
 	p.blameMode = true
 	p.blameLines = nil // blame mode but no data yet
@@ -310,7 +310,7 @@ func TestContentLineCountBlameModeEmptyLines(t *testing.T) {
 // --- Blame scrolling tests ---
 
 func TestBlameScrolling(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.Focus()
 	p.SetSize(80, 5) // viewport height = 4 (minus scroll indicator)
 	p.filePath = "test.go"
@@ -364,7 +364,7 @@ func TestBisectStatusMsgInactive(t *testing.T) {
 // --- KeyBindings includes blame ---
 
 func TestKeyBindingsIncludesBlame(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	bindings := p.KeyBindings()
 
 	found := false

--- a/internal/panels/preview/buffer.go
+++ b/internal/panels/preview/buffer.go
@@ -1,0 +1,330 @@
+package preview
+
+import (
+	"slices"
+	"time"
+)
+
+// nowNano returns the current time in nanoseconds.
+// Replaced in tests for deterministic undo coalescing.
+var nowNano = func() int64 { return time.Now().UnixNano() }
+
+const (
+	maxUndoDepth     = 100
+	coalesceWindowNs = 500_000_000 // 500ms in nanoseconds
+)
+
+// TextBuffer is a line-oriented editable text buffer with undo/redo support.
+// It stores raw text lines (no ANSI) for in-place editing within the preview panel.
+type TextBuffer struct {
+	lines        []string
+	dirty        bool
+	undoStack    []bufferSnapshot
+	redoStack    []bufferSnapshot
+	lastEditNano int64 // time.Now().UnixNano() of last edit
+}
+
+type bufferSnapshot struct {
+	lines      []string
+	cursorLine int
+	cursorCol  int
+}
+
+// NewTextBuffer creates a buffer from the given lines, deep-copying the input.
+// An empty or nil input produces a single empty line.
+func NewTextBuffer(lines []string) *TextBuffer {
+	if len(lines) == 0 {
+		lines = []string{""}
+	}
+	return &TextBuffer{lines: copyLines(lines)}
+}
+
+// Lines returns the current lines (read-only view).
+func (b *TextBuffer) Lines() []string { return b.lines }
+
+// LineCount returns the number of lines in the buffer.
+func (b *TextBuffer) LineCount() int { return len(b.lines) }
+
+// Line returns line n. Returns "" if n is out of range.
+func (b *TextBuffer) Line(n int) string {
+	if n < 0 || n >= len(b.lines) {
+		return ""
+	}
+	return b.lines[n]
+}
+
+// SetLines replaces all content, marks the buffer dirty, and clears undo/redo.
+func (b *TextBuffer) SetLines(lines []string) {
+	if len(lines) == 0 {
+		lines = []string{""}
+	}
+	b.lines = copyLines(lines)
+	b.dirty = true
+	b.undoStack = nil
+	b.redoStack = nil
+	b.lastEditNano = 0
+}
+
+// Dirty reports whether the buffer has unsaved changes.
+func (b *TextBuffer) Dirty() bool { return b.dirty }
+
+// MarkClean clears the dirty flag, typically called after a successful save.
+func (b *TextBuffer) MarkClean() { b.dirty = false }
+
+// InsertRune inserts a rune at (line, col). Out-of-bounds values are clamped.
+// Undo snapshots are coalesced for rapid consecutive inserts.
+func (b *TextBuffer) InsertRune(line, col int, r rune) {
+	line = b.clampLine(line)
+	col = b.clampCol(line, col)
+	b.saveSnapshot(line, col)
+	runes := []rune(b.lines[line])
+	runes = slices.Insert(runes, col, r)
+	b.lines[line] = string(runes)
+	b.dirty = true
+}
+
+// DeleteRune performs backspace at (line, col): deletes the character before
+// the cursor. If col==0 and line>0, the current line joins with the previous
+// one. Returns the new cursor position.
+func (b *TextBuffer) DeleteRune(line, col int) (newLine, newCol int) {
+	line = b.clampLine(line)
+	col = b.clampCol(line, col)
+
+	if col > 0 {
+		b.saveSnapshot(line, col)
+		runes := []rune(b.lines[line])
+		runes = slices.Delete(runes, col-1, col)
+		b.lines[line] = string(runes)
+		b.dirty = true
+		return line, col - 1
+	}
+
+	if line == 0 {
+		return 0, 0 // first line, col 0 — nothing to delete
+	}
+
+	// col==0, line>0: join with previous line (forces undo break).
+	b.saveSnapshotForce(line, col)
+	prevLen := len([]rune(b.lines[line-1]))
+	b.lines[line-1] += b.lines[line]
+	b.lines = slices.Delete(b.lines, line, line+1)
+	b.dirty = true
+	return line - 1, prevLen
+}
+
+// DeleteForward performs the delete-key at (line, col): removes the character
+// at the cursor position. If the cursor is at end-of-line, the next line is
+// joined onto the current one.
+func (b *TextBuffer) DeleteForward(line, col int) {
+	line = b.clampLine(line)
+	col = b.clampCol(line, col)
+
+	runes := []rune(b.lines[line])
+	if col < len(runes) {
+		b.saveSnapshot(line, col)
+		runes = slices.Delete(runes, col, col+1)
+		b.lines[line] = string(runes)
+		b.dirty = true
+		return
+	}
+
+	// At end of line — join with next if one exists.
+	if line >= len(b.lines)-1 {
+		return // last line EOL — no-op
+	}
+	b.saveSnapshotForce(line, col)
+	b.lines[line] += b.lines[line+1]
+	b.lines = slices.Delete(b.lines, line+1, line+2)
+	b.dirty = true
+}
+
+// SplitLine splits the line at col (Enter key). If autoIndent is true the new
+// line inherits the leading whitespace of the current line.
+func (b *TextBuffer) SplitLine(line, col int, autoIndent bool) {
+	line = b.clampLine(line)
+	col = b.clampCol(line, col)
+
+	b.saveSnapshotForce(line, col)
+
+	runes := []rune(b.lines[line])
+	before := string(runes[:col])
+	after := string(runes[col:])
+
+	if autoIndent {
+		after = leadingWhitespace(b.lines[line]) + after
+	}
+
+	b.lines[line] = before
+	b.lines = slices.Insert(b.lines, line+1, after)
+	b.dirty = true
+}
+
+// InsertTab inserts spaces to the next tab stop at (line, col) and returns
+// the new column. tabSize is clamped to >= 1.
+func (b *TextBuffer) InsertTab(line, col int, tabSize int) int {
+	if tabSize < 1 {
+		tabSize = 4
+	}
+	line = b.clampLine(line)
+	col = b.clampCol(line, col)
+
+	spaces := tabSize - (col % tabSize)
+	b.saveSnapshot(line, col)
+
+	runes := []rune(b.lines[line])
+	pad := make([]rune, spaces)
+	for i := range pad {
+		pad[i] = ' '
+	}
+	runes = slices.Insert(runes, col, pad...)
+	b.lines[line] = string(runes)
+	b.dirty = true
+	return col + spaces
+}
+
+// Dedent removes up to tabSize leading spaces from the line.
+func (b *TextBuffer) Dedent(line int, tabSize int) {
+	if tabSize < 1 {
+		tabSize = 4
+	}
+	line = b.clampLine(line)
+
+	runes := []rune(b.lines[line])
+	remove := 0
+	for remove < tabSize && remove < len(runes) && runes[remove] == ' ' {
+		remove++
+	}
+	if remove == 0 {
+		return
+	}
+	b.saveSnapshot(line, 0)
+	b.lines[line] = string(runes[remove:])
+	b.dirty = true
+}
+
+// DuplicateLine duplicates the line at the given index, inserting the copy
+// below it. Always forces an undo break.
+func (b *TextBuffer) DuplicateLine(line int) {
+	line = b.clampLine(line)
+	b.saveSnapshotForce(line, 0)
+	b.lines = slices.Insert(b.lines, line+1, b.lines[line])
+	b.dirty = true
+}
+
+// Undo restores the previous buffer snapshot. Returns the restored cursor
+// position and true, or the original position and false if nothing to undo.
+func (b *TextBuffer) Undo(cursorLine, cursorCol int) (newLine, newCol int, ok bool) {
+	if len(b.undoStack) == 0 {
+		return cursorLine, cursorCol, false
+	}
+	b.redoStack = append(b.redoStack, bufferSnapshot{
+		lines:      copyLines(b.lines),
+		cursorLine: cursorLine,
+		cursorCol:  cursorCol,
+	})
+	snap := b.undoStack[len(b.undoStack)-1]
+	b.undoStack = b.undoStack[:len(b.undoStack)-1]
+	b.lines = snap.lines
+	b.dirty = true
+	b.lastEditNano = 0
+	return snap.cursorLine, snap.cursorCol, true
+}
+
+// Redo restores the next buffer snapshot. Returns the restored cursor position
+// and true, or the original position and false if nothing to redo.
+func (b *TextBuffer) Redo(cursorLine, cursorCol int) (newLine, newCol int, ok bool) {
+	if len(b.redoStack) == 0 {
+		return cursorLine, cursorCol, false
+	}
+	b.undoStack = append(b.undoStack, bufferSnapshot{
+		lines:      copyLines(b.lines),
+		cursorLine: cursorLine,
+		cursorCol:  cursorCol,
+	})
+	snap := b.redoStack[len(b.redoStack)-1]
+	b.redoStack = b.redoStack[:len(b.redoStack)-1]
+	b.lines = snap.lines
+	b.dirty = true
+	b.lastEditNano = 0
+	return snap.cursorLine, snap.cursorCol, true
+}
+
+// ---------------------------------------------------------------------------
+// internal helpers
+// ---------------------------------------------------------------------------
+
+// saveSnapshot pushes the current buffer state onto the undo stack and clears
+// the redo stack. If the last snapshot was saved within 500ms the push is
+// coalesced (skipped) so that rapid typing forms a single undo unit.
+func (b *TextBuffer) saveSnapshot(cursorLine, cursorCol int) {
+	now := nowNano()
+	if len(b.undoStack) > 0 && now-b.lastEditNano < coalesceWindowNs {
+		b.lastEditNano = now
+		b.redoStack = nil
+		return
+	}
+	b.pushSnapshot(cursorLine, cursorCol)
+	b.lastEditNano = now
+}
+
+// saveSnapshotForce always pushes a new snapshot regardless of the coalescing
+// window. Used for structural changes (SplitLine, line joins, DuplicateLine).
+func (b *TextBuffer) saveSnapshotForce(cursorLine, cursorCol int) {
+	b.lastEditNano = 0 // break coalescing
+	b.pushSnapshot(cursorLine, cursorCol)
+	b.lastEditNano = nowNano()
+}
+
+// pushSnapshot performs the actual push to the undo stack.
+func (b *TextBuffer) pushSnapshot(cursorLine, cursorCol int) {
+	b.undoStack = append(b.undoStack, bufferSnapshot{
+		lines:      copyLines(b.lines),
+		cursorLine: cursorLine,
+		cursorCol:  cursorCol,
+	})
+	if len(b.undoStack) > maxUndoDepth {
+		copy(b.undoStack, b.undoStack[1:])
+		b.undoStack = b.undoStack[:len(b.undoStack)-1]
+	}
+	b.redoStack = nil
+}
+
+// copyLines deep-copies a string slice.
+func copyLines(lines []string) []string {
+	c := make([]string, len(lines))
+	copy(c, lines)
+	return c
+}
+
+// clampLine constrains line to [0, len(b.lines)-1].
+func (b *TextBuffer) clampLine(line int) int {
+	if line < 0 {
+		return 0
+	}
+	if line >= len(b.lines) {
+		return len(b.lines) - 1
+	}
+	return line
+}
+
+// clampCol constrains col to [0, runeCount] for the given (already-clamped) line.
+func (b *TextBuffer) clampCol(line, col int) int {
+	if col < 0 {
+		return 0
+	}
+	n := len([]rune(b.lines[line]))
+	if col > n {
+		return n
+	}
+	return col
+}
+
+// leadingWhitespace returns the leading spaces and tabs from s.
+func leadingWhitespace(s string) string {
+	for i, r := range s {
+		if r != ' ' && r != '\t' {
+			return s[:i]
+		}
+	}
+	return s // entire string is whitespace
+}

--- a/internal/panels/preview/buffer_test.go
+++ b/internal/panels/preview/buffer_test.go
@@ -1,0 +1,616 @@
+package preview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withFakeTime overrides nowNano with a controllable clock for the duration
+// of a test. The returned function advances the fake clock.
+func withFakeTime(t *testing.T) func(int64) {
+	t.Helper()
+	var fakeNano int64
+	orig := nowNano
+	nowNano = func() int64 { return fakeNano }
+	t.Cleanup(func() { nowNano = orig })
+	return func(ns int64) { fakeNano = ns }
+}
+
+// ---------------------------------------------------------------------------
+// NewTextBuffer
+// ---------------------------------------------------------------------------
+
+func TestNewTextBuffer_Nil(t *testing.T) {
+	buf := NewTextBuffer(nil)
+	assert.Equal(t, 1, buf.LineCount())
+	assert.Equal(t, "", buf.Line(0))
+	assert.False(t, buf.Dirty())
+}
+
+func TestNewTextBuffer_Empty(t *testing.T) {
+	buf := NewTextBuffer([]string{})
+	assert.Equal(t, 1, buf.LineCount())
+	assert.Equal(t, "", buf.Line(0))
+}
+
+func TestNewTextBuffer_SingleLine(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	assert.Equal(t, 1, buf.LineCount())
+	assert.Equal(t, "hello", buf.Line(0))
+}
+
+func TestNewTextBuffer_MultiLine(t *testing.T) {
+	buf := NewTextBuffer([]string{"a", "b", "c"})
+	assert.Equal(t, 3, buf.LineCount())
+	assert.Equal(t, []string{"a", "b", "c"}, buf.Lines())
+}
+
+func TestNewTextBuffer_DeepCopy(t *testing.T) {
+	orig := []string{"hello", "world"}
+	buf := NewTextBuffer(orig)
+	orig[0] = "mutated"
+	assert.Equal(t, "hello", buf.Line(0), "constructor must deep-copy input")
+}
+
+// ---------------------------------------------------------------------------
+// Line bounds
+// ---------------------------------------------------------------------------
+
+func TestLine_OutOfRange(t *testing.T) {
+	buf := NewTextBuffer([]string{"only"})
+	assert.Equal(t, "", buf.Line(-1))
+	assert.Equal(t, "", buf.Line(1))
+	assert.Equal(t, "", buf.Line(999))
+}
+
+// ---------------------------------------------------------------------------
+// InsertRune
+// ---------------------------------------------------------------------------
+
+func TestInsertRune_Start(t *testing.T) {
+	buf := NewTextBuffer([]string{"ello"})
+	buf.InsertRune(0, 0, 'h')
+	assert.Equal(t, "hello", buf.Line(0))
+}
+
+func TestInsertRune_Middle(t *testing.T) {
+	buf := NewTextBuffer([]string{"hllo"})
+	buf.InsertRune(0, 1, 'e')
+	assert.Equal(t, "hello", buf.Line(0))
+}
+
+func TestInsertRune_End(t *testing.T) {
+	buf := NewTextBuffer([]string{"hell"})
+	buf.InsertRune(0, 4, 'o')
+	assert.Equal(t, "hello", buf.Line(0))
+}
+
+func TestInsertRune_Emoji(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.InsertRune(0, 5, '🌍')
+	assert.Equal(t, "hello🌍", buf.Line(0))
+}
+
+func TestInsertRune_CJK(t *testing.T) {
+	buf := NewTextBuffer([]string{"你好"})
+	buf.InsertRune(0, 1, '世')
+	assert.Equal(t, "你世好", buf.Line(0))
+}
+
+func TestInsertRune_ClampsOutOfBounds(t *testing.T) {
+	buf := NewTextBuffer([]string{"ab"})
+	buf.InsertRune(0, 99, 'c') // col clamped to 2
+	assert.Equal(t, "abc", buf.Line(0))
+
+	buf.InsertRune(99, 0, 'x') // line clamped to 0
+	assert.Equal(t, "xabc", buf.Line(0))
+}
+
+// ---------------------------------------------------------------------------
+// DeleteRune (backspace)
+// ---------------------------------------------------------------------------
+
+func TestDeleteRune_Middle(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	nl, nc := buf.DeleteRune(0, 3) // delete 'l' at index 2
+	assert.Equal(t, 0, nl)
+	assert.Equal(t, 2, nc)
+	assert.Equal(t, "helo", buf.Line(0))
+}
+
+func TestDeleteRune_JoinLines(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello", "world"})
+	nl, nc := buf.DeleteRune(1, 0) // backspace at start of line 1
+	assert.Equal(t, 0, nl)
+	assert.Equal(t, 5, nc)
+	assert.Equal(t, 1, buf.LineCount())
+	assert.Equal(t, "helloworld", buf.Line(0))
+}
+
+func TestDeleteRune_FirstLineCol0_Noop(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	nl, nc := buf.DeleteRune(0, 0)
+	assert.Equal(t, 0, nl)
+	assert.Equal(t, 0, nc)
+	assert.Equal(t, "hello", buf.Line(0))
+	assert.False(t, buf.Dirty(), "no-op should not set dirty")
+}
+
+func TestDeleteRune_SingleCharLine(t *testing.T) {
+	buf := NewTextBuffer([]string{"x"})
+	nl, nc := buf.DeleteRune(0, 1)
+	assert.Equal(t, 0, nl)
+	assert.Equal(t, 0, nc)
+	assert.Equal(t, "", buf.Line(0))
+}
+
+// ---------------------------------------------------------------------------
+// DeleteForward (delete key)
+// ---------------------------------------------------------------------------
+
+func TestDeleteForward_Middle(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.DeleteForward(0, 2) // delete 'l' at index 2
+	assert.Equal(t, "helo", buf.Line(0))
+}
+
+func TestDeleteForward_JoinLines(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello", "world"})
+	buf.DeleteForward(0, 5) // at EOL — join
+	assert.Equal(t, 1, buf.LineCount())
+	assert.Equal(t, "helloworld", buf.Line(0))
+}
+
+func TestDeleteForward_LastLineEOL_Noop(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.DeleteForward(0, 5)
+	assert.Equal(t, "hello", buf.Line(0))
+	assert.False(t, buf.Dirty(), "no-op should not set dirty")
+}
+
+func TestDeleteForward_EmptyLine(t *testing.T) {
+	buf := NewTextBuffer([]string{"", "world"})
+	buf.DeleteForward(0, 0) // empty line, join with next
+	assert.Equal(t, 1, buf.LineCount())
+	assert.Equal(t, "world", buf.Line(0))
+}
+
+// ---------------------------------------------------------------------------
+// SplitLine
+// ---------------------------------------------------------------------------
+
+func TestSplitLine_Middle(t *testing.T) {
+	buf := NewTextBuffer([]string{"helloworld"})
+	buf.SplitLine(0, 5, false)
+	assert.Equal(t, 2, buf.LineCount())
+	assert.Equal(t, "hello", buf.Line(0))
+	assert.Equal(t, "world", buf.Line(1))
+}
+
+func TestSplitLine_Start(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.SplitLine(0, 0, false)
+	assert.Equal(t, 2, buf.LineCount())
+	assert.Equal(t, "", buf.Line(0))
+	assert.Equal(t, "hello", buf.Line(1))
+}
+
+func TestSplitLine_End(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.SplitLine(0, 5, false)
+	assert.Equal(t, 2, buf.LineCount())
+	assert.Equal(t, "hello", buf.Line(0))
+	assert.Equal(t, "", buf.Line(1))
+}
+
+func TestSplitLine_AutoIndent(t *testing.T) {
+	buf := NewTextBuffer([]string{"    hello"})
+	buf.SplitLine(0, 9, true) // split after all content
+	assert.Equal(t, "    hello", buf.Line(0))
+	assert.Equal(t, "    ", buf.Line(1))
+}
+
+func TestSplitLine_AutoIndentMiddle(t *testing.T) {
+	buf := NewTextBuffer([]string{"  helloworld"})
+	buf.SplitLine(0, 7, true) // "  hello" | "world"
+	assert.Equal(t, "  hello", buf.Line(0))
+	assert.Equal(t, "  world", buf.Line(1))
+}
+
+func TestSplitLine_AutoIndentTabsAndSpaces(t *testing.T) {
+	buf := NewTextBuffer([]string{"\t  code"})
+	buf.SplitLine(0, 5, true) // "\t  co" | "de"
+	assert.Equal(t, "\t  co", buf.Line(0))
+	assert.Equal(t, "\t  de", buf.Line(1))
+}
+
+// ---------------------------------------------------------------------------
+// InsertTab
+// ---------------------------------------------------------------------------
+
+func TestInsertTab_AtCol0(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	nc := buf.InsertTab(0, 0, 4)
+	assert.Equal(t, 4, nc)
+	assert.Equal(t, "    hello", buf.Line(0))
+}
+
+func TestInsertTab_Alignment(t *testing.T) {
+	buf := NewTextBuffer([]string{"  hello"})
+	nc := buf.InsertTab(0, 2, 4) // 4 - (2%4) = 2 spaces
+	assert.Equal(t, 4, nc)
+	assert.Equal(t, "    hello", buf.Line(0))
+}
+
+func TestInsertTab_AlreadyAligned(t *testing.T) {
+	buf := NewTextBuffer([]string{"    hello"})
+	nc := buf.InsertTab(0, 4, 4) // 4 - (4%4) = 4 spaces (full tab)
+	assert.Equal(t, 8, nc)
+	assert.Equal(t, "        hello", buf.Line(0))
+}
+
+func TestInsertTab_TabSize2(t *testing.T) {
+	buf := NewTextBuffer([]string{"x"})
+	nc := buf.InsertTab(0, 1, 2) // 2 - (1%2) = 1 space
+	assert.Equal(t, 2, nc)
+	assert.Equal(t, "x ", buf.Line(0))
+}
+
+// ---------------------------------------------------------------------------
+// Dedent
+// ---------------------------------------------------------------------------
+
+func TestDedent_FullTabWidth(t *testing.T) {
+	buf := NewTextBuffer([]string{"    hello"})
+	buf.Dedent(0, 4)
+	assert.Equal(t, "hello", buf.Line(0))
+}
+
+func TestDedent_Partial(t *testing.T) {
+	buf := NewTextBuffer([]string{"  hello"})
+	buf.Dedent(0, 4) // only 2 spaces available
+	assert.Equal(t, "hello", buf.Line(0))
+}
+
+func TestDedent_NoWhitespace(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.Dedent(0, 4)
+	assert.Equal(t, "hello", buf.Line(0))
+	assert.False(t, buf.Dirty(), "no-op dedent should not set dirty")
+}
+
+func TestDedent_TabsNotRemoved(t *testing.T) {
+	buf := NewTextBuffer([]string{"\thello"})
+	buf.Dedent(0, 4) // tab is not a space — nothing removed
+	assert.Equal(t, "\thello", buf.Line(0))
+	assert.False(t, buf.Dirty())
+}
+
+// ---------------------------------------------------------------------------
+// DuplicateLine
+// ---------------------------------------------------------------------------
+
+func TestDuplicateLine(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello", "world"})
+	buf.DuplicateLine(0)
+	assert.Equal(t, 3, buf.LineCount())
+	assert.Equal(t, "hello", buf.Line(0))
+	assert.Equal(t, "hello", buf.Line(1))
+	assert.Equal(t, "world", buf.Line(2))
+}
+
+func TestDuplicateLine_LastLine(t *testing.T) {
+	buf := NewTextBuffer([]string{"only"})
+	buf.DuplicateLine(0)
+	assert.Equal(t, 2, buf.LineCount())
+	assert.Equal(t, "only", buf.Line(0))
+	assert.Equal(t, "only", buf.Line(1))
+}
+
+// ---------------------------------------------------------------------------
+// Undo / Redo
+// ---------------------------------------------------------------------------
+
+func TestUndo_RestoresState(t *testing.T) {
+	setTime := withFakeTime(t)
+	setTime(1_000_000_000)
+
+	buf := NewTextBuffer([]string{"hello"})
+	buf.InsertRune(0, 5, '!')
+	assert.Equal(t, "hello!", buf.Line(0))
+
+	nl, nc, ok := buf.Undo(0, 6)
+	require.True(t, ok)
+	assert.Equal(t, "hello", buf.Line(0))
+	assert.Equal(t, 0, nl)
+	assert.Equal(t, 5, nc)
+}
+
+func TestUndo_EmptyStack(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	nl, nc, ok := buf.Undo(0, 0)
+	assert.False(t, ok)
+	assert.Equal(t, 0, nl)
+	assert.Equal(t, 0, nc)
+}
+
+func TestRedo_RestoresState(t *testing.T) {
+	setTime := withFakeTime(t)
+	setTime(1_000_000_000)
+
+	buf := NewTextBuffer([]string{"hello"})
+	buf.InsertRune(0, 5, '!')
+	buf.Undo(0, 6)
+	assert.Equal(t, "hello", buf.Line(0))
+
+	_, _, ok := buf.Redo(0, 5)
+	require.True(t, ok)
+	assert.Equal(t, "hello!", buf.Line(0))
+}
+
+func TestRedo_EmptyStack(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	_, _, ok := buf.Redo(0, 0)
+	assert.False(t, ok)
+}
+
+func TestRedo_ClearedByNewEdit(t *testing.T) {
+	setTime := withFakeTime(t)
+
+	buf := NewTextBuffer([]string{"hello"})
+	setTime(1_000_000_000)
+	buf.InsertRune(0, 5, '!')
+	buf.Undo(0, 6)
+
+	// New edit should clear redo stack.
+	setTime(2_000_000_000)
+	buf.InsertRune(0, 5, '?')
+	_, _, ok := buf.Redo(0, 6)
+	assert.False(t, ok, "redo should be empty after new edit")
+}
+
+func TestUndoRedo_MultipleSteps(t *testing.T) {
+	setTime := withFakeTime(t)
+
+	buf := NewTextBuffer([]string{""})
+	setTime(1_000_000_000)
+	buf.InsertRune(0, 0, 'a')
+	setTime(2_000_000_000) // beyond 500ms — separate undo unit
+	buf.InsertRune(0, 1, 'b')
+	assert.Equal(t, "ab", buf.Line(0))
+
+	// Undo 'b'
+	_, _, ok := buf.Undo(0, 2)
+	require.True(t, ok)
+	assert.Equal(t, "a", buf.Line(0))
+
+	// Undo 'a'
+	_, _, ok = buf.Undo(0, 1)
+	require.True(t, ok)
+	assert.Equal(t, "", buf.Line(0))
+
+	// No more undo
+	_, _, ok = buf.Undo(0, 0)
+	assert.False(t, ok)
+}
+
+// ---------------------------------------------------------------------------
+// Undo coalescing
+// ---------------------------------------------------------------------------
+
+func TestUndoCoalescing_RapidInsertsAreOneUnit(t *testing.T) {
+	setTime := withFakeTime(t)
+
+	buf := NewTextBuffer([]string{""})
+	setTime(1_000_000_000)
+	buf.InsertRune(0, 0, 'a')
+	setTime(1_100_000_000) // +100ms
+	buf.InsertRune(0, 1, 'b')
+	setTime(1_200_000_000) // +100ms
+	buf.InsertRune(0, 2, 'c')
+
+	assert.Equal(t, "abc", buf.Line(0))
+
+	// Single undo reverts all three
+	_, _, ok := buf.Undo(0, 3)
+	require.True(t, ok)
+	assert.Equal(t, "", buf.Line(0))
+
+	// Nothing more to undo
+	_, _, ok = buf.Undo(0, 0)
+	assert.False(t, ok)
+}
+
+func TestUndoCoalescing_PauseBreaksCoalescing(t *testing.T) {
+	setTime := withFakeTime(t)
+
+	buf := NewTextBuffer([]string{""})
+	setTime(1_000_000_000)
+	buf.InsertRune(0, 0, 'a')
+	setTime(1_100_000_000) // +100ms — coalesced
+	buf.InsertRune(0, 1, 'b')
+
+	setTime(2_000_000_000) // +900ms — beyond 500ms window
+	buf.InsertRune(0, 2, 'c')
+
+	assert.Equal(t, "abc", buf.Line(0))
+
+	// Undo 'c' (separate unit)
+	_, _, ok := buf.Undo(0, 3)
+	require.True(t, ok)
+	assert.Equal(t, "ab", buf.Line(0))
+
+	// Undo 'a'+'b' (coalesced unit)
+	_, _, ok = buf.Undo(0, 2)
+	require.True(t, ok)
+	assert.Equal(t, "", buf.Line(0))
+}
+
+func TestUndoCoalescing_SplitLineBreaks(t *testing.T) {
+	setTime := withFakeTime(t)
+
+	buf := NewTextBuffer([]string{"ab"})
+	setTime(1_000_000_000)
+	buf.InsertRune(0, 2, 'c')
+	setTime(1_100_000_000) // +100ms — would coalesce for InsertRune
+	buf.SplitLine(0, 2, false)
+
+	// SplitLine forces undo break — should be separate from 'c' insert
+	assert.Equal(t, 2, buf.LineCount())
+	assert.Equal(t, "ab", buf.Line(0))
+	assert.Equal(t, "c", buf.Line(1))
+
+	// Undo SplitLine
+	_, _, ok := buf.Undo(0, 0)
+	require.True(t, ok)
+	assert.Equal(t, 1, buf.LineCount())
+	assert.Equal(t, "abc", buf.Line(0))
+
+	// Undo InsertRune('c')
+	_, _, ok = buf.Undo(0, 0)
+	require.True(t, ok)
+	assert.Equal(t, "ab", buf.Line(0))
+}
+
+// ---------------------------------------------------------------------------
+// Dirty flag
+// ---------------------------------------------------------------------------
+
+func TestDirty_InitiallyClean(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	assert.False(t, buf.Dirty())
+}
+
+func TestDirty_SetByEdit(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.InsertRune(0, 0, 'x')
+	assert.True(t, buf.Dirty())
+}
+
+func TestDirty_ClearedByMarkClean(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.InsertRune(0, 0, 'x')
+	buf.MarkClean()
+	assert.False(t, buf.Dirty())
+}
+
+func TestDirty_SetBySetLines(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.SetLines([]string{"new"})
+	assert.True(t, buf.Dirty())
+}
+
+func TestDirty_SetByDeleteRune(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.DeleteRune(0, 3)
+	assert.True(t, buf.Dirty())
+}
+
+func TestDirty_SetByDeleteForward(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.DeleteForward(0, 2)
+	assert.True(t, buf.Dirty())
+}
+
+func TestDirty_SetBySplitLine(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.SplitLine(0, 3, false)
+	assert.True(t, buf.Dirty())
+}
+
+func TestDirty_SetByDuplicateLine(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.DuplicateLine(0)
+	assert.True(t, buf.Dirty())
+}
+
+// ---------------------------------------------------------------------------
+// SetLines
+// ---------------------------------------------------------------------------
+
+func TestSetLines_ReplacesContent(t *testing.T) {
+	buf := NewTextBuffer([]string{"old"})
+	buf.SetLines([]string{"new", "content"})
+	assert.Equal(t, []string{"new", "content"}, buf.Lines())
+}
+
+func TestSetLines_ClearsUndo(t *testing.T) {
+	setTime := withFakeTime(t)
+	setTime(1_000_000_000)
+
+	buf := NewTextBuffer([]string{"hello"})
+	buf.InsertRune(0, 5, '!')
+	buf.SetLines([]string{"replaced"})
+
+	_, _, ok := buf.Undo(0, 0)
+	assert.False(t, ok, "undo should be empty after SetLines")
+}
+
+func TestSetLines_EmptyProducesSingleLine(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.SetLines(nil)
+	assert.Equal(t, 1, buf.LineCount())
+	assert.Equal(t, "", buf.Line(0))
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases: empty buffer
+// ---------------------------------------------------------------------------
+
+func TestEmptyBuffer_InsertAndDelete(t *testing.T) {
+	buf := NewTextBuffer(nil)
+	assert.Equal(t, 1, buf.LineCount())
+	assert.Equal(t, "", buf.Line(0))
+
+	buf.InsertRune(0, 0, 'x')
+	assert.Equal(t, "x", buf.Line(0))
+
+	nl, nc := buf.DeleteRune(0, 1)
+	assert.Equal(t, 0, nl)
+	assert.Equal(t, 0, nc)
+	assert.Equal(t, "", buf.Line(0))
+}
+
+func TestEmptyBuffer_SplitLine(t *testing.T) {
+	buf := NewTextBuffer(nil)
+	buf.SplitLine(0, 0, false)
+	assert.Equal(t, 2, buf.LineCount())
+	assert.Equal(t, "", buf.Line(0))
+	assert.Equal(t, "", buf.Line(1))
+}
+
+func TestEmptyBuffer_DuplicateLine(t *testing.T) {
+	buf := NewTextBuffer(nil)
+	buf.DuplicateLine(0)
+	assert.Equal(t, 2, buf.LineCount())
+	assert.Equal(t, "", buf.Line(0))
+	assert.Equal(t, "", buf.Line(1))
+}
+
+// ---------------------------------------------------------------------------
+// Max undo depth
+// ---------------------------------------------------------------------------
+
+func TestMaxUndoDepth(t *testing.T) {
+	setTime := withFakeTime(t)
+
+	buf := NewTextBuffer([]string{""})
+	// Push 105 snapshots (exceeding maxUndoDepth of 100).
+	for i := 0; i < 105; i++ {
+		setTime(int64(i+1) * 1_000_000_000) // each 1s apart — no coalescing
+		buf.InsertRune(0, i, rune('a'+(i%26)))
+	}
+
+	// Should only be able to undo 100 times.
+	undone := 0
+	for {
+		_, _, ok := buf.Undo(0, 0)
+		if !ok {
+			break
+		}
+		undone++
+	}
+	assert.Equal(t, maxUndoDepth, undone)
+}

--- a/internal/panels/preview/editor.go
+++ b/internal/panels/preview/editor.go
@@ -1,0 +1,447 @@
+// editor.go provides inline edit-mode logic for the preview panel.
+// It manages cursor movement, text input, undo/redo dispatch, and
+// the atomic save flow. Functions here are called from Preview.Update
+// when editMode is true.
+package preview
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/jongio/grut/internal/notify"
+	"github.com/jongio/grut/internal/panels"
+)
+
+// fileSavedMsg is sent after a successful file save from edit mode.
+// The Update handler reacts by emitting FileModifiedMsg, refreshing
+// the diff, and showing a toast.
+type fileSavedMsg struct {
+	path string
+}
+
+// ---------------------------------------------------------------------------
+// Mode transitions
+// ---------------------------------------------------------------------------
+
+// enterEditMode reads the file from disk, creates a TextBuffer, and places
+// the cursor at the current scroll position. Returns a cmd that emits
+// EditModeEnteredMsg. Returns nil if the file cannot be edited (binary,
+// oversized, GitHub content, or empty path).
+func enterEditMode(p *Preview) tea.Cmd {
+	if p.isBinary || p.isLarge || p.ghMode || p.filePath == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(p.filePath)
+	if err != nil {
+		return func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: "Cannot edit: " + err.Error(),
+				Level:   notify.Error,
+			}
+		}
+	}
+
+	p.editBuf = NewTextBuffer(strings.Split(string(data), "\n"))
+	p.editMode = true
+	p.cursorLine = p.scrollY
+	p.cursorCol = 0
+	p.clearSelection()
+
+	filePath := p.filePath
+	return func() tea.Msg {
+		return panels.EditModeEnteredMsg{Path: filePath}
+	}
+}
+
+// exitEditMode leaves edit mode, restoring the scroll position and reloading
+// the file with syntax highlighting. If discard is false and the buffer has
+// unsaved changes, a dirty-guard modal is shown instead.
+func exitEditMode(p *Preview, discard bool) tea.Cmd {
+	if !p.editMode {
+		return nil
+	}
+	if !discard && p.editBuf != nil && p.editBuf.Dirty() {
+		return dirtyGuardCmd(p, "exit")
+	}
+
+	p.editMode = false
+	p.scrollY = p.cursorLine
+	p.editBuf = nil
+
+	filePath := p.filePath
+	cmds := []tea.Cmd{
+		func() tea.Msg {
+			return panels.EditModeExitedMsg{Path: filePath}
+		},
+		p.loadFileCmd(filePath),
+	}
+	if p.gitClient != nil {
+		cmds = append(cmds, p.loadDiffCmd(filePath))
+	}
+	return tea.Batch(cmds...)
+}
+
+// ---------------------------------------------------------------------------
+// Dirty guard modal
+// ---------------------------------------------------------------------------
+
+// dirtyGuardCmd shows a modal asking the user how to handle unsaved changes.
+// The action string (e.g. "exit") is encoded in the action option IDs so that
+// handleModalResult can determine what to do after the user responds.
+func dirtyGuardCmd(p *Preview, action string) tea.Cmd {
+	baseName := filepath.Base(p.filePath)
+	return func() tea.Msg {
+		return notify.ShowModalMsg{
+			Title:   "Unsaved Changes",
+			Message: "Save changes to " + baseName + "?",
+			Kind:    notify.ModalActionPicker,
+			Actions: []notify.ActionOption{
+				{ID: "save_" + action, Label: "Save & " + action},
+				{ID: "discard_" + action, Label: "Discard"},
+				{ID: "cancel", Label: "Cancel"},
+			},
+		}
+	}
+}
+
+// handleModalResult processes the user's response to the dirty-guard modal.
+// The selected action's ID encodes both the intent (save/discard/cancel) and
+// the original action (e.g. "exit").
+func handleModalResult(p *Preview, msg notify.ModalResultMsg) (panels.Panel, tea.Cmd) {
+	if !msg.Accept {
+		// User cancelled (pressed Esc or chose cancel).
+		return p, nil
+	}
+	value := msg.Value
+	switch {
+	case value == "cancel":
+		return p, nil
+	case strings.HasPrefix(value, "save_"):
+		// Save, then perform the action.
+		return p, tea.Batch(saveFile(p), exitEditMode(p, true))
+	case strings.HasPrefix(value, "discard_"):
+		return p, exitEditMode(p, true)
+	default:
+		return p, nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Save
+// ---------------------------------------------------------------------------
+
+// saveFile performs an atomic write-to-temp-then-rename save of the edit
+// buffer contents. Returns a cmd that produces fileSavedMsg on success or
+// a toast on error.
+func saveFile(p *Preview) tea.Cmd {
+	buf := p.editBuf
+	filePath := p.filePath
+	if buf == nil || filePath == "" {
+		return nil
+	}
+	content := strings.Join(buf.Lines(), "\n")
+	return func() tea.Msg {
+		dir := filepath.Dir(filePath)
+		tmp, err := os.CreateTemp(dir, ".grut-tmp-*")
+		if err != nil {
+			return notify.ShowToastMsg{
+				Message: "Save failed: " + err.Error(),
+				Level:   notify.Error,
+			}
+		}
+		if _, err := tmp.WriteString(content); err != nil {
+			tmp.Close()
+			os.Remove(tmp.Name())
+			return notify.ShowToastMsg{
+				Message: "Save failed: " + err.Error(),
+				Level:   notify.Error,
+			}
+		}
+		tmp.Close()
+		if err := os.Rename(tmp.Name(), filePath); err != nil {
+			os.Remove(tmp.Name())
+			return notify.ShowToastMsg{
+				Message: "Save failed: " + err.Error(),
+				Level:   notify.Error,
+			}
+		}
+		return fileSavedMsg{path: filePath}
+	}
+}
+
+// handleFileSaved processes a successful save by marking the buffer clean,
+// emitting a toast, broadcasting FileModifiedMsg, and refreshing the diff.
+func handleFileSaved(p *Preview, msg fileSavedMsg) (panels.Panel, tea.Cmd) {
+	if p.editBuf != nil {
+		p.editBuf.MarkClean()
+	}
+	cmds := []tea.Cmd{
+		func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: "Saved " + filepath.Base(msg.path),
+				Level:   notify.Info,
+			}
+		},
+		func() tea.Msg {
+			return panels.FileModifiedMsg{Path: msg.path}
+		},
+	}
+	if p.gitClient != nil {
+		cmds = append(cmds, p.loadDiffCmd(msg.path))
+	}
+	return p, tea.Batch(cmds...)
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard handling
+// ---------------------------------------------------------------------------
+
+// handleEditKeyPress dispatches keyboard input while the preview panel is in
+// edit mode. It handles movement, editing operations, undo/redo, and mode
+// transitions.
+func handleEditKeyPress(p *Preview, msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
+	key := msg.String()
+	switch key {
+	// --- Mode transitions ---
+	case "escape", "esc":
+		if p.editBuf != nil && p.editBuf.Dirty() {
+			return p, dirtyGuardCmd(p, "exit")
+		}
+		return p, exitEditMode(p, true)
+
+	case "ctrl+s":
+		return p, saveFile(p)
+
+	// --- Undo / redo ---
+	case "ctrl+z":
+		if p.editBuf != nil {
+			newLine, newCol, ok := p.editBuf.Undo(p.cursorLine, p.cursorCol)
+			if ok {
+				p.cursorLine = newLine
+				p.cursorCol = newCol
+				ensureCursorVisible(p)
+			}
+		}
+
+	case "ctrl+y":
+		if p.editBuf != nil {
+			newLine, newCol, ok := p.editBuf.Redo(p.cursorLine, p.cursorCol)
+			if ok {
+				p.cursorLine = newLine
+				p.cursorCol = newCol
+				ensureCursorVisible(p)
+			}
+		}
+
+	// --- Line manipulation ---
+	case "ctrl+d":
+		if p.editBuf != nil {
+			p.editBuf.DuplicateLine(p.cursorLine)
+			p.cursorLine++
+			ensureCursorVisible(p)
+		}
+
+	case "enter":
+		if p.editBuf != nil {
+			p.editBuf.SplitLine(p.cursorLine, p.cursorCol, p.editCfg.AutoIndent)
+			p.cursorLine++
+			if p.editCfg.AutoIndent {
+				newLine := p.editBuf.Line(p.cursorLine)
+				p.cursorCol = countLeadingSpaces(newLine)
+			} else {
+				p.cursorCol = 0
+			}
+			ensureCursorVisible(p)
+		}
+
+	case "backspace":
+		if p.editBuf != nil {
+			newLine, newCol := p.editBuf.DeleteRune(p.cursorLine, p.cursorCol)
+			p.cursorLine = newLine
+			p.cursorCol = newCol
+			ensureCursorVisible(p)
+		}
+
+	case "delete":
+		if p.editBuf != nil {
+			p.editBuf.DeleteForward(p.cursorLine, p.cursorCol)
+		}
+
+	// --- Indentation ---
+	case "tab":
+		if p.editBuf != nil {
+			p.cursorCol = p.editBuf.InsertTab(p.cursorLine, p.cursorCol, p.editCfg.TabSize)
+			ensureCursorVisible(p)
+		}
+
+	case "shift+tab":
+		if p.editBuf != nil {
+			p.editBuf.Dedent(p.cursorLine, p.editCfg.TabSize)
+			line := p.editBuf.Line(p.cursorLine)
+			lineRunes := []rune(line)
+			if p.cursorCol > len(lineRunes) {
+				p.cursorCol = len(lineRunes)
+			}
+		}
+
+	// --- Cursor movement ---
+	case "left":
+		moveCursorLeft(p)
+
+	case "right":
+		moveCursorRight(p)
+
+	case "up":
+		moveCursorUp(p)
+
+	case "down":
+		moveCursorDown(p)
+
+	case "home", "ctrl+a":
+		p.cursorCol = 0
+
+	case "end", "ctrl+e":
+		if p.editBuf != nil {
+			line := p.editBuf.Line(p.cursorLine)
+			p.cursorCol = len([]rune(line))
+		}
+
+	case "ctrl+home":
+		p.cursorLine = 0
+		p.cursorCol = 0
+		ensureCursorVisible(p)
+
+	case "ctrl+end":
+		if p.editBuf != nil {
+			p.cursorLine = p.editBuf.LineCount() - 1
+			if p.cursorLine < 0 {
+				p.cursorLine = 0
+			}
+			line := p.editBuf.Line(p.cursorLine)
+			p.cursorCol = len([]rune(line))
+			ensureCursorVisible(p)
+		}
+
+	default:
+		// Character input — insert each rune from the text payload.
+		if msg.Text != "" {
+			for _, r := range msg.Text {
+				if p.editBuf != nil {
+					p.editBuf.InsertRune(p.cursorLine, p.cursorCol, r)
+					p.cursorCol++
+				}
+			}
+			ensureCursorVisible(p)
+		}
+	}
+	return p, nil
+}
+
+// ---------------------------------------------------------------------------
+// Cursor movement helpers
+// ---------------------------------------------------------------------------
+
+// moveCursorLeft moves the cursor one rune to the left, wrapping to the
+// end of the previous line if at column 0.
+func moveCursorLeft(p *Preview) {
+	if p.cursorCol > 0 {
+		p.cursorCol--
+	} else if p.cursorLine > 0 {
+		p.cursorLine--
+		line := p.editBuf.Line(p.cursorLine)
+		p.cursorCol = len([]rune(line))
+		ensureCursorVisible(p)
+	}
+}
+
+// moveCursorRight moves the cursor one rune to the right, wrapping to
+// the start of the next line if at the end.
+func moveCursorRight(p *Preview) {
+	if p.editBuf == nil {
+		return
+	}
+	line := p.editBuf.Line(p.cursorLine)
+	lineLen := len([]rune(line))
+	if p.cursorCol < lineLen {
+		p.cursorCol++
+	} else if p.cursorLine < p.editBuf.LineCount()-1 {
+		p.cursorLine++
+		p.cursorCol = 0
+		ensureCursorVisible(p)
+	}
+}
+
+// moveCursorUp moves the cursor one line up, clamping the column to
+// the length of the target line.
+func moveCursorUp(p *Preview) {
+	if p.cursorLine > 0 {
+		p.cursorLine--
+		clampCursorCol(p)
+		ensureCursorVisible(p)
+	}
+}
+
+// moveCursorDown moves the cursor one line down, clamping the column to
+// the length of the target line.
+func moveCursorDown(p *Preview) {
+	if p.editBuf == nil {
+		return
+	}
+	if p.cursorLine < p.editBuf.LineCount()-1 {
+		p.cursorLine++
+		clampCursorCol(p)
+		ensureCursorVisible(p)
+	}
+}
+
+// clampCursorCol ensures the cursor column does not exceed the length
+// of the current line.
+func clampCursorCol(p *Preview) {
+	if p.editBuf == nil {
+		return
+	}
+	line := p.editBuf.Line(p.cursorLine)
+	lineLen := len([]rune(line))
+	if p.cursorCol > lineLen {
+		p.cursorCol = lineLen
+	}
+}
+
+// ensureCursorVisible adjusts scrollY so that the cursor line is within
+// the visible viewport.
+func ensureCursorVisible(p *Preview) {
+	vh := p.viewportHeight()
+	if vh <= 0 {
+		vh = 20
+	}
+	if p.cursorLine < p.scrollY {
+		p.scrollY = p.cursorLine
+	}
+	if p.cursorLine >= p.scrollY+vh {
+		p.scrollY = p.cursorLine - vh + 1
+	}
+	if p.scrollY < 0 {
+		p.scrollY = 0
+	}
+}
+
+// countLeadingSpaces returns the number of leading whitespace columns in
+// a string, counting tabs as 4 spaces.
+func countLeadingSpaces(s string) int {
+	count := 0
+	for _, r := range s {
+		switch r {
+		case ' ':
+			count++
+		case '\t':
+			count += 4
+		default:
+			return count
+		}
+	}
+	return count
+}

--- a/internal/panels/preview/editor_render.go
+++ b/internal/panels/preview/editor_render.go
@@ -1,0 +1,251 @@
+package preview
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/formatters"
+	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/alecthomas/chroma/v2/styles"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// renderEditContent renders the buffer contents with syntax highlighting,
+// a cursor block, current-line highlight, line-number gutter, and a
+// status bar at the bottom.
+func renderEditContent(p *Preview, width, height int) string {
+	if p.editBuf == nil {
+		return ""
+	}
+	lines := p.editBuf.Lines()
+	totalLines := len(lines)
+
+	// Reserve 1 line for the status bar.
+	contentHeight := height - 1
+	if contentHeight < 1 {
+		contentHeight = 1
+	}
+
+	// Calculate visible range based on scroll position.
+	p.clampEditScroll(totalLines, contentHeight)
+	start := p.scrollY
+	end := start + contentHeight
+	if end > totalLines {
+		end = totalLines
+	}
+
+	// Line number gutter sizing: "NNN │ " where NNN is right-aligned.
+	numWidth := len(fmt.Sprintf("%d", totalLines))
+	if numWidth < 3 {
+		numWidth = 3
+	}
+	gutterWidth := numWidth + 3 // digits + " │ "
+	contentWidth := width - gutterWidth
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+
+	// Styles used for rendering.
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#666666"))
+	cursorStyle := lipgloss.NewStyle().Reverse(true)
+	currentLineNumStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#C9A027"))
+	currentLineBg := lipgloss.Color("#1A1A1A")
+
+	rendered := make([]string, 0, contentHeight)
+	for i := start; i < end; i++ {
+		lineNum := i + 1
+		rawLine := lines[i]
+
+		// Expand tabs for display.
+		tabSize := p.editCfg.TabSize
+		if tabSize < 1 {
+			tabSize = 4
+		}
+		displayLine := strings.ReplaceAll(rawLine, "\t", strings.Repeat(" ", tabSize))
+
+		// Apply syntax highlighting to this single line.
+		highlighted := highlightLine(displayLine, p.filePath, p.cfg.Theme)
+
+		isCursorLine := i == p.cursorLine
+
+		// Render cursor on the cursor line.
+		if isCursorLine {
+			highlighted = renderCursorOnLine(highlighted, displayLine, p.cursorCol, cursorStyle)
+		}
+
+		// Truncate content to fit the available width.
+		highlighted = ansi.Truncate(highlighted, contentWidth, "")
+
+		// Apply current line background highlight and build gutter.
+		numStr := fmt.Sprintf("%*d │ ", numWidth, lineNum)
+		if isCursorLine {
+			highlighted = lipgloss.NewStyle().Background(currentLineBg).Width(contentWidth).Render(highlighted)
+			highlighted = currentLineNumStyle.Render(numStr) + highlighted
+		} else {
+			highlighted = dimStyle.Render(numStr) + highlighted
+		}
+
+		// Hard truncate to panel width.
+		highlighted = ansi.Truncate(highlighted, width, "")
+		rendered = append(rendered, highlighted)
+	}
+
+	// Pad remaining lines with empty gutter space.
+	for len(rendered) < contentHeight {
+		numStr := strings.Repeat(" ", gutterWidth)
+		rendered = append(rendered, dimStyle.Render(numStr))
+	}
+
+	content := strings.Join(rendered, "\n")
+
+	// Status bar at the bottom.
+	statusBar := renderEditStatusBar(p, width, totalLines)
+	content += "\n" + statusBar
+
+	return content
+}
+
+// highlightLine applies Chroma syntax highlighting to a single line of
+// text, using the filename for lexer matching and the given theme name.
+func highlightLine(line, filename, theme string) string {
+	if line == "" {
+		return ""
+	}
+	lexer := lexers.Match(filename)
+	if lexer == nil {
+		return line
+	}
+	lexer = chroma.Coalesce(lexer)
+	style := styles.Get(theme)
+	if style == nil {
+		style = styles.Fallback
+	}
+	formatter := formatters.Get("terminal16m")
+	if formatter == nil {
+		return line
+	}
+	iterator, err := lexer.Tokenise(nil, line)
+	if err != nil {
+		return line
+	}
+	var buf strings.Builder
+	if err := formatter.Format(&buf, style, iterator); err != nil {
+		return line
+	}
+	// Remove any trailing newline added by Chroma.
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// renderCursorOnLine renders the cursor as an inverse-video block at the
+// cursor column position within an ANSI-highlighted line. It walks the
+// highlighted string counting visible runes (skipping escape sequences)
+// to locate the cursor character.
+func renderCursorOnLine(highlighted, rawLine string, cursorCol int, cursorStyle lipgloss.Style) string {
+	runes := []rune(rawLine)
+	if cursorCol >= len(runes) {
+		// Cursor at end of line — render a thin block cursor.
+		return highlighted + cursorStyle.Render("▏")
+	}
+
+	// Walk through the highlighted string, counting visible runes
+	// (skipping ANSI escape sequences) to split at the cursor position.
+	runeIdx := 0
+	i := 0
+	var before, cursor, after strings.Builder
+	for i < len(highlighted) {
+		if highlighted[i] == '\x1b' {
+			// ANSI escape — copy verbatim to the current segment.
+			seqEnd := i + 1
+			if seqEnd < len(highlighted) && highlighted[seqEnd] == '[' {
+				seqEnd++
+				for seqEnd < len(highlighted) && !isCSITerminator(highlighted[seqEnd]) {
+					seqEnd++
+				}
+				if seqEnd < len(highlighted) {
+					seqEnd++
+				}
+			}
+			seq := highlighted[i:seqEnd]
+			switch {
+			case runeIdx < cursorCol:
+				before.WriteString(seq)
+			case runeIdx == cursorCol:
+				cursor.WriteString(seq)
+			default:
+				after.WriteString(seq)
+			}
+			i = seqEnd
+			continue
+		}
+
+		// Normal rune.
+		_, size := utf8.DecodeRuneInString(highlighted[i:])
+		ch := highlighted[i : i+size]
+		switch {
+		case runeIdx < cursorCol:
+			before.WriteString(ch)
+		case runeIdx == cursorCol:
+			cursor.WriteString(ch)
+		default:
+			after.WriteString(ch)
+		}
+		runeIdx++
+		i += size
+	}
+
+	if cursor.Len() == 0 {
+		return highlighted + cursorStyle.Render("▏")
+	}
+
+	// Strip ANSI from cursor char to get a clean character, then
+	// apply the inverse-video cursor style.
+	cursorChar := ansi.Strip(cursor.String())
+	return before.String() + cursorStyle.Render(cursorChar) + after.String()
+}
+
+// renderEditStatusBar renders the bottom status bar showing cursor
+// position, tab settings, dirty indicator, and total line count.
+func renderEditStatusBar(p *Preview, width, totalLines int) string {
+	statusStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#888888")).
+		Background(lipgloss.Color("#1A1A1A"))
+
+	left := fmt.Sprintf(" Ln %d, Col %d", p.cursorLine+1, p.cursorCol+1)
+
+	tabSize := p.editCfg.TabSize
+	if tabSize < 1 {
+		tabSize = 4
+	}
+	right := fmt.Sprintf("Tab: %d │ %d lines ", tabSize, totalLines)
+	if p.editBuf != nil && p.editBuf.Dirty() {
+		right = "[+] " + right
+	}
+
+	// Pad middle with spaces so left and right are flush.
+	padding := width - lipgloss.Width(left) - lipgloss.Width(right)
+	if padding < 1 {
+		padding = 1
+	}
+	bar := left + strings.Repeat(" ", padding) + right
+
+	return statusStyle.Width(width).Render(bar)
+}
+
+// clampEditScroll ensures the scroll offset keeps the cursor visible and
+// doesn't exceed the buffer bounds.
+func (p *Preview) clampEditScroll(totalLines, contentHeight int) {
+	maxScroll := totalLines - contentHeight
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if p.scrollY > maxScroll {
+		p.scrollY = maxScroll
+	}
+	if p.scrollY < 0 {
+		p.scrollY = 0
+	}
+}

--- a/internal/panels/preview/editor_render_test.go
+++ b/internal/panels/preview/editor_render_test.go
@@ -1,0 +1,339 @@
+package preview
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/jongio/grut/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// highlightLine
+// ---------------------------------------------------------------------------
+
+func TestHighlightLine_GoCode(t *testing.T) {
+	line := `func main() { fmt.Println("hello") }`
+	result := highlightLine(line, "main.go", "dracula")
+	// Should contain ANSI escape sequences for syntax highlighting.
+	assert.NotEmpty(t, result)
+	// Stripped output should match the original text.
+	assert.Equal(t, line, ansi.Strip(result))
+}
+
+func TestHighlightLine_EmptyString(t *testing.T) {
+	result := highlightLine("", "main.go", "dracula")
+	assert.Equal(t, "", result)
+}
+
+func TestHighlightLine_UnknownFileType(t *testing.T) {
+	line := "some random text"
+	result := highlightLine(line, "file.unknown_ext_xyz", "dracula")
+	// No lexer matched — should return raw text.
+	assert.Equal(t, line, result)
+}
+
+func TestHighlightLine_NilThemeFallback(t *testing.T) {
+	line := "package main"
+	result := highlightLine(line, "main.go", "nonexistent_theme")
+	// Should still produce output (falls back to Fallback style).
+	stripped := ansi.Strip(result)
+	assert.Contains(t, stripped, "package")
+}
+
+// ---------------------------------------------------------------------------
+// renderCursorOnLine
+// ---------------------------------------------------------------------------
+
+func TestRenderCursorOnLine_AtStart(t *testing.T) {
+	raw := "hello"
+	highlighted := raw // no ANSI — plain text
+	cursorStyle := lipgloss.NewStyle().Reverse(true)
+
+	result := renderCursorOnLine(highlighted, raw, 0, cursorStyle)
+	stripped := ansi.Strip(result)
+	// The cursor character 'h' should still be present in stripped output.
+	assert.Contains(t, stripped, "h")
+	// The full stripped text should equal the original.
+	assert.Equal(t, raw, stripped)
+}
+
+func TestRenderCursorOnLine_AtMiddle(t *testing.T) {
+	raw := "hello"
+	highlighted := raw
+	cursorStyle := lipgloss.NewStyle().Reverse(true)
+
+	result := renderCursorOnLine(highlighted, raw, 2, cursorStyle)
+	stripped := ansi.Strip(result)
+	assert.Equal(t, raw, stripped)
+}
+
+func TestRenderCursorOnLine_AtEnd(t *testing.T) {
+	raw := "hello"
+	highlighted := raw
+	cursorStyle := lipgloss.NewStyle().Reverse(true)
+
+	result := renderCursorOnLine(highlighted, raw, 5, cursorStyle)
+	stripped := ansi.Strip(result)
+	// Cursor past end of line — should append a thin block cursor "▏".
+	assert.Contains(t, stripped, "▏")
+	assert.True(t, strings.HasPrefix(stripped, "hello"))
+}
+
+func TestRenderCursorOnLine_EmptyLine(t *testing.T) {
+	raw := ""
+	highlighted := ""
+	cursorStyle := lipgloss.NewStyle().Reverse(true)
+
+	result := renderCursorOnLine(highlighted, raw, 0, cursorStyle)
+	stripped := ansi.Strip(result)
+	assert.Contains(t, stripped, "▏")
+}
+
+func TestRenderCursorOnLine_WithANSI(t *testing.T) {
+	raw := "ab"
+	// Simulate ANSI: \x1b[31m a \x1b[0m b
+	highlighted := "\x1b[31ma\x1b[0mb"
+	cursorStyle := lipgloss.NewStyle().Reverse(true)
+
+	result := renderCursorOnLine(highlighted, raw, 0, cursorStyle)
+	stripped := ansi.Strip(result)
+	assert.Equal(t, "ab", stripped)
+}
+
+// ---------------------------------------------------------------------------
+// renderEditStatusBar
+// ---------------------------------------------------------------------------
+
+func TestRenderEditStatusBar_Basic(t *testing.T) {
+	p := &Preview{
+		cursorLine: 4,
+		cursorCol:  10,
+		editCfg:    config.EditorConfig{TabSize: 4},
+	}
+
+	bar := renderEditStatusBar(p, 80, 100)
+	stripped := ansi.Strip(bar)
+	assert.Contains(t, stripped, "Ln 5")
+	assert.Contains(t, stripped, "Col 11")
+	assert.Contains(t, stripped, "Tab: 4")
+	assert.Contains(t, stripped, "100 lines")
+}
+
+func TestRenderEditStatusBar_DirtyIndicator(t *testing.T) {
+	buf := NewTextBuffer([]string{"original"})
+	buf.InsertRune(0, 0, 'x')
+
+	p := &Preview{
+		cursorLine: 0,
+		cursorCol:  0,
+		editBuf:    buf,
+		editCfg:    config.EditorConfig{TabSize: 2},
+	}
+
+	bar := renderEditStatusBar(p, 80, 10)
+	stripped := ansi.Strip(bar)
+	assert.Contains(t, stripped, "[+]")
+}
+
+func TestRenderEditStatusBar_CleanBuffer(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+
+	p := &Preview{
+		cursorLine: 0,
+		cursorCol:  0,
+		editBuf:    buf,
+		editCfg:    config.EditorConfig{TabSize: 4},
+	}
+
+	bar := renderEditStatusBar(p, 80, 1)
+	stripped := ansi.Strip(bar)
+	assert.NotContains(t, stripped, "[+]")
+}
+
+func TestRenderEditStatusBar_ZeroTabSize(t *testing.T) {
+	p := &Preview{
+		editCfg: config.EditorConfig{TabSize: 0},
+	}
+	bar := renderEditStatusBar(p, 60, 5)
+	stripped := ansi.Strip(bar)
+	// Should default to 4 when TabSize is 0.
+	assert.Contains(t, stripped, "Tab: 4")
+}
+
+// ---------------------------------------------------------------------------
+// renderEditContent (smoke test)
+// ---------------------------------------------------------------------------
+
+func TestRenderEditContent_NilBuffer(t *testing.T) {
+	p := &Preview{editMode: true, editBuf: nil}
+	result := renderEditContent(p, 80, 24)
+	assert.Equal(t, "", result)
+}
+
+func TestRenderEditContent_BasicSmoke(t *testing.T) {
+	buf := NewTextBuffer([]string{"line one", "line two", "line three"})
+
+	p := &Preview{
+		editMode:   true,
+		editBuf:    buf,
+		cursorLine: 0,
+		cursorCol:  0,
+		cfg:        defaultCfg(),
+		editCfg:    config.EditorConfig{TabSize: 4},
+		filePath:   "test.go",
+	}
+
+	result := renderEditContent(p, 60, 10)
+	require.NotEmpty(t, result)
+
+	stripped := ansi.Strip(result)
+	// Should contain line numbers.
+	assert.Contains(t, stripped, "1")
+	assert.Contains(t, stripped, "2")
+	assert.Contains(t, stripped, "3")
+	// Should contain the text content.
+	assert.Contains(t, stripped, "line one")
+	assert.Contains(t, stripped, "line two")
+	// Should contain a status bar with cursor info.
+	assert.Contains(t, stripped, "Ln 1")
+	assert.Contains(t, stripped, "Col 1")
+}
+
+func TestRenderEditContent_CursorOnLastLine(t *testing.T) {
+	buf := NewTextBuffer([]string{"a", "b", "c"})
+
+	p := &Preview{
+		editMode:   true,
+		editBuf:    buf,
+		cursorLine: 2,
+		cursorCol:  1,
+		cfg:        defaultCfg(),
+		editCfg:    config.EditorConfig{TabSize: 4},
+		filePath:   "test.txt",
+	}
+
+	result := renderEditContent(p, 40, 10)
+	stripped := ansi.Strip(result)
+	assert.Contains(t, stripped, "Ln 3")
+	assert.Contains(t, stripped, "Col 2")
+}
+
+func TestRenderEditContent_SmallHeight(t *testing.T) {
+	buf := NewTextBuffer([]string{"line 1", "line 2", "line 3", "line 4", "line 5"})
+
+	p := &Preview{
+		editMode:   true,
+		editBuf:    buf,
+		cursorLine: 0,
+		cursorCol:  0,
+		cfg:        defaultCfg(),
+		editCfg:    config.EditorConfig{TabSize: 4},
+	}
+
+	// height=2 means 1 line for content, 1 for status bar.
+	result := renderEditContent(p, 40, 2)
+	require.NotEmpty(t, result)
+	lines := strings.Split(result, "\n")
+	// Should have exactly 2 lines: 1 content + 1 status bar.
+	assert.Equal(t, 2, len(lines))
+}
+
+// ---------------------------------------------------------------------------
+// clampEditScroll
+// ---------------------------------------------------------------------------
+
+func TestClampEditScroll_NoOverflow(t *testing.T) {
+	p := &Preview{scrollY: 0}
+	p.clampEditScroll(100, 20)
+	assert.Equal(t, 0, p.scrollY)
+}
+
+func TestClampEditScroll_ClampsMax(t *testing.T) {
+	p := &Preview{scrollY: 90}
+	p.clampEditScroll(100, 20)
+	assert.Equal(t, 80, p.scrollY)
+}
+
+func TestClampEditScroll_ClampsNegative(t *testing.T) {
+	p := &Preview{scrollY: -5}
+	p.clampEditScroll(100, 20)
+	assert.Equal(t, 0, p.scrollY)
+}
+
+func TestClampEditScroll_ContentTallerThanLines(t *testing.T) {
+	p := &Preview{scrollY: 5}
+	// Only 3 lines but viewport can show 10.
+	p.clampEditScroll(3, 10)
+	assert.Equal(t, 0, p.scrollY)
+}
+
+// ---------------------------------------------------------------------------
+// Title edit-mode indicators
+// ---------------------------------------------------------------------------
+
+func TestTitle_EditMode(t *testing.T) {
+	p := New(defaultCfg(), defaultEditorCfg())
+	p.filePath = "/tmp/test.go"
+	p.editMode = true
+
+	assert.Equal(t, "test.go [edit]", p.Title())
+}
+
+func TestTitle_EditModeDirty(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+	buf.InsertRune(0, 0, 'x')
+
+	p := New(defaultCfg(), defaultEditorCfg())
+	p.filePath = "/tmp/test.go"
+	p.editMode = true
+	p.editBuf = buf
+
+	assert.Equal(t, "test.go [+]", p.Title())
+}
+
+func TestTitle_EditModeClean(t *testing.T) {
+	buf := NewTextBuffer([]string{"hello"})
+
+	p := New(defaultCfg(), defaultEditorCfg())
+	p.filePath = "/tmp/test.go"
+	p.editMode = true
+	p.editBuf = buf
+
+	assert.Equal(t, "test.go [edit]", p.Title())
+}
+
+// ---------------------------------------------------------------------------
+// KeyBindings edit-mode vs read-mode
+// ---------------------------------------------------------------------------
+
+func TestKeyBindings_ReadMode(t *testing.T) {
+	p := New(defaultCfg(), defaultEditorCfg())
+	bindings := p.KeyBindings()
+
+	// Read mode should include "e" for edit and standard navigation.
+	keys := make(map[string]bool)
+	for _, b := range bindings {
+		keys[b.Key] = true
+	}
+	assert.True(t, keys["e"], "read mode should have 'e' binding")
+	assert.True(t, keys["j/↓"], "read mode should have scroll bindings")
+}
+
+func TestKeyBindings_EditMode(t *testing.T) {
+	p := New(defaultCfg(), defaultEditorCfg())
+	p.editMode = true
+	bindings := p.KeyBindings()
+
+	keys := make(map[string]bool)
+	for _, b := range bindings {
+		keys[b.Key] = true
+	}
+	assert.True(t, keys["Esc"], "edit mode should have Esc binding")
+	assert.True(t, keys["Ctrl+S"], "edit mode should have save binding")
+	assert.True(t, keys["Ctrl+Z"], "edit mode should have undo binding")
+	assert.False(t, keys["j/↓"], "edit mode should not have read-mode scroll bindings")
+}

--- a/internal/panels/preview/editor_test.go
+++ b/internal/panels/preview/editor_test.go
@@ -1,0 +1,714 @@
+package preview
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/jongio/grut/internal/config"
+	"github.com/jongio/grut/internal/notify"
+	"github.com/jongio/grut/internal/panels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testPreview returns a Preview with edit-related fields ready for testing.
+func testPreview() *Preview {
+	edCfg := config.EditorConfig{
+		TabSize:    4,
+		AutoIndent: true,
+	}
+	p := New(defaultCfg(), edCfg)
+	p.width = 80
+	p.height = 24
+	p.focused = true
+	return p
+}
+
+// testPreviewWithFile writes content to a temp file, sets it as the preview's
+// current file, and returns the preview and file path.
+func testPreviewWithFile(t *testing.T, content string) (*Preview, string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.go")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	p := testPreview()
+	p.filePath = path
+	return p, path
+}
+
+// ---------------------------------------------------------------------------
+// enterEditMode
+// ---------------------------------------------------------------------------
+
+func TestEnterEditMode_Success(t *testing.T) {
+	content := "line one\nline two\nline three"
+	p, path := testPreviewWithFile(t, content)
+	p.scrollY = 1
+
+	cmd := enterEditMode(p)
+
+	assert.True(t, p.editMode, "editMode should be true")
+	assert.NotNil(t, p.editBuf, "editBuf should be created")
+	assert.Equal(t, 3, p.editBuf.LineCount(), "buffer should have 3 lines")
+	assert.Equal(t, "line one", p.editBuf.Line(0))
+	assert.Equal(t, "line two", p.editBuf.Line(1))
+	assert.Equal(t, "line three", p.editBuf.Line(2))
+	assert.Equal(t, 1, p.cursorLine, "cursor should be at scrollY")
+	assert.Equal(t, 0, p.cursorCol, "cursor col should be 0")
+
+	// The cmd should produce an EditModeEnteredMsg.
+	require.NotNil(t, cmd, "cmd should not be nil")
+	msg := cmd()
+	entered, ok := msg.(panels.EditModeEnteredMsg)
+	require.True(t, ok, "should produce EditModeEnteredMsg")
+	assert.Equal(t, path, entered.Path)
+}
+
+func TestEnterEditMode_BlockedBinary(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "data")
+	p.isBinary = true
+
+	cmd := enterEditMode(p)
+	assert.Nil(t, cmd)
+	assert.False(t, p.editMode)
+}
+
+func TestEnterEditMode_BlockedLarge(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "data")
+	p.isLarge = true
+
+	cmd := enterEditMode(p)
+	assert.Nil(t, cmd)
+	assert.False(t, p.editMode)
+}
+
+func TestEnterEditMode_BlockedGHMode(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "data")
+	p.ghMode = true
+
+	cmd := enterEditMode(p)
+	assert.Nil(t, cmd)
+	assert.False(t, p.editMode)
+}
+
+func TestEnterEditMode_BlockedEmptyPath(t *testing.T) {
+	p := testPreview()
+	p.filePath = ""
+
+	cmd := enterEditMode(p)
+	assert.Nil(t, cmd)
+	assert.False(t, p.editMode)
+}
+
+func TestEnterEditMode_FileReadError(t *testing.T) {
+	p := testPreview()
+	p.filePath = filepath.Join(t.TempDir(), "nonexistent.txt")
+
+	cmd := enterEditMode(p)
+	require.NotNil(t, cmd)
+	msg := cmd()
+	toast, ok := msg.(notify.ShowToastMsg)
+	require.True(t, ok, "should produce a toast for read error")
+	assert.Equal(t, notify.Error, toast.Level)
+	assert.Contains(t, toast.Message, "Cannot edit")
+}
+
+// ---------------------------------------------------------------------------
+// exitEditMode
+// ---------------------------------------------------------------------------
+
+func TestExitEditMode_Clean(t *testing.T) {
+	content := "hello\nworld"
+	p, path := testPreviewWithFile(t, content)
+	enterEditMode(p)
+	require.True(t, p.editMode)
+
+	p.cursorLine = 1
+	cmd := exitEditMode(p, true)
+
+	assert.False(t, p.editMode, "editMode should be false")
+	assert.Nil(t, p.editBuf, "editBuf should be nil")
+	assert.Equal(t, 1, p.scrollY, "scrollY should preserve cursor position")
+	require.NotNil(t, cmd)
+
+	// Run the batch — it should include EditModeExitedMsg and loadFileCmd.
+	msg := cmd()
+	// The batch produces a tea.BatchMsg with sub-commands.
+	batchMsg, ok := msg.(tea.BatchMsg)
+	require.True(t, ok, "should produce tea.BatchMsg, got %T", msg)
+	// Find the EditModeExitedMsg in the batch results.
+	foundExited := false
+	for _, subCmd := range batchMsg {
+		if subCmd == nil {
+			continue
+		}
+		subMsg := subCmd()
+		if exited, ok := subMsg.(panels.EditModeExitedMsg); ok {
+			assert.Equal(t, path, exited.Path)
+			foundExited = true
+		}
+	}
+	assert.True(t, foundExited, "batch should contain EditModeExitedMsg")
+}
+
+func TestExitEditMode_NotInEditMode(t *testing.T) {
+	p := testPreview()
+	p.editMode = false
+
+	cmd := exitEditMode(p, false)
+	assert.Nil(t, cmd)
+}
+
+// ---------------------------------------------------------------------------
+// handleEditKeyPress — character insert
+// ---------------------------------------------------------------------------
+
+func TestHandleEditKeyPress_CharInsert(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "abc")
+	enterEditMode(p)
+	p.cursorLine = 0
+	p.cursorCol = 0
+
+	msg := tea.KeyPressMsg{Text: "X", Code: 'X'}
+	handleEditKeyPress(p, msg)
+
+	assert.Equal(t, "Xabc", p.editBuf.Line(0))
+	assert.Equal(t, 1, p.cursorCol)
+}
+
+func TestHandleEditKeyPress_MultiRuneInsert(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "abc")
+	enterEditMode(p)
+	p.cursorCol = 3
+
+	msg := tea.KeyPressMsg{Text: "XY"}
+	handleEditKeyPress(p, msg)
+
+	assert.Equal(t, "abcXY", p.editBuf.Line(0))
+	assert.Equal(t, 5, p.cursorCol)
+}
+
+// ---------------------------------------------------------------------------
+// handleEditKeyPress — backspace
+// ---------------------------------------------------------------------------
+
+func TestHandleEditKeyPress_Backspace(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "abc")
+	enterEditMode(p)
+	p.cursorCol = 2
+
+	msg := tea.KeyPressMsg{Code: tea.KeyBackspace}
+	handleEditKeyPress(p, msg)
+
+	assert.Equal(t, "ac", p.editBuf.Line(0))
+	assert.Equal(t, 1, p.cursorCol)
+}
+
+// ---------------------------------------------------------------------------
+// handleEditKeyPress — enter
+// ---------------------------------------------------------------------------
+
+func TestHandleEditKeyPress_Enter(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "hello world")
+	enterEditMode(p)
+	p.editCfg.AutoIndent = false
+	p.cursorCol = 5
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	handleEditKeyPress(p, msg)
+
+	assert.Equal(t, 2, p.editBuf.LineCount())
+	assert.Equal(t, "hello", p.editBuf.Line(0))
+	assert.Equal(t, " world", p.editBuf.Line(1))
+	assert.Equal(t, 1, p.cursorLine)
+	assert.Equal(t, 0, p.cursorCol)
+}
+
+func TestHandleEditKeyPress_EnterAutoIndent(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "    indented line")
+	enterEditMode(p)
+	p.editCfg.AutoIndent = true
+	p.cursorCol = 17 // end of line
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	handleEditKeyPress(p, msg)
+
+	assert.Equal(t, 2, p.editBuf.LineCount())
+	assert.Equal(t, 1, p.cursorLine)
+	// The new line should have auto-indentation; cursor at indent position.
+	assert.Equal(t, countLeadingSpaces(p.editBuf.Line(1)), p.cursorCol)
+}
+
+// ---------------------------------------------------------------------------
+// handleEditKeyPress — arrows / movement
+// ---------------------------------------------------------------------------
+
+func TestHandleEditKeyPress_ArrowKeys(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "abc\ndef\nghi")
+	enterEditMode(p)
+	p.cursorLine = 1
+	p.cursorCol = 1
+
+	// down
+	handleEditKeyPress(p, tea.KeyPressMsg{Code: tea.KeyDown})
+	assert.Equal(t, 2, p.cursorLine)
+
+	// up twice (should clamp at 0)
+	handleEditKeyPress(p, tea.KeyPressMsg{Code: tea.KeyUp})
+	handleEditKeyPress(p, tea.KeyPressMsg{Code: tea.KeyUp})
+	assert.Equal(t, 0, p.cursorLine)
+
+	// right to end of line, then one more wraps
+	p.cursorCol = 3
+	handleEditKeyPress(p, tea.KeyPressMsg{Code: tea.KeyRight})
+	assert.Equal(t, 1, p.cursorLine)
+	assert.Equal(t, 0, p.cursorCol)
+
+	// left wraps to end of previous line
+	handleEditKeyPress(p, tea.KeyPressMsg{Code: tea.KeyLeft})
+	assert.Equal(t, 0, p.cursorLine)
+	assert.Equal(t, 3, p.cursorCol)
+}
+
+func TestHandleEditKeyPress_HomeEnd(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "hello world")
+	enterEditMode(p)
+	p.cursorCol = 5
+
+	// home
+	handleEditKeyPress(p, tea.KeyPressMsg{Code: tea.KeyHome})
+	assert.Equal(t, 0, p.cursorCol)
+
+	// end
+	handleEditKeyPress(p, tea.KeyPressMsg{Code: tea.KeyEnd})
+	assert.Equal(t, 11, p.cursorCol) // len("hello world")
+}
+
+func TestHandleEditKeyPress_CtrlHomeEnd(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "line1\nline2\nline3")
+	enterEditMode(p)
+	p.cursorLine = 1
+
+	// ctrl+end goes to last line, end of line
+	handleEditKeyPress(p, tea.KeyPressMsg{Code: tea.KeyEnd, Mod: tea.ModCtrl})
+	assert.Equal(t, 2, p.cursorLine)
+	assert.Equal(t, 5, p.cursorCol) // len("line3")
+
+	// ctrl+home goes to 0,0
+	handleEditKeyPress(p, tea.KeyPressMsg{Code: tea.KeyHome, Mod: tea.ModCtrl})
+	assert.Equal(t, 0, p.cursorLine)
+	assert.Equal(t, 0, p.cursorCol)
+}
+
+func TestHandleEditKeyPress_Escape_Clean(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "clean buffer")
+	enterEditMode(p)
+	require.True(t, p.editMode)
+
+	_, cmd := handleEditKeyPress(p, tea.KeyPressMsg{Code: tea.KeyEscape})
+	// Since buffer is clean, should produce an exit command.
+	assert.NotNil(t, cmd)
+}
+
+func TestHandleEditKeyPress_CtrlS(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "save me")
+	enterEditMode(p)
+
+	_, cmd := handleEditKeyPress(p, tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	assert.NotNil(t, cmd, "ctrl+s should produce a save command")
+}
+
+// ---------------------------------------------------------------------------
+// moveCursor boundary tests
+// ---------------------------------------------------------------------------
+
+func TestMoveCursorLeft_AtOrigin(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "abc")
+	enterEditMode(p)
+	p.cursorLine = 0
+	p.cursorCol = 0
+
+	moveCursorLeft(p)
+	assert.Equal(t, 0, p.cursorLine)
+	assert.Equal(t, 0, p.cursorCol, "should not go negative")
+}
+
+func TestMoveCursorLeft_WrapToPreviousLine(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "abc\ndef")
+	enterEditMode(p)
+	p.cursorLine = 1
+	p.cursorCol = 0
+
+	moveCursorLeft(p)
+	assert.Equal(t, 0, p.cursorLine)
+	assert.Equal(t, 3, p.cursorCol, "should wrap to end of previous line")
+}
+
+func TestMoveCursorRight_AtEnd(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "abc")
+	enterEditMode(p)
+	p.cursorLine = 0
+	p.cursorCol = 3
+
+	moveCursorRight(p)
+	// Single line, no next line to wrap to.
+	assert.Equal(t, 0, p.cursorLine)
+	assert.Equal(t, 3, p.cursorCol)
+}
+
+func TestMoveCursorRight_WrapToNextLine(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "abc\ndef")
+	enterEditMode(p)
+	p.cursorLine = 0
+	p.cursorCol = 3
+
+	moveCursorRight(p)
+	assert.Equal(t, 1, p.cursorLine)
+	assert.Equal(t, 0, p.cursorCol)
+}
+
+func TestMoveCursorUp_AtTop(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "only line")
+	enterEditMode(p)
+	p.cursorLine = 0
+
+	moveCursorUp(p)
+	assert.Equal(t, 0, p.cursorLine, "should stay at line 0")
+}
+
+func TestMoveCursorDown_AtBottom(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "only line")
+	enterEditMode(p)
+	p.cursorLine = 0
+
+	moveCursorDown(p)
+	assert.Equal(t, 0, p.cursorLine, "should stay at last line")
+}
+
+func TestMoveCursorDown_ClampCol(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "long line here\nhi")
+	enterEditMode(p)
+	p.cursorLine = 0
+	p.cursorCol = 14 // end of "long line here"
+
+	moveCursorDown(p)
+	assert.Equal(t, 1, p.cursorLine)
+	assert.Equal(t, 2, p.cursorCol, "should clamp to length of shorter line")
+}
+
+// ---------------------------------------------------------------------------
+// ensureCursorVisible
+// ---------------------------------------------------------------------------
+
+func TestEnsureCursorVisible_ScrollsDown(t *testing.T) {
+	p := testPreview()
+	p.height = 10 // viewportHeight = 9
+	p.scrollY = 0
+	p.cursorLine = 15
+
+	ensureCursorVisible(p)
+	// cursorLine should be within [scrollY, scrollY+vh)
+	assert.LessOrEqual(t, p.scrollY, p.cursorLine)
+	assert.Greater(t, p.scrollY+p.viewportHeight(), p.cursorLine)
+}
+
+func TestEnsureCursorVisible_ScrollsUp(t *testing.T) {
+	p := testPreview()
+	p.height = 10
+	p.scrollY = 20
+	p.cursorLine = 5
+
+	ensureCursorVisible(p)
+	assert.Equal(t, 5, p.scrollY, "scrollY should match cursorLine when scrolling up")
+}
+
+func TestEnsureCursorVisible_NoChangeWhenVisible(t *testing.T) {
+	p := testPreview()
+	p.height = 10
+	p.scrollY = 5
+	p.cursorLine = 8
+
+	ensureCursorVisible(p)
+	assert.Equal(t, 5, p.scrollY, "scrollY should not change when cursor is visible")
+}
+
+func TestEnsureCursorVisible_NegativeScrollY(t *testing.T) {
+	p := testPreview()
+	p.height = 10
+	p.scrollY = -5
+	p.cursorLine = 0
+
+	ensureCursorVisible(p)
+	assert.Equal(t, 0, p.scrollY, "scrollY should be clamped to 0")
+}
+
+// ---------------------------------------------------------------------------
+// saveFile
+// ---------------------------------------------------------------------------
+
+func TestSaveFile_WritesToDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "saveable.txt")
+	require.NoError(t, os.WriteFile(path, []byte("original"), 0o644))
+
+	p := testPreview()
+	p.filePath = path
+	p.editBuf = NewTextBuffer([]string{"modified", "content"})
+	p.editMode = true
+
+	cmd := saveFile(p)
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	saved, ok := msg.(fileSavedMsg)
+	require.True(t, ok, "should produce fileSavedMsg, got %T", msg)
+	assert.Equal(t, path, saved.path)
+
+	// Verify disk content.
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "modified\ncontent", string(data))
+}
+
+func TestSaveFile_NilBuffer(t *testing.T) {
+	p := testPreview()
+	p.editBuf = nil
+
+	cmd := saveFile(p)
+	assert.Nil(t, cmd)
+}
+
+func TestSaveFile_EmptyPath(t *testing.T) {
+	p := testPreview()
+	p.filePath = ""
+	p.editBuf = NewTextBuffer([]string{"data"})
+
+	cmd := saveFile(p)
+	assert.Nil(t, cmd)
+}
+
+func TestSaveFile_InvalidDir(t *testing.T) {
+	p := testPreview()
+	p.filePath = filepath.Join(t.TempDir(), "nonexistent", "deep", "file.txt")
+	p.editBuf = NewTextBuffer([]string{"data"})
+	p.editMode = true
+
+	cmd := saveFile(p)
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	toast, ok := msg.(notify.ShowToastMsg)
+	require.True(t, ok, "should produce error toast, got %T", msg)
+	assert.Equal(t, notify.Error, toast.Level)
+	assert.Contains(t, toast.Message, "Save failed")
+}
+
+// ---------------------------------------------------------------------------
+// handleFileSaved
+// ---------------------------------------------------------------------------
+
+func TestHandleFileSaved_MarksClean(t *testing.T) {
+	p, path := testPreviewWithFile(t, "content")
+	enterEditMode(p)
+	// Simulate modification to make buffer dirty.
+	p.editBuf.InsertRune(0, 0, 'X')
+	require.True(t, p.editBuf.Dirty())
+
+	_, cmd := handleFileSaved(p, fileSavedMsg{path: path})
+	assert.False(t, p.editBuf.Dirty(), "buffer should be marked clean")
+	assert.NotNil(t, cmd, "should produce batch cmd for toast + FileModifiedMsg")
+}
+
+// ---------------------------------------------------------------------------
+// handleModalResult
+// ---------------------------------------------------------------------------
+
+func TestHandleModalResult_Cancel(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "data")
+	enterEditMode(p)
+
+	// Esc / cancel
+	_, cmd := handleModalResult(p, notify.ModalResultMsg{Accept: false})
+	assert.Nil(t, cmd, "cancel should produce no command")
+	assert.True(t, p.editMode, "should still be in edit mode")
+}
+
+func TestHandleModalResult_CancelAction(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "data")
+	enterEditMode(p)
+
+	_, cmd := handleModalResult(p, notify.ModalResultMsg{Accept: true, Value: "cancel"})
+	assert.Nil(t, cmd)
+	assert.True(t, p.editMode)
+}
+
+func TestHandleModalResult_Discard(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "data")
+	enterEditMode(p)
+
+	_, cmd := handleModalResult(p, notify.ModalResultMsg{Accept: true, Value: "discard_exit"})
+	// Should trigger exit (editMode cleared, buffer nil'd).
+	assert.NotNil(t, cmd)
+}
+
+func TestHandleModalResult_SaveAndExit(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "data")
+	enterEditMode(p)
+
+	_, cmd := handleModalResult(p, notify.ModalResultMsg{Accept: true, Value: "save_exit"})
+	assert.NotNil(t, cmd, "save+exit should produce a batch cmd")
+}
+
+// ---------------------------------------------------------------------------
+// dirtyGuardCmd
+// ---------------------------------------------------------------------------
+
+func TestDirtyGuardCmd_ProducesModal(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "some content")
+	enterEditMode(p)
+
+	cmd := dirtyGuardCmd(p, "exit")
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	modal, ok := msg.(notify.ShowModalMsg)
+	require.True(t, ok, "should produce ShowModalMsg, got %T", msg)
+	assert.Equal(t, "Unsaved Changes", modal.Title)
+	assert.Equal(t, notify.ModalActionPicker, modal.Kind)
+	require.Len(t, modal.Actions, 3)
+	assert.Equal(t, "save_exit", modal.Actions[0].ID)
+	assert.Equal(t, "discard_exit", modal.Actions[1].ID)
+	assert.Equal(t, "cancel", modal.Actions[2].ID)
+}
+
+// ---------------------------------------------------------------------------
+// countLeadingSpaces
+// ---------------------------------------------------------------------------
+
+func TestCountLeadingSpaces(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"no indent", "hello", 0},
+		{"spaces", "    hello", 4},
+		{"tab", "\thello", 4},
+		{"mixed", "  \thello", 6},
+		{"empty", "", 0},
+		{"only spaces", "   ", 3},
+		{"only tabs", "\t\t", 8},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countLeadingSpaces(tt.in)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// clampCursorCol
+// ---------------------------------------------------------------------------
+
+func TestClampCursorCol(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "hi")
+	enterEditMode(p)
+	p.cursorCol = 100
+
+	clampCursorCol(p)
+	assert.Equal(t, 2, p.cursorCol, "should clamp to line length")
+}
+
+func TestClampCursorCol_NilBuffer(t *testing.T) {
+	p := testPreview()
+	p.editBuf = nil
+	p.cursorCol = 10
+
+	clampCursorCol(p) // should not panic
+	assert.Equal(t, 10, p.cursorCol, "should be unchanged with nil buffer")
+}
+
+// ---------------------------------------------------------------------------
+// handleEditKeyPress — tab / shift+tab
+// ---------------------------------------------------------------------------
+
+func TestHandleEditKeyPress_Tab(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "hello")
+	enterEditMode(p)
+	p.cursorCol = 0
+	p.editCfg.TabSize = 4
+
+	handleEditKeyPress(p, tea.KeyPressMsg{Code: tea.KeyTab})
+
+	line := p.editBuf.Line(0)
+	assert.True(t, strings.HasPrefix(line, "    "), "should insert 4 spaces, got: %q", line)
+	assert.Equal(t, 4, p.cursorCol)
+}
+
+func TestHandleEditKeyPress_Delete(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "abc")
+	enterEditMode(p)
+	p.cursorCol = 1
+
+	handleEditKeyPress(p, tea.KeyPressMsg{Code: tea.KeyDelete})
+
+	assert.Equal(t, "ac", p.editBuf.Line(0))
+	assert.Equal(t, 1, p.cursorCol, "cursor should stay in place after delete")
+}
+
+func TestHandleEditKeyPress_CtrlD_DuplicateLine(t *testing.T) {
+	p, _ := testPreviewWithFile(t, "duplicate me")
+	enterEditMode(p)
+	p.cursorLine = 0
+
+	handleEditKeyPress(p, tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+
+	assert.Equal(t, 2, p.editBuf.LineCount())
+	assert.Equal(t, "duplicate me", p.editBuf.Line(0))
+	assert.Equal(t, "duplicate me", p.editBuf.Line(1))
+	assert.Equal(t, 1, p.cursorLine, "cursor should move to duplicated line")
+}
+
+// ---------------------------------------------------------------------------
+// Integration: multiple edits
+// ---------------------------------------------------------------------------
+
+func TestEditSequence_TypeAndSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "editable.txt")
+	require.NoError(t, os.WriteFile(path, []byte("start"), 0o644))
+
+	p := testPreview()
+	p.filePath = path
+	p.width = 80
+	p.height = 24
+	p.editCfg = config.EditorConfig{TabSize: 4, AutoIndent: true}
+
+	// Enter edit mode.
+	cmd := enterEditMode(p)
+	require.NotNil(t, cmd)
+	require.True(t, p.editMode)
+
+	// Type at end of first line.
+	p.cursorCol = 5
+	handleEditKeyPress(p, tea.KeyPressMsg{Text: "!", Code: '!'})
+	assert.Equal(t, "start!", p.editBuf.Line(0))
+
+	// Save.
+	saveCmd := saveFile(p)
+	require.NotNil(t, saveCmd)
+	msg := saveCmd()
+	_, ok := msg.(fileSavedMsg)
+	require.True(t, ok)
+
+	// Verify on disk.
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "start!", string(data))
+}

--- a/internal/panels/preview/preview.go
+++ b/internal/panels/preview/preview.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jongio/grut/internal/config"
 	"github.com/jongio/grut/internal/git"
 	"github.com/jongio/grut/internal/markdown"
+	"github.com/jongio/grut/internal/notify"
 	"github.com/jongio/grut/internal/panels"
 	"github.com/jongio/grut/internal/theme"
 )
@@ -69,6 +70,12 @@ type Preview struct {
 	selAnchor *selPoint // where the click/drag began (absolute line + rune col)
 	selEnd    *selPoint // where the drag/shift-move reached
 	selecting bool      // true while mouse button is held and dragging
+	// Inline editor state (edit mode)
+	editMode   bool              // true when in edit mode
+	editBuf    *TextBuffer       // editable text buffer (nil when not editing)
+	cursorLine int               // cursor line (0-based, in buffer)
+	cursorCol  int               // cursor column (rune offset, 0-based)
+	editCfg    config.EditorConfig // editor configuration
 }
 
 // fileLoadedMsg is the result of an async file load operation (F01).
@@ -91,9 +98,10 @@ type diffLoadedMsg struct {
 var _ panels.Panel = (*Preview)(nil)
 
 // New creates a new Preview panel with the given configuration.
-func New(cfg config.PreviewConfig, th *theme.Theme) *Preview {
+func New(cfg config.PreviewConfig, editorCfg config.EditorConfig, th *theme.Theme) *Preview {
 	return &Preview{
 		cfg:            cfg,
+		editCfg:        editorCfg,
 		lineNumbers:    cfg.LineNumbers,
 		wordWrap:       cfg.WordWrap,
 		renderMarkdown: cfg.RenderMarkdown,
@@ -160,7 +168,42 @@ func (p *Preview) Init(_ context.Context) tea.Cmd {
 // keyboard events for scrolling and toggling display options.
 func (p *Preview) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 	switch msg := msg.(type) {
+	// Handle edit-mode-specific modal results (dirty guard).
+	case notify.ModalResultMsg:
+		if p.editMode {
+			return handleModalResult(p, msg)
+		}
+
+	// Handle file saved result.
+	case fileSavedMsg:
+		if msg.path == p.filePath {
+			if p.editBuf != nil {
+				p.editBuf.MarkClean()
+			}
+			cmds := []tea.Cmd{
+				func() tea.Msg {
+					return notify.ShowToastMsg{Message: "Saved " + filepath.Base(p.filePath), Level: notify.Info}
+				},
+				func() tea.Msg {
+					return panels.FileModifiedMsg{Path: p.filePath}
+				},
+			}
+			if p.gitClient != nil {
+				cmds = append(cmds, p.loadDiffCmd(p.filePath))
+			}
+			return p, tea.Batch(cmds...)
+		}
+
 	case panels.FileSelectedMsg:
+		// If in edit mode with unsaved changes, prompt before switching.
+		if p.editMode && p.editBuf != nil && p.editBuf.Dirty() {
+			return p, dirtyGuardCmd(p, "switch")
+		}
+		if p.editMode {
+			// Clean exit from edit mode before switching files.
+			p.editMode = false
+			p.editBuf = nil
+		}
 		// Clear GitHub content mode if active — file selection takes precedence.
 		p.ghMode = false
 		p.ghTitle = ""
@@ -360,7 +403,13 @@ func (p *Preview) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 		if !p.focused {
 			return p, nil
 		}
+		// Edit mode keyboard handling takes priority.
+		if p.editMode {
+			return handleEditKeyPress(p, msg)
+		}
 		switch msg.String() {
+		case "e":
+			return p, enterEditMode(p)
 		case "j", "down":
 			p.scrollDown(1)
 		case "k", "up":
@@ -431,6 +480,10 @@ func (p *Preview) View(width, height int) string {
 	if p.isBinary || p.isLarge {
 		return p.renderMetadata(width, height)
 	}
+	// Edit mode rendering
+	if p.editMode && p.editBuf != nil {
+		return renderEditContent(p, width, height)
+	}
 	// Blame mode
 	if p.blameMode && len(p.blameLines) > 0 {
 		return p.renderBlameContent(width, height)
@@ -468,12 +521,31 @@ func (p *Preview) Title() string {
 	if p.filePath == "" {
 		return "preview"
 	}
-	return filepath.Base(p.filePath)
+	name := filepath.Base(p.filePath)
+	if p.editMode && p.editBuf != nil && p.editBuf.Dirty() {
+		return name + " [+]"
+	}
+	if p.editMode {
+		return name + " [edit]"
+	}
+	return name
 }
 
 // KeyBindings implements panels.Panel.
 func (p *Preview) KeyBindings() []panels.KeyBinding {
+	if p.editMode {
+		return []panels.KeyBinding{
+			{Key: "Esc", Description: "Exit edit mode", Action: "exit_edit"},
+			{Key: "Ctrl+S", Description: "Save file", Action: "save"},
+			{Key: "Ctrl+Z", Description: "Undo", Action: "undo"},
+			{Key: "Ctrl+Y", Description: "Redo", Action: "redo"},
+			{Key: "Ctrl+D", Description: "Duplicate line", Action: "duplicate_line"},
+			{Key: "Tab", Description: "Insert indent", Action: "indent"},
+			{Key: "Shift+Tab", Description: "Remove indent", Action: "dedent"},
+		}
+	}
 	return []panels.KeyBinding{
+		{Key: "e", Description: "Edit file", Action: "edit"},
 		{Key: "j/↓", Description: "Scroll down", Action: "scroll_down"},
 		{Key: "k/↑", Description: "Scroll up", Action: "scroll_up"},
 		{Key: "d/PgDn", Description: "Page down", Action: "page_down"},

--- a/internal/panels/preview/preview_test.go
+++ b/internal/panels/preview/preview_test.go
@@ -30,6 +30,15 @@ func defaultCfg() config.PreviewConfig {
 	}
 }
 
+// defaultEditorCfg returns an EditorConfig with sensible defaults for testing.
+func defaultEditorCfg() config.EditorConfig {
+	return config.EditorConfig{
+		TabSize:    4,
+		InsertTabs: false,
+		AutoIndent: true,
+	}
+}
+
 // keyMsg creates a tea.KeyPressMsg for a printable character.
 func keyMsg(key string) tea.KeyPressMsg {
 	if len(key) == 1 {
@@ -94,7 +103,7 @@ func TestImplementsPanel(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	cfg := defaultCfg()
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 
 	assert.NotNil(t, p)
 	assert.Equal(t, "preview", p.Title())
@@ -111,7 +120,7 @@ func TestNewCustomConfig(t *testing.T) {
 		RenderMarkdown: false,
 		MaxFileSize:    512,
 	}
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 
 	assert.False(t, p.lineNumbers)
 	assert.True(t, p.wordWrap)
@@ -120,13 +129,13 @@ func TestNewCustomConfig(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	cmd := p.Init(context.Background())
 	assert.Nil(t, cmd)
 }
 
 func TestEmptyStateRendering(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 
 	content := p.View(60, 20)
 	assert.NotEmpty(t, content)
@@ -135,7 +144,7 @@ func TestEmptyStateRendering(t *testing.T) {
 }
 
 func TestEmptyStateZeroSize(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	assert.Empty(t, p.View(0, 20))
 	assert.Empty(t, p.View(20, 0))
 	assert.Empty(t, p.View(0, 0))
@@ -149,7 +158,7 @@ func TestPlainTextFile(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 
 	// Load via FileSelectedMsg
@@ -166,7 +175,7 @@ func TestTitleChangesOnFileSelect(t *testing.T) {
 	dir := t.TempDir()
 	path := writeFile(t, dir, "example.txt", "content")
 
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	assert.Equal(t, "preview", p.Title())
 
 	loadFile(t, p, path)
@@ -185,7 +194,7 @@ func main() {
 `
 	path := writeFile(t, dir, "main.go", goCode)
 
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 	loadFile(t, p, path)
 
@@ -214,7 +223,7 @@ if __name__ == "__main__":
 `
 	path := writeFile(t, dir, "script.py", pyCode)
 
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 	loadFile(t, p, path)
 
@@ -234,7 +243,7 @@ greet("World");
 `
 	path := writeFile(t, dir, "app.js", jsCode)
 
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 	loadFile(t, p, path)
 
@@ -251,7 +260,7 @@ func TestSyntaxHighlightingDisabled(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(80, 20)
 	loadFile(t, p, path)
 
@@ -265,7 +274,7 @@ func TestMarkdownRendering(t *testing.T) {
 	mdContent := "# Hello World\n\nThis is a **bold** paragraph.\n\n- Item 1\n- Item 2\n"
 	path := writeFile(t, dir, "README.md", mdContent)
 
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	loadFile(t, p, path)
 
@@ -291,7 +300,7 @@ func TestMarkdownExtensions(t *testing.T) {
 		name := "test" + ext
 		path := writeFile(t, dir, name, mdContent)
 
-		p := New(defaultCfg(), nil)
+		p := New(defaultCfg(), defaultEditorCfg(), nil)
 		p.SetSize(60, 20)
 		loadFile(t, p, path)
 
@@ -305,7 +314,7 @@ func TestBinaryFileDetection(t *testing.T) {
 	dir := t.TempDir()
 	path := writeBinaryFile(t, dir, "image.png")
 
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	loadFile(t, p, path)
 
@@ -326,7 +335,7 @@ func TestLargeFileRejection(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.MaxFileSize = 100 // 100 bytes
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	loadFile(t, p, path)
 
@@ -344,7 +353,7 @@ func TestLargeFileShowsMetadata(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.MaxFileSize = 100
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	loadFile(t, p, path)
 
@@ -363,7 +372,7 @@ func TestMaxFileSizeZeroDisablesCheck(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.MaxFileSize = 0 // disabled
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	loadFile(t, p, path)
 
@@ -380,7 +389,7 @@ func TestLineNumberDisplay(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
 	cfg.LineNumbers = true
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	loadFile(t, p, path)
 
@@ -399,7 +408,7 @@ func TestLineNumberToggle(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
 	cfg.LineNumbers = true
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	p.Focus()
 	loadFile(t, p, path)
@@ -430,7 +439,7 @@ func TestWordWrapToggle(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
 	cfg.WordWrap = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	p.Focus()
 	loadFile(t, p, path)
@@ -454,7 +463,7 @@ func TestRenderMarkdownToggle(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
 	cfg.RenderMarkdown = true
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	p.Focus()
 	loadFile(t, p, path)
@@ -492,7 +501,7 @@ func TestRenderMarkdownToggleNonMarkdownFile(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	p.Focus()
 	loadFile(t, p, path)
@@ -515,7 +524,7 @@ func TestScrollDown(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 10)
 	p.Focus()
 	loadFile(t, p, path)
@@ -542,7 +551,7 @@ func TestScrollUp(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 10)
 	p.Focus()
 	loadFile(t, p, path)
@@ -568,7 +577,7 @@ func TestScrollUpBoundsAtZero(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 10)
 	p.Focus()
 	loadFile(t, p, path)
@@ -589,7 +598,7 @@ func TestPageDown(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 10)
 	p.Focus()
 	loadFile(t, p, path)
@@ -615,7 +624,7 @@ func TestPageUp(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 10)
 	p.Focus()
 	loadFile(t, p, path)
@@ -645,7 +654,7 @@ func TestGotoTop(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 10)
 	p.Focus()
 	loadFile(t, p, path)
@@ -670,7 +679,7 @@ func TestGotoBottom(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 10)
 	p.Focus()
 	loadFile(t, p, path)
@@ -693,7 +702,7 @@ func TestScrollClampOnShortFile(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 20) // much taller than content
 	p.Focus()
 	loadFile(t, p, path)
@@ -707,7 +716,7 @@ func TestFileSelectedMsg(t *testing.T) {
 	dir := t.TempDir()
 	path := writeFile(t, dir, "test.txt", "hello")
 
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 
 	// F01: Update now returns a cmd for async file loading.
@@ -731,7 +740,7 @@ func TestFileSelectedMsgResetsState(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 10)
 	p.Focus()
 
@@ -747,7 +756,7 @@ func TestFileSelectedMsgResetsState(t *testing.T) {
 }
 
 func TestFocusBlur(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	assert.False(t, p.focused)
 
 	p.Focus()
@@ -758,14 +767,14 @@ func TestFocusBlur(t *testing.T) {
 }
 
 func TestSetSize(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 24)
 	assert.Equal(t, 80, p.width)
 	assert.Equal(t, 24, p.height)
 }
 
 func TestKeyBindings(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	bindings := p.KeyBindings()
 
 	assert.NotEmpty(t, bindings)
@@ -778,6 +787,7 @@ func TestKeyBindings(t *testing.T) {
 		assert.NotEmpty(t, b.Key)
 		assert.NotEmpty(t, b.Description)
 	}
+	assert.Contains(t, actions, "edit")
 	assert.Contains(t, actions, "scroll_down")
 	assert.Contains(t, actions, "scroll_up")
 	assert.Contains(t, actions, "page_down")
@@ -802,7 +812,7 @@ func TestKeysIgnoredWhenBlurred(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 10)
 	// Don't focus
 	loadFile(t, p, path)
@@ -813,7 +823,7 @@ func TestKeysIgnoredWhenBlurred(t *testing.T) {
 }
 
 func TestNonexistentFile(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	loadFile(t, p, "/nonexistent/path/file.txt")
 
@@ -828,7 +838,7 @@ func TestDirectory(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	loadFile(t, p, dir)
 
@@ -842,7 +852,7 @@ func TestEmptyFile(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	loadFile(t, p, path)
 
@@ -863,7 +873,7 @@ func TestScrollIndicator(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
 	cfg.LineNumbers = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 10)
 	p.Focus()
 	loadFile(t, p, path)
@@ -885,7 +895,7 @@ func TestScrollIndicator(t *testing.T) {
 }
 
 func TestUpdateReturnsPanel(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	result, cmd := p.Update(nil)
 	assert.Equal(t, p, result)
 	assert.Nil(t, cmd)
@@ -923,7 +933,7 @@ func TestIsTextMIME(t *testing.T) {
 }
 
 func TestViewportHeight(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 
 	// With normal height
 	p.height = 20
@@ -963,7 +973,7 @@ func TestRenderMarkdown_NoHashPrefixes(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestIssueSelectedMsg(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 
 	_, cmd := p.Update(panels.IssueSelectedMsg{
@@ -985,7 +995,7 @@ func TestIssueSelectedMsg(t *testing.T) {
 }
 
 func TestIssueSelectedMsg_EmptyBody(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 
 	p.Update(panels.IssueSelectedMsg{
@@ -999,7 +1009,7 @@ func TestIssueSelectedMsg_EmptyBody(t *testing.T) {
 }
 
 func TestIssueDeselectedMsg(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 
 	// Select an issue first.
@@ -1018,7 +1028,7 @@ func TestIssueDeselectedMsg_RestoresFile(t *testing.T) {
 	dir := t.TempDir()
 	path := writeFile(t, dir, "restore.txt", "file content")
 
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 
 	// Load a file first.
@@ -1040,7 +1050,7 @@ func TestIssueDeselectedMsg_RestoresFile(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPRSelectedMsg(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 
 	_, cmd := p.Update(panels.PRSelectedMsg{
@@ -1062,7 +1072,7 @@ func TestPRSelectedMsg(t *testing.T) {
 }
 
 func TestPRDeselectedMsg(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 
 	p.Update(panels.PRSelectedMsg{Number: 1, Title: "T", State: "open", HeadBranch: "b"})
@@ -1079,7 +1089,7 @@ func TestPRDeselectedMsg_RestoresFile(t *testing.T) {
 	dir := t.TempDir()
 	path := writeFile(t, dir, "file.txt", "content")
 
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 	loadFile(t, p, path)
 
@@ -1093,7 +1103,7 @@ func TestPRDeselectedMsg_RestoresFile(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestActionRunSelectedMsg(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 
 	_, cmd := p.Update(panels.ActionRunSelectedMsg{
@@ -1113,7 +1123,7 @@ func TestActionRunSelectedMsg(t *testing.T) {
 }
 
 func TestActionRunDeselectedMsg(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 
 	p.Update(panels.ActionRunSelectedMsg{RunID: 1, WorkflowName: "CI", Status: "completed"})
@@ -1130,7 +1140,7 @@ func TestActionRunDeselectedMsg_RestoresFile(t *testing.T) {
 	dir := t.TempDir()
 	path := writeFile(t, dir, "file.txt", "content")
 
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 	loadFile(t, p, path)
 
@@ -1275,7 +1285,7 @@ func TestRenderActionLog_Truncation(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRenderError(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 20)
 	p.filePath = "test.txt"
 	p.err = os.ErrNotExist
@@ -1289,7 +1299,7 @@ func TestRenderError(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestGitFilterActiveMsg(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	assert.False(t, p.gitDiffOnly)
 
 	_, cmd := p.Update(panels.GitFilterActiveMsg{Active: true})
@@ -1316,7 +1326,7 @@ func TestMouseWheelScrolling(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 10)
 	loadFile(t, p, path)
 
@@ -1342,7 +1352,7 @@ func TestDiffLinesRenderedInView(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
 	cfg.LineNumbers = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 	loadFile(t, p, path)
 
@@ -1367,7 +1377,7 @@ func TestGitDiffOnlyMode(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
 	cfg.LineNumbers = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 	loadFile(t, p, path)
 
@@ -1385,7 +1395,7 @@ func TestDiffLoadedMsg_WrongPath(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(80, 20)
 	loadFile(t, p, path)
 
@@ -1403,7 +1413,7 @@ func TestDiffLoadedMsg_WrongPath(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestActionJobsLoadedMsg(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 
 	jobs := []panels.ActionJob{
@@ -1419,7 +1429,7 @@ func TestActionJobsLoadedMsg(t *testing.T) {
 }
 
 func TestActionLogMsg(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 
 	// Put panel in ghMode first.
@@ -1439,7 +1449,7 @@ func TestActionLogMsg(t *testing.T) {
 }
 
 func TestActionLogMsg_NotInGhMode(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.ghMode = false
 
 	origContent := p.ghContent
@@ -1450,7 +1460,7 @@ func TestActionLogMsg_NotInGhMode(t *testing.T) {
 }
 
 func TestActionLogMsg_EmptyLog(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.ghMode = true
 	p.ghContent = "before"
 
@@ -1468,7 +1478,7 @@ func TestFileSelectedMsg_ClearsGhMode(t *testing.T) {
 	dir := t.TempDir()
 	path := writeFile(t, dir, "test.txt", "hello")
 
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 
 	// Enter ghMode via issue.
@@ -1497,7 +1507,7 @@ func TestPreviewScrollMsg(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.SyntaxHighlighting = false
-	p := New(cfg, nil)
+	p := New(cfg, defaultEditorCfg(), nil)
 	p.SetSize(60, 10)
 	loadFile(t, p, path)
 
@@ -1516,7 +1526,7 @@ func TestPreviewScrollMsg(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBlameLoadedMsg_Success(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.blameMode = true
 
 	blameLines := []git.BlameLine{
@@ -1531,7 +1541,7 @@ func TestBlameLoadedMsg_Success(t *testing.T) {
 }
 
 func TestBlameLoadedMsg_Error(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.blameMode = true
 
 	_, cmd := p.Update(panels.BlameLoadedMsg{Err: os.ErrNotExist})
@@ -1545,7 +1555,7 @@ func TestBlameLoadedMsg_Error(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLoadingStateRendering(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	p.loading = true
 
@@ -1558,7 +1568,7 @@ func TestLoadingStateRendering(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestGhModeViewRendering(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 
 	// Enter ghMode.
@@ -1597,7 +1607,7 @@ func TestFilePath_ReturnsCurrentPath(t *testing.T) {
 	dir := t.TempDir()
 	path := writeFile(t, dir, "file.go", "package main\n")
 
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 	loadFile(t, p, path)
 
@@ -1605,7 +1615,7 @@ func TestFilePath_ReturnsCurrentPath(t *testing.T) {
 }
 
 func TestFilePath_EmptyWhenNoFile(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(60, 20)
 
 	assert.Equal(t, "", p.FilePath())
@@ -1616,7 +1626,7 @@ func TestFilePath_EmptyWhenNoFile(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRepoChangedMsg_ClearsPreview(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.Init(context.Background())
 
 	// Set up some preview state.
@@ -1646,7 +1656,7 @@ func TestRepoChangedMsg_ClearsPreview(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestIssueSelectedMsg_ANSIInjection(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 	msg := panels.IssueSelectedMsg{
 		Number: 42,
@@ -1659,7 +1669,7 @@ func TestIssueSelectedMsg_ANSIInjection(t *testing.T) {
 }
 
 func TestPRSelectedMsg_ANSIInjection(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 	msg := panels.PRSelectedMsg{
 		Number:     99,
@@ -1677,7 +1687,7 @@ func TestPRSelectedMsg_ANSIInjection(t *testing.T) {
 }
 
 func TestActionRunSelectedMsg_ANSIInjection(t *testing.T) {
-	p := New(defaultCfg(), nil)
+	p := New(defaultCfg(), defaultEditorCfg(), nil)
 	p.SetSize(80, 30)
 	msg := panels.ActionRunSelectedMsg{
 		WorkflowName: "CI \x1b[2J\x1b[H",

--- a/internal/panels/preview/selection_test.go
+++ b/internal/panels/preview/selection_test.go
@@ -18,7 +18,7 @@ func newTestPreview(lines []string) *Preview {
 	p := New(config.PreviewConfig{
 		Enabled:     true,
 		MaxFileSize: 1048576,
-	}, nil)
+}, defaultEditorCfg(), nil)
 	p.lines = lines
 	p.width = 80
 	p.height = 24


### PR DESCRIPTION
Adds inline editing capability to the preview panel, allowing quick file edits without leaving the TUI.

**Changes:**
- Add editor mode toggle to preview panel
- Implement text buffer with insert/delete/cursor operations
- Editor rendering with cursor display and line numbers
- Integration with existing preview keybindings
- Comprehensive test coverage for buffer and editor