### PR TITLE
fix(update): remove dev build guard from grut update

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -60,7 +60,6 @@ var (
 	downloadBaseURL = "https://github.com/jongio/grut/releases/download"
 
 	// Sentinel errors for testable error checking via errors.Is().
-	ErrDevBuild           = errors.New("cannot update a development build")
 	ErrTooManyRedirects   = errors.New("too many redirects")
 	ErrPayloadTooLarge    = errors.New("payload exceeds size limit")
 	ErrUnsafeArchivePath  = errors.New("unsafe archive entry path")
@@ -135,10 +134,6 @@ func matchArchiveTarget(name, target string) (bool, error) {
 // RunUpdate downloads and installs the latest version of grut. It
 // prints progress to stderr and returns an error on failure.
 func RunUpdate(ctx context.Context, currentVersion string) error {
-	if isDevVersion(currentVersion) {
-		return fmt.Errorf("%w — install a release build first", ErrDevBuild)
-	}
-
 	// Acquire an exclusive lock to prevent concurrent updates.
 	configDir, err := os.UserConfigDir()
 	if err != nil {

--- a/internal/update/update_extra_test.go
+++ b/internal/update/update_extra_test.go
@@ -15,20 +15,6 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// RunUpdate — additional error paths
-// ---------------------------------------------------------------------------
-
-func TestRunUpdate_DevPrefix(t *testing.T) {
-	err := RunUpdate(context.Background(), "dev-abc123")
-	if err == nil {
-		t.Fatal("expected error for dev-prefixed version")
-	}
-	if !errors.Is(err, ErrDevBuild) {
-		t.Errorf("error should wrap ErrDevBuild, got: %v", err)
-	}
-}
-
-// ---------------------------------------------------------------------------
 // downloadAsset — redirect handling edge cases
 // ---------------------------------------------------------------------------
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -354,13 +354,6 @@ func TestCopyFile_MissingSrc(t *testing.T) {
 // RunUpdate edge cases
 // ---------------------------------------------------------------------------
 
-func TestRunUpdate_DevVersion(t *testing.T) {
-	err := RunUpdate(context.Background(), "dev")
-	if err == nil {
-		t.Fatal("expected error for dev version")
-	}
-}
-
 func TestReplaceUnix(t *testing.T) {
 	tmpDir := t.TempDir()
 	exePath := filepath.Join(tmpDir, "grut")


### PR DESCRIPTION
## Summary

Removes the dev build guard from `grut update` so it works regardless of build type.

Previously, running `grut update` on a dev build (e.g. from `mage install`) would refuse with:
`
Error: update: cannot update a development build — install a release build first
`

This was overly restrictive. Dev builds and release builds are separate concerns: a user running a dev build should still be able to update to the latest release when desired.

### Changes

- Removed the `isDevVersion` check from `RunUpdate`
- Removed the unused `ErrDevBuild` sentinel error
- Removed the corresponding test (`TestRunUpdate_DevPrefix`)

The passive `CheckForUpdate` background notification still skips dev builds (no "update available" toast), which remains appropriate.

### Testing

All tests pass (`go test ./...`), `mage install` deployed successfully.
