### PR TITLE
test: coverage improvements for panels, panelreg, github, and gitinfo

### DIFF
--- a/internal/github/delete_branch_test.go
+++ b/internal/github/delete_branch_test.go
@@ -1,0 +1,126 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// DeleteBranch — 0% → tested
+// ---------------------------------------------------------------------------
+
+func TestClient_DeleteBranch_Success(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		branch string
+	}{
+		{name: "simple branch name", branch: "feature-x"},
+		{name: "slash in branch name", branch: "user/feature"},
+		{name: "long branch name", branch: "very-long-branch-name-with-many-parts"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var deletedRef string
+			client, _ := setupMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodDelete {
+					deletedRef = r.URL.Path
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+				http.NotFound(w, r)
+			})
+
+			err := client.DeleteBranch(context.Background(), "owner", "repo", tt.branch)
+			require.NoError(t, err)
+			assert.Equal(t, fmt.Sprintf("/repos/owner/repo/git/refs/heads/%s", tt.branch), deletedRef)
+		})
+	}
+}
+
+func TestClient_DeleteBranch_APIError(t *testing.T) {
+	t.Parallel()
+	client, _ := setupMockClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message": "Reference does not exist"}`))
+	})
+
+	err := client.DeleteBranch(context.Background(), "owner", "repo", "nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `delete branch "nonexistent"`)
+}
+
+// ---------------------------------------------------------------------------
+// GetJobLogs — redirect limit enforcement (too many redirects)
+// ---------------------------------------------------------------------------
+
+func TestClient_GetJobLogs_TooManyRedirects(t *testing.T) {
+	t.Parallel()
+
+	// Create a server that always redirects to itself, exceeding the 5-redirect limit.
+	redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, r.URL.String(), http.StatusFound)
+	}))
+	t.Cleanup(redirectServer.Close)
+
+	client, _ := setupMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/actions/jobs/42/logs" {
+			// Redirect to the infinite-redirect server (uses HTTPS scheme to pass scheme check).
+			http.Redirect(w, r, redirectServer.URL+"/logs", http.StatusFound)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	_, err := client.GetJobLogs(context.Background(), "owner", "repo", 42)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch job 42 logs")
+}
+
+// ---------------------------------------------------------------------------
+// GetJobLogs — successful fetch and caching
+// ---------------------------------------------------------------------------
+
+func TestClient_GetJobLogs_SuccessfulFetchIsCached(t *testing.T) {
+	t.Parallel()
+	const logContent = "2024-01-01 build succeeded\n"
+
+	logsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(logContent))
+	}))
+	t.Cleanup(logsServer.Close)
+
+	callCount := 0
+	client, _ := setupMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/actions/jobs/55/logs" {
+			callCount++
+			http.Redirect(w, r, logsServer.URL+"/logs.txt", http.StatusFound)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	ctx := context.Background()
+
+	// First call fetches from API.
+	logs, err := client.GetJobLogs(ctx, "owner", "repo", 55)
+	require.NoError(t, err)
+	assert.Equal(t, logContent, logs)
+	assert.Equal(t, 1, callCount)
+
+	// Second call should hit cache.
+	logs2, err := client.GetJobLogs(ctx, "owner", "repo", 55)
+	require.NoError(t, err)
+	assert.Equal(t, logContent, logs2)
+	assert.Equal(t, 1, callCount, "should not call API again due to cache")
+}

--- a/internal/panels/gitinfo/handle_pages_test.go
+++ b/internal/panels/gitinfo/handle_pages_test.go
@@ -1,0 +1,555 @@
+package gitinfo
+
+import (
+	"testing"
+
+	ghclient "github.com/jongio/grut/internal/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// handleMetaLoaded — sets user and repoPrivate
+// ---------------------------------------------------------------------------
+
+func TestHandleMetaLoaded(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		msg         ghMetaLoadedMsg
+		wantUser    string
+		wantPrivate bool
+	}{
+		{
+			name:        "sets user and private flag",
+			msg:         ghMetaLoadedMsg{user: "octocat", repoPrivate: true},
+			wantUser:    "octocat",
+			wantPrivate: true,
+		},
+		{
+			name:        "empty user leaves field unchanged",
+			msg:         ghMetaLoadedMsg{user: "", repoPrivate: false},
+			wantUser:    "pre-existing",
+			wantPrivate: false,
+		},
+		{
+			name:        "sets public repo",
+			msg:         ghMetaLoadedMsg{user: "bob", repoPrivate: false},
+			wantUser:    "bob",
+			wantPrivate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := newTestPanel(defaultMock())
+			p.gh.user = "pre-existing"
+
+			result, cmd := p.handleMetaLoaded(tt.msg)
+			assert.Nil(t, cmd)
+			panel := result.(*Panel)
+			assert.Equal(t, tt.wantUser, panel.gh.user)
+			assert.Equal(t, tt.wantPrivate, panel.gh.repoPrivate)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleIssuesPage — pagination, replace vs append, max cap
+// ---------------------------------------------------------------------------
+
+func TestHandleIssuesPage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		existing       []ghIssueItem
+		msg            ghIssuesPageMsg
+		wantCount      int
+		wantAllLoaded  bool
+		wantNextPage   int
+		wantFirstTitle string
+	}{
+		{
+			name:     "replace mode sets items directly",
+			existing: []ghIssueItem{{Number: 99, Title: "old"}},
+			msg: ghIssuesPageMsg{
+				issues:   []ghIssueItem{{Number: 1, Title: "new"}},
+				nextPage: 2,
+				replace:  true,
+			},
+			wantCount:      1,
+			wantNextPage:   2,
+			wantAllLoaded:  false,
+			wantFirstTitle: "new",
+		},
+		{
+			name:     "append mode adds to existing",
+			existing: []ghIssueItem{{Number: 1, Title: "first"}},
+			msg: ghIssuesPageMsg{
+				issues:   []ghIssueItem{{Number: 2, Title: "second"}},
+				nextPage: 3,
+				replace:  false,
+			},
+			wantCount:      2,
+			wantNextPage:   3,
+			wantAllLoaded:  false,
+			wantFirstTitle: "first",
+		},
+		{
+			name:     "nextPage zero marks all loaded",
+			existing: nil,
+			msg: ghIssuesPageMsg{
+				issues:   []ghIssueItem{{Number: 5, Title: "last"}},
+				nextPage: 0,
+				replace:  true,
+			},
+			wantCount:      1,
+			wantNextPage:   0,
+			wantAllLoaded:  true,
+			wantFirstTitle: "last",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := newTestPanel(defaultMock())
+			p.gh.allIssues = tt.existing
+			p.tabPaging[tabIssues] = tabPagination{loading: true}
+
+			result, cmd := p.handleIssuesPage(tt.msg)
+			assert.Nil(t, cmd)
+			panel := result.(*Panel)
+
+			assert.Equal(t, tt.wantCount, len(panel.gh.allIssues))
+			assert.Equal(t, tt.wantAllLoaded, panel.tabPaging[tabIssues].allLoaded)
+			assert.Equal(t, tt.wantNextPage, panel.tabPaging[tabIssues].nextPage)
+			assert.False(t, panel.tabPaging[tabIssues].loading, "loading should be cleared")
+			if tt.wantCount > 0 {
+				assert.Equal(t, tt.wantFirstTitle, panel.gh.allIssues[0].Title)
+			}
+		})
+	}
+}
+
+func TestHandleIssuesPage_MaxCapEnforced(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(defaultMock())
+
+	// Pre-populate with MaxPaginationItems-1 issues.
+	existing := make([]ghIssueItem, ghclient.MaxPaginationItems-1)
+	for i := range existing {
+		existing[i] = ghIssueItem{Number: i, Title: "existing"}
+	}
+	p.gh.allIssues = existing
+
+	// Append 5 more (would exceed MaxPaginationItems).
+	msg := ghIssuesPageMsg{
+		issues:   []ghIssueItem{{Number: 9001}, {Number: 9002}, {Number: 9003}, {Number: 9004}, {Number: 9005}},
+		nextPage: 5,
+		replace:  false,
+	}
+
+	result, _ := p.handleIssuesPage(msg)
+	panel := result.(*Panel)
+	assert.Equal(t, ghclient.MaxPaginationItems, len(panel.gh.allIssues))
+	assert.True(t, panel.tabPaging[tabIssues].allLoaded, "should mark all loaded when capped")
+}
+
+// ---------------------------------------------------------------------------
+// handlePRsPage — pagination, replace vs append, max cap
+// ---------------------------------------------------------------------------
+
+func TestHandlePRsPage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		existing      []ghPRItem
+		msg           ghPRsPageMsg
+		wantCount     int
+		wantAllLoaded bool
+		wantNextPage  int
+	}{
+		{
+			name:     "replace mode sets PRs directly",
+			existing: []ghPRItem{{Number: 10, Title: "stale"}},
+			msg: ghPRsPageMsg{
+				prs:      []ghPRItem{{Number: 1, Title: "new-pr"}},
+				nextPage: 2,
+				replace:  true,
+			},
+			wantCount:     1,
+			wantNextPage:  2,
+			wantAllLoaded: false,
+		},
+		{
+			name:     "append mode adds to existing PRs",
+			existing: []ghPRItem{{Number: 1, Title: "first-pr"}},
+			msg: ghPRsPageMsg{
+				prs:      []ghPRItem{{Number: 2, Title: "second-pr"}},
+				nextPage: 3,
+				replace:  false,
+			},
+			wantCount:     2,
+			wantNextPage:  3,
+			wantAllLoaded: false,
+		},
+		{
+			name:     "nextPage zero marks all loaded",
+			existing: nil,
+			msg: ghPRsPageMsg{
+				prs:      []ghPRItem{{Number: 7, Title: "final"}},
+				nextPage: 0,
+				replace:  true,
+			},
+			wantCount:     1,
+			wantNextPage:  0,
+			wantAllLoaded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := newTestPanel(defaultMock())
+			p.gh.allPRs = tt.existing
+			p.tabPaging[tabPRs] = tabPagination{loading: true}
+
+			result, cmd := p.handlePRsPage(tt.msg)
+			assert.Nil(t, cmd)
+			panel := result.(*Panel)
+
+			assert.Equal(t, tt.wantCount, len(panel.gh.allPRs))
+			assert.Equal(t, tt.wantAllLoaded, panel.tabPaging[tabPRs].allLoaded)
+			assert.Equal(t, tt.wantNextPage, panel.tabPaging[tabPRs].nextPage)
+			assert.False(t, panel.tabPaging[tabPRs].loading)
+		})
+	}
+}
+
+func TestHandlePRsPage_MaxCapEnforced(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(defaultMock())
+
+	existing := make([]ghPRItem, ghclient.MaxPaginationItems-1)
+	for i := range existing {
+		existing[i] = ghPRItem{Number: i, Title: "existing-pr"}
+	}
+	p.gh.allPRs = existing
+
+	msg := ghPRsPageMsg{
+		prs:      []ghPRItem{{Number: 9001}, {Number: 9002}, {Number: 9003}},
+		nextPage: 4,
+		replace:  false,
+	}
+
+	result, _ := p.handlePRsPage(msg)
+	panel := result.(*Panel)
+	assert.Equal(t, ghclient.MaxPaginationItems, len(panel.gh.allPRs))
+	assert.True(t, panel.tabPaging[tabPRs].allLoaded)
+}
+
+// ---------------------------------------------------------------------------
+// handleActionsPage — pagination, replace vs append, watching state
+// ---------------------------------------------------------------------------
+
+func TestHandleActionsPage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		msg             ghActionsPageMsg
+		wantItemCount   int
+		wantNextPage    int
+		wantAllLoaded   bool
+		wantWatching    bool
+		existingActions []listItem
+	}{
+		{
+			name: "replace mode clears existing actions",
+			msg: ghActionsPageMsg{
+				actions:  []ghActionItem{{RunID: 1, WorkflowName: "CI", Status: "completed"}},
+				nextPage: 2,
+				replace:  true,
+			},
+			existingActions: []listItem{{kind: kindActionRun, actionRun: ghActionItem{RunID: 99}}},
+			wantItemCount:   1,
+			wantNextPage:    2,
+			wantAllLoaded:   false,
+			wantWatching:    false,
+		},
+		{
+			name: "append mode adds to existing",
+			msg: ghActionsPageMsg{
+				actions:  []ghActionItem{{RunID: 2, WorkflowName: "Deploy", Status: "completed"}},
+				nextPage: 3,
+				replace:  false,
+			},
+			existingActions: []listItem{{kind: kindActionRun, actionRun: ghActionItem{RunID: 1}}},
+			wantItemCount:   2,
+			wantNextPage:    3,
+			wantAllLoaded:   false,
+			wantWatching:    false,
+		},
+		{
+			name: "in-progress run enables watching",
+			msg: ghActionsPageMsg{
+				actions:  []ghActionItem{{RunID: 3, Status: statusInProgress}},
+				nextPage: 0,
+				replace:  true,
+			},
+			wantItemCount: 1,
+			wantNextPage:  0,
+			wantAllLoaded: true,
+			wantWatching:  true,
+		},
+		{
+			name: "queued run enables watching",
+			msg: ghActionsPageMsg{
+				actions:  []ghActionItem{{RunID: 4, Status: statusQueued}},
+				nextPage: 0,
+				replace:  true,
+			},
+			wantItemCount: 1,
+			wantNextPage:  0,
+			wantAllLoaded: true,
+			wantWatching:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := newTestPanel(defaultMock())
+			p.tabItems[tabActions] = tt.existingActions
+			p.tabPaging[tabActions] = tabPagination{loading: true}
+
+			result, _ := p.handleActionsPage(tt.msg)
+			panel := result.(*Panel)
+
+			assert.Equal(t, tt.wantItemCount, len(panel.tabItems[tabActions]))
+			assert.Equal(t, tt.wantNextPage, panel.tabPaging[tabActions].nextPage)
+			assert.Equal(t, tt.wantAllLoaded, panel.tabPaging[tabActions].allLoaded)
+			assert.False(t, panel.tabPaging[tabActions].loading)
+			assert.Equal(t, tt.wantWatching, panel.actionsWatching)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleWorkflowsPage — pagination and replace
+// ---------------------------------------------------------------------------
+
+func TestHandleWorkflowsPage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		msg           ghWorkflowsPageMsg
+		existing      []listItem
+		wantCount     int
+		wantAllLoaded bool
+	}{
+		{
+			name: "replace mode clears existing",
+			msg: ghWorkflowsPageMsg{
+				workflows: []ghWorkflowItem{{Name: "CI", ID: 1}},
+				nextPage:  2,
+				replace:   true,
+			},
+			existing:      []listItem{{kind: kindWorkflow, workflow: ghWorkflowItem{Name: "old"}}},
+			wantCount:     1,
+			wantAllLoaded: false,
+		},
+		{
+			name: "append mode adds to existing",
+			msg: ghWorkflowsPageMsg{
+				workflows: []ghWorkflowItem{{Name: "Deploy", ID: 2}},
+				nextPage:  3,
+				replace:   false,
+			},
+			existing:      []listItem{{kind: kindWorkflow, workflow: ghWorkflowItem{Name: "CI"}}},
+			wantCount:     2,
+			wantAllLoaded: false,
+		},
+		{
+			name: "nextPage zero marks all loaded",
+			msg: ghWorkflowsPageMsg{
+				workflows: []ghWorkflowItem{{Name: "Lint", ID: 3}},
+				nextPage:  0,
+				replace:   true,
+			},
+			wantCount:     1,
+			wantAllLoaded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := newTestPanel(defaultMock())
+			p.tabItems[tabWorkflows] = tt.existing
+			p.tabPaging[tabWorkflows] = tabPagination{loading: true}
+
+			result, cmd := p.handleWorkflowsPage(tt.msg)
+			assert.Nil(t, cmd)
+			panel := result.(*Panel)
+
+			assert.Equal(t, tt.wantCount, len(panel.tabItems[tabWorkflows]))
+			assert.Equal(t, tt.wantAllLoaded, panel.tabPaging[tabWorkflows].allLoaded)
+			assert.False(t, panel.tabPaging[tabWorkflows].loading)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleReleasesPage — pagination and replace
+// ---------------------------------------------------------------------------
+
+func TestHandleReleasesPage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		msg           ghReleasesPageMsg
+		existing      []listItem
+		wantCount     int
+		wantAllLoaded bool
+	}{
+		{
+			name: "replace mode clears existing",
+			msg: ghReleasesPageMsg{
+				releases: []ghReleaseItem{{TagName: "v1.0", ID: 1}},
+				nextPage: 2,
+				replace:  true,
+			},
+			existing:      []listItem{{kind: kindRelease, release: ghReleaseItem{TagName: "v0.9"}}},
+			wantCount:     1,
+			wantAllLoaded: false,
+		},
+		{
+			name: "append mode adds to existing",
+			msg: ghReleasesPageMsg{
+				releases: []ghReleaseItem{{TagName: "v1.1", ID: 2}},
+				nextPage: 3,
+				replace:  false,
+			},
+			existing:      []listItem{{kind: kindRelease, release: ghReleaseItem{TagName: "v1.0"}}},
+			wantCount:     2,
+			wantAllLoaded: false,
+		},
+		{
+			name: "nextPage zero marks all loaded",
+			msg: ghReleasesPageMsg{
+				releases: []ghReleaseItem{{TagName: "v2.0", ID: 3}},
+				nextPage: 0,
+				replace:  true,
+			},
+			wantCount:     1,
+			wantAllLoaded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := newTestPanel(defaultMock())
+			p.tabItems[tabReleases] = tt.existing
+			p.tabPaging[tabReleases] = tabPagination{loading: true}
+
+			result, cmd := p.handleReleasesPage(tt.msg)
+			assert.Nil(t, cmd)
+			panel := result.(*Panel)
+
+			assert.Equal(t, tt.wantCount, len(panel.tabItems[tabReleases]))
+			assert.Equal(t, tt.wantAllLoaded, panel.tabPaging[tabReleases].allLoaded)
+			assert.False(t, panel.tabPaging[tabReleases].loading)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleActionsPage — cursor/offset reset on replace
+// ---------------------------------------------------------------------------
+
+func TestHandleActionsPage_ResetsCursorOnReplace(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(defaultMock())
+	p.tabCursor[tabActions] = 5
+	p.tabOffset[tabActions] = 3
+
+	msg := ghActionsPageMsg{
+		actions: []ghActionItem{{RunID: 1, Status: "completed"}},
+		replace: true,
+	}
+	result, _ := p.handleActionsPage(msg)
+	panel := result.(*Panel)
+
+	assert.Equal(t, 0, panel.tabCursor[tabActions])
+	assert.Equal(t, 0, panel.tabOffset[tabActions])
+}
+
+func TestHandleWorkflowsPage_ResetsCursorOnReplace(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(defaultMock())
+	p.tabCursor[tabWorkflows] = 4
+	p.tabOffset[tabWorkflows] = 2
+
+	msg := ghWorkflowsPageMsg{
+		workflows: []ghWorkflowItem{{Name: "CI", ID: 1}},
+		replace:   true,
+	}
+	result, _ := p.handleWorkflowsPage(msg)
+	panel := result.(*Panel)
+
+	assert.Equal(t, 0, panel.tabCursor[tabWorkflows])
+	assert.Equal(t, 0, panel.tabOffset[tabWorkflows])
+}
+
+func TestHandleReleasesPage_ResetsCursorOnReplace(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(defaultMock())
+	p.tabCursor[tabReleases] = 3
+	p.tabOffset[tabReleases] = 1
+
+	msg := ghReleasesPageMsg{
+		releases: []ghReleaseItem{{TagName: "v1.0", ID: 1}},
+		replace:  true,
+	}
+	result, _ := p.handleReleasesPage(msg)
+	panel := result.(*Panel)
+
+	assert.Equal(t, 0, panel.tabCursor[tabReleases])
+	assert.Equal(t, 0, panel.tabOffset[tabReleases])
+}
+
+// ---------------------------------------------------------------------------
+// handleIssuesPage — preserves cursor/offset on append
+// ---------------------------------------------------------------------------
+
+func TestHandleIssuesPage_PreservesCursorOnAppend(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(defaultMock())
+	p.gh.allIssues = []ghIssueItem{{Number: 1, Title: "first"}}
+	p.tabCursor[tabIssues] = 0
+	p.tabOffset[tabIssues] = 0
+
+	// Set cursor position before append
+	p.tabCursor[tabIssues] = 0
+	p.tabOffset[tabIssues] = 0
+
+	msg := ghIssuesPageMsg{
+		issues:   []ghIssueItem{{Number: 2, Title: "second"}},
+		nextPage: 3,
+		replace:  false,
+	}
+
+	result, _ := p.handleIssuesPage(msg)
+	panel := result.(*Panel)
+	require.Equal(t, 2, len(panel.gh.allIssues))
+	assert.Equal(t, 0, panel.tabCursor[tabIssues], "cursor should be preserved on append")
+}

--- a/internal/panels/open_placeholder_test.go
+++ b/internal/panels/open_placeholder_test.go
@@ -1,0 +1,210 @@
+package panels
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jongio/grut/internal/theme"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// OpenInBrowser — validation rejection paths
+// ---------------------------------------------------------------------------
+
+func TestOpenInBrowser_RejectsInvalidURLs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		url     string
+		wantErr string
+	}{
+		{
+			name:    "empty URL",
+			url:     "",
+			wantErr: "browser URL must not be empty",
+		},
+		{
+			name:    "javascript scheme",
+			url:     "javascript:alert(1)",
+			wantErr: "not allowed",
+		},
+		{
+			name:    "data scheme",
+			url:     "data:text/html,<h1>hi</h1>",
+			wantErr: "not allowed",
+		},
+		{
+			name:    "file scheme",
+			url:     "file:///etc/passwd",
+			wantErr: "not allowed",
+		},
+		{
+			name:    "no scheme",
+			url:     "example.com/path",
+			wantErr: "no scheme",
+		},
+		{
+			name:    "credentials in URL",
+			url:     "https://user:pass@evil.com",
+			wantErr: "must not contain credentials",
+		},
+		{
+			name:    "null byte",
+			url:     "https://example.com/\x00path",
+			wantErr: "null byte",
+		},
+		{
+			name:    "ftp scheme",
+			url:     "ftp://files.example.com/data",
+			wantErr: "not allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := OpenInBrowser(context.Background(), tt.url)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OpenInTerminal — validation rejection paths
+// ---------------------------------------------------------------------------
+
+func TestOpenInTerminal_RejectsInvalidPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dir     string
+		wantErr string
+	}{
+		{
+			name:    "empty path",
+			dir:     "",
+			wantErr: "editor path must not be empty",
+		},
+		{
+			name:    "null byte in path",
+			dir:     "/tmp/\x00evil",
+			wantErr: "null byte",
+		},
+		{
+			name:    "semicolon injection",
+			dir:     "/tmp/dir;rm -rf /",
+			wantErr: "forbidden character",
+		},
+		{
+			name:    "pipe character",
+			dir:     "/tmp/dir|cat /etc/passwd",
+			wantErr: "forbidden character",
+		},
+		{
+			name:    "backtick injection",
+			dir:     "/tmp/`whoami`",
+			wantErr: "forbidden character",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := OpenInTerminal(context.Background(), tt.dir)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// colorFallback — theme-aware color resolution
+// ---------------------------------------------------------------------------
+
+func TestColorFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		th       *theme.Theme
+		getter   func(theme.Colors) string
+		fallback string
+		wantNil  bool // if true, verify returned color is non-nil (lipgloss.Color always returns non-nil)
+	}{
+		{
+			name:     "nil theme uses fallback",
+			th:       nil,
+			getter:   func(c theme.Colors) string { return c.BrightBlack },
+			fallback: "#aabbcc",
+		},
+		{
+			name:     "theme with empty value uses fallback",
+			th:       &theme.Theme{Colors: theme.Colors{BrightBlack: ""}},
+			getter:   func(c theme.Colors) string { return c.BrightBlack },
+			fallback: "#112233",
+		},
+		{
+			name:     "theme with value uses theme color",
+			th:       &theme.Theme{Colors: theme.Colors{BrightBlack: "#ff0000"}},
+			getter:   func(c theme.Colors) string { return c.BrightBlack },
+			fallback: "#000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := colorFallback(tt.th, tt.getter, tt.fallback)
+			assert.NotNil(t, result)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Placeholder — View with zero/negative dimensions
+// ---------------------------------------------------------------------------
+
+func TestPlaceholder_View_ZeroDimensions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		width  int
+		height int
+		want   string
+	}{
+		{name: "zero width", width: 0, height: 10, want: ""},
+		{name: "zero height", width: 10, height: 0, want: ""},
+		{name: "negative width", width: -1, height: 10, want: ""},
+		{name: "negative height", width: 10, height: -1, want: ""},
+		{name: "both zero", width: 0, height: 0, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := NewPlaceholder("test", nil)
+			assert.Equal(t, tt.want, p.View(tt.width, tt.height))
+		})
+	}
+}
+
+func TestPlaceholder_View_Focused(t *testing.T) {
+	t.Parallel()
+	p := NewPlaceholder("Preview", nil)
+	p.Focus()
+	view := p.View(40, 5)
+	assert.Contains(t, view, "Preview")
+}
+
+func TestPlaceholder_View_Unfocused(t *testing.T) {
+	t.Parallel()
+	p := NewPlaceholder("Status", nil)
+	p.Blur()
+	view := p.View(40, 5)
+	assert.Contains(t, view, "Status")
+}


### PR DESCRIPTION
## Summary

Adds targeted tests for coverage gaps identified in issues #154, #155, #156, and #157.

### Changes

**internal/panels/gitinfo/handle_pages_test.go** - Table-driven tests for all page handler methods:
- \handleMetaLoaded\ - user/private flag assignment
- \handleIssuesPage\ - replace vs append, nextPage=0 marks allLoaded, MaxPaginationItems cap, cursor preservation
- \handlePRsPage\ - same pagination patterns + max cap enforcement
- \handleActionsPage\ - replace/append, watching state transitions (in_progress/queued enables watching)
- \handleWorkflowsPage\ - replace/append, cursor reset on replace
- \handleReleasesPage\ - replace/append, cursor reset on replace

**internal/github/delete_branch_test.go** - Tests for previously untested API methods:
- \DeleteBranch\ - success with various branch name patterns, API error wrapping
- \GetJobLogs\ - redirect limit enforcement (too many redirects), successful fetch caching

**internal/panels/open_placeholder_test.go** - Validation and edge case coverage:
- \OpenInBrowser\ - rejects dangerous schemes (javascript, data, file, ftp), credentials, null bytes
- \OpenInTerminal\ - rejects empty paths, null bytes, shell metacharacters
- \colorFallback\ - nil theme, empty theme value, themed value resolution
- \Placeholder.View\ - zero/negative dimensions, focused/unfocused rendering

Fixes #154
Fixes #155
Fixes #156
Fixes #157