### PR TITLE
fix(editor): add clipboard timeout and remove splitLines duplication

### DIFF
--- a/internal/panels/preview/buffer.go
+++ b/internal/panels/preview/buffer.go
@@ -2,6 +2,7 @@ package preview
 
 import (
 	"slices"
+	"strings"
 	"time"
 )
 
@@ -307,7 +308,7 @@ func (b *TextBuffer) InsertText(line, col int, text string) (newLine, newCol int
 	after := string(runes[col:])
 
 	// Split the inserted text on newlines.
-	parts := splitLines(text)
+	parts := strings.Split(text, "\n")
 
 	if len(parts) == 1 {
 		// Single-line insert.
@@ -430,21 +431,6 @@ func (b *TextBuffer) clampCol(line, col int) int {
 		return n
 	}
 	return col
-}
-
-// splitLines splits text on "\n" boundaries. A trailing newline produces an
-// extra empty element (matching strings.Split semantics).
-func splitLines(text string) []string {
-	result := []string{}
-	start := 0
-	for i := 0; i < len(text); i++ {
-		if text[i] == '\n' {
-			result = append(result, text[start:i])
-			start = i + 1
-		}
-	}
-	result = append(result, text[start:])
-	return result
 }
 
 // leadingWhitespace returns the leading spaces and tabs from s.

--- a/internal/panels/preview/editor.go
+++ b/internal/panels/preview/editor.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -19,6 +20,9 @@ import (
 // Key name constants for KeyPressMsg.String() comparisons.
 const (
 	keyDown = "down"
+
+	// clipboardTimeout bounds how long clipboard subprocess calls may block.
+	clipboardTimeout = 2 * time.Second
 )
 
 // fileSavedMsg is sent after a successful file save from edit mode.
@@ -394,7 +398,9 @@ func handleEditKeyPress(p *Preview, msg tea.KeyPressMsg) (panels.Panel, tea.Cmd)
 			}
 			if text != "" {
 				return p, func() tea.Msg {
-					err := panels.CopyToClipboard(context.Background(), text)
+					ctx, cancel := context.WithTimeout(context.Background(), clipboardTimeout)
+					defer cancel()
+					err := panels.CopyToClipboard(ctx, text)
 					return clipboardCopiedMsg{text: text, err: err}
 				}
 			}
@@ -421,7 +427,9 @@ func handleEditKeyPress(p *Preview, msg tea.KeyPressMsg) (panels.Panel, tea.Cmd)
 			}
 			if text != "" {
 				return p, func() tea.Msg {
-					err := panels.CopyToClipboard(context.Background(), text)
+					ctx, cancel := context.WithTimeout(context.Background(), clipboardTimeout)
+					defer cancel()
+					err := panels.CopyToClipboard(ctx, text)
 					return clipboardCopiedMsg{text: text, err: err}
 				}
 			}
@@ -430,7 +438,9 @@ func handleEditKeyPress(p *Preview, msg tea.KeyPressMsg) (panels.Panel, tea.Cmd)
 	case "ctrl+v":
 		if p.editBuf != nil {
 			return p, func() tea.Msg {
-				text, err := panels.PasteFromClipboard(context.Background())
+				ctx, cancel := context.WithTimeout(context.Background(), clipboardTimeout)
+				defer cancel()
+				text, err := panels.PasteFromClipboard(ctx)
 				return clipboardPastedMsg{text: text, err: err}
 			}
 		}


### PR DESCRIPTION
## Summary

Addresses #163: two cleanup items from the inline editor PR review.

### Changes

**1. Add 2-second timeout to clipboard operations (MEDIUM)**

All three clipboard calls (copy, cut, paste) now use context.WithTimeout instead of context.Background(). This prevents goroutine leaks when PowerShell clipboard commands hang on headless or remote sessions. The timeout value is extracted into a named clipboardTimeout constant.

**2. Remove splitLines duplication (LOW)**

Replaced the custom splitLines function with strings.Split(text, "\n") which has identical semantics. This removes 13 lines of unnecessary code.

### Testing

All existing tests pass (go test ./...), go vet is clean, and mage install deployed successfully.

Closes #163
