### PR TITLE
fix(pprof): add read/write timeouts to diagnostic HTTP server

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -283,7 +283,14 @@ Environment:
 				addr := "127.0.0.1:" + pprofPort
 				go func() {
 					slog.Info("pprof server starting", "addr", "http://"+addr+"/debug/pprof/")
-					if err := http.ListenAndServe(addr, nil); err != nil { //nolint:gosec // pprof is opt-in dev tool
+					srv := &http.Server{ //nolint:gosec // pprof is opt-in dev tool
+						Addr:              addr,
+						ReadHeaderTimeout: 10 * time.Second,
+						ReadTimeout:       30 * time.Second,
+						WriteTimeout:      60 * time.Second,
+						IdleTimeout:       120 * time.Second,
+					}
+					if err := srv.ListenAndServe(); err != nil {
 						slog.Error("pprof server failed", "err", err)
 					}
 				}()


### PR DESCRIPTION
## Summary

The pprof diagnostic HTTP server used **http.ListenAndServe** with the default
**http.Server** settings, which means no read or write timeouts. A malicious
local process could exhaust the server's connection pool via a slowloris-style
attack (CWE-400, CVSS 3.1 Low — requires local access).

## Changes

Replaced the bare **http.ListenAndServe** call with an explicit **http.Server**
that sets:

| Timeout | Value | Purpose |
|---|---|---|
| ReadHeaderTimeout | 10 s | Limits time to read request headers |
| ReadTimeout | 30 s | Limits total time to read the full request |
| WriteTimeout | 60 s | Limits time to write the response |
| IdleTimeout | 120 s | Limits how long idle keep-alive connections persist |

The server remains opt-in (requires **--pprof** flag) and bound to **127.0.0.1**.

## CWE Reference

- **CWE-400**: Uncontrolled Resource Consumption
- **Severity**: Low (localhost-only, opt-in diagnostic tool)
