### PR TITLE
Add fuzzy finder source prefixes

### DIFF
--- a/internal/overlayreg/overlayreg.go
+++ b/internal/overlayreg/overlayreg.go
@@ -63,19 +63,18 @@ func (f *Factory) NewSettingsPanel(
 // Supported modes: "files", "commands", "directories".
 // The bindings parameter is used for the "commands" mode source.
 func (f *Factory) NewFuzzyFinder(mode string, bindings []keymap.Binding) panels.Panel {
-	var sources []fuzzyfinder.Source
-	defaultCategories := []string{fuzzyfinder.DefaultCategoryFile()}
 	cwd, err := os.Getwd()
 	if err != nil {
 		cwd = "."
 	}
-	sources = append(sources,
+	sources := []fuzzyfinder.Source{
 		fuzzyfinder.NewFileSource(cwd),
 		fuzzyfinder.NewDirectorySource(cwd, fuzzyfinder.DefaultDirectorySourceMaxDepth),
 		fuzzyfinder.NewCommandSource(bindings),
 		fuzzyfinder.NewBookmarkSource(f.bookmarkMgr),
 		fuzzyfinder.NewGitChangedSource(cwd),
-	)
+	}
+	defaultCategories := []string{fuzzyfinder.DefaultCategoryFile()}
 	switch mode {
 	case "files":
 		defaultCategories = []string{fuzzyfinder.DefaultCategoryFile()}

--- a/internal/overlayreg/overlayreg.go
+++ b/internal/overlayreg/overlayreg.go
@@ -64,21 +64,25 @@ func (f *Factory) NewSettingsPanel(
 // The bindings parameter is used for the "commands" mode source.
 func (f *Factory) NewFuzzyFinder(mode string, bindings []keymap.Binding) panels.Panel {
 	var sources []fuzzyfinder.Source
+	defaultCategories := []string{fuzzyfinder.DefaultCategoryFile()}
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "."
+	}
+	sources = append(sources,
+		fuzzyfinder.NewFileSource(cwd),
+		fuzzyfinder.NewDirectorySource(cwd, fuzzyfinder.DefaultDirectorySourceMaxDepth),
+		fuzzyfinder.NewCommandSource(bindings),
+		fuzzyfinder.NewBookmarkSource(f.bookmarkMgr),
+		fuzzyfinder.NewGitChangedSource(cwd),
+	)
 	switch mode {
 	case "files":
-		cwd, err := os.Getwd()
-		if err != nil {
-			cwd = "."
-		}
-		sources = append(sources, fuzzyfinder.NewFileSource(cwd))
+		defaultCategories = []string{fuzzyfinder.DefaultCategoryFile()}
 	case "commands":
-		sources = append(sources, fuzzyfinder.NewCommandSource(bindings))
+		defaultCategories = []string{fuzzyfinder.DefaultCategoryCommand()}
 	case "directories":
-		cwd, err := os.Getwd()
-		if err != nil {
-			cwd = "."
-		}
-		sources = append(sources, fuzzyfinder.NewDirectorySource(cwd, fuzzyfinder.DefaultDirectorySourceMaxDepth))
+		defaultCategories = []string{fuzzyfinder.DefaultCategoryDirectory()}
 	}
-	return fuzzyfinder.New(f.theme, sources...)
+	return fuzzyfinder.NewWithDefaultCategories(f.theme, defaultCategories, sources...)
 }

--- a/internal/panels/fuzzyfinder/constants.go
+++ b/internal/panels/fuzzyfinder/constants.go
@@ -10,6 +10,15 @@ const (
 	dirGit             = ".git"
 )
 
+// Source names, returned by Source.Name and used as prefix labels.
+const (
+	sourceNameFiles       = "files"
+	sourceNameDirectories = "directories"
+	sourceNameCommands    = "commands"
+	sourceNameBookmarks   = "bookmarks"
+	sourceNameGitChanged  = "git changed"
+)
+
 // DefaultCategoryFile returns the file category name for overlay factories.
 func DefaultCategoryFile() string { return categoryFile }
 

--- a/internal/panels/fuzzyfinder/constants.go
+++ b/internal/panels/fuzzyfinder/constants.go
@@ -1,8 +1,20 @@
 package fuzzyfinder
 
 const (
-	categoryCommand  = "command"
-	categoryFile     = "file"
-	actionCursorDown = "cursor_down"
-	dirGit           = ".git"
+	categoryBookmark   = "bookmark"
+	categoryCommand    = "command"
+	categoryDirectory  = "directory"
+	categoryFile       = "file"
+	categoryGitChanged = "git"
+	actionCursorDown   = "cursor_down"
+	dirGit             = ".git"
 )
+
+// DefaultCategoryFile returns the file category name for overlay factories.
+func DefaultCategoryFile() string { return categoryFile }
+
+// DefaultCategoryCommand returns the command category name for overlay factories.
+func DefaultCategoryCommand() string { return categoryCommand }
+
+// DefaultCategoryDirectory returns the directory category name for overlay factories.
+func DefaultCategoryDirectory() string { return categoryDirectory }

--- a/internal/panels/fuzzyfinder/fuzzyfinder.go
+++ b/internal/panels/fuzzyfinder/fuzzyfinder.go
@@ -25,17 +25,19 @@ type FuzzyFinder struct {
 	items   []Item        // all items from all sources
 	matches []fuzzy.Match // filtered results
 	panels.BasePanel
-	cursor           int // index into matches
-	offset           int // scroll offset for results
-	qCursor          int // cursor position in query
-	theme            *theme.Theme
-	promptStyle      lipgloss.Style
-	placeholderStyle lipgloss.Style
-	matchHighlight   lipgloss.Style
-	descStyle        lipgloss.Style
-	statusStyle      lipgloss.Style
-	separatorStyle   lipgloss.Style
-	cursorBg         string
+	defaultCategories map[string]bool
+	activeSourceLabel string
+	cursor            int // index into matches
+	offset            int // scroll offset for results
+	qCursor           int // cursor position in query
+	theme             *theme.Theme
+	promptStyle       lipgloss.Style
+	placeholderStyle  lipgloss.Style
+	matchHighlight    lipgloss.Style
+	descStyle         lipgloss.Style
+	statusStyle       lipgloss.Style
+	separatorStyle    lipgloss.Style
+	cursorBg          string
 }
 
 // Compile-time interface check.
@@ -44,6 +46,13 @@ var _ panels.Panel = (*FuzzyFinder)(nil)
 // New creates a new FuzzyFinder with the given sources. Items are loaded
 // eagerly from all sources at construction time.
 func New(th *theme.Theme, sources ...Source) *FuzzyFinder {
+	return NewWithDefaultCategories(th, nil, sources...)
+}
+
+// NewWithDefaultCategories creates a FuzzyFinder whose no-prefix query is
+// limited to the given categories. An empty default category list shows all
+// source items when no source prefix is active.
+func NewWithDefaultCategories(th *theme.Theme, defaultCategories []string, sources ...Source) *FuzzyFinder {
 	tc := theme.Colors{}
 	if th != nil {
 		tc = th.Colors
@@ -59,6 +68,10 @@ func New(th *theme.Theme, sources ...Source) *FuzzyFinder {
 		statusStyle:      lipgloss.NewStyle().Foreground(panels.ColorOf(tc.BrightBlack, "#555555")),
 		separatorStyle:   lipgloss.NewStyle().Foreground(panels.ColorOf(tc.SelectionBg, "#2A2A2A")),
 		cursorBg:         panels.OrDefault(tc.SelectionBg, "#2A2A2A"),
+	}
+	if len(defaultCategories) > 0 {
+		ff.defaultCategories = categorySet(defaultCategories...)
+		ff.activeSourceLabel = sourceLabelForCategories(ff.defaultCategories)
 	}
 	ff.loadItems()
 	ff.filter()
@@ -77,22 +90,101 @@ func (ff *FuzzyFinder) loadItems() {
 // is empty, all items are shown in their original order. When there are
 // matches, they are re-ranked so that filename-level matches sort higher.
 func (ff *FuzzyFinder) filter() {
-	if ff.query == "" {
+	search, categories, label := ff.parseSourceFilter()
+	ff.activeSourceLabel = label
+	candidateItems, candidateIndexes := ff.filteredItems(categories)
+	if search == "" {
 		// Show all items when query is empty.
-		ff.matches = make([]fuzzy.Match, len(ff.items))
-		for i, item := range ff.items {
+		ff.matches = make([]fuzzy.Match, len(candidateItems))
+		for i, item := range candidateItems {
 			ff.matches[i] = fuzzy.Match{
 				Str:   item.Text,
-				Index: i,
+				Index: candidateIndexes[i],
 			}
 		}
 	} else {
-		ff.matches = fuzzy.FindFrom(ff.query, itemList(ff.items))
-		rerank(ff.query, ff.matches)
+		ff.matches = fuzzy.FindFrom(search, itemList(candidateItems))
+		for i := range ff.matches {
+			ff.matches[i].Index = candidateIndexes[ff.matches[i].Index]
+		}
+		rerank(search, ff.matches)
 	}
 	// Reset cursor and offset after filtering.
 	ff.cursor = 0
 	ff.offset = 0
+}
+
+func (ff *FuzzyFinder) filteredItems(categories map[string]bool) ([]Item, []int) {
+	if len(categories) == 0 {
+		indexes := make([]int, len(ff.items))
+		for i := range ff.items {
+			indexes[i] = i
+		}
+		return ff.items, indexes
+	}
+	items := make([]Item, 0, len(ff.items))
+	indexes := make([]int, 0, len(ff.items))
+	for i, item := range ff.items {
+		if categories[item.Category] {
+			items = append(items, item)
+			indexes = append(indexes, i)
+		}
+	}
+	return items, indexes
+}
+
+func (ff *FuzzyFinder) parseSourceFilter() (string, map[string]bool, string) {
+	if len(ff.query) >= 2 && ff.query[1] == ':' {
+		if categories, label, ok := categoriesForPrefix(ff.query[0]); ok {
+			return ff.query[2:], categories, label
+		}
+	}
+	return ff.query, ff.defaultCategories, sourceLabelForCategories(ff.defaultCategories)
+}
+
+func categoriesForPrefix(prefix byte) (map[string]bool, string, bool) {
+	switch prefix {
+	case 'f', 'F':
+		return categorySet(categoryFile), "files", true
+	case 'd', 'D':
+		return categorySet(categoryDirectory), "directories", true
+	case 'c', 'C':
+		return categorySet(categoryCommand), "commands", true
+	case 'b', 'B':
+		return categorySet(categoryBookmark), "bookmarks", true
+	case 'g', 'G':
+		return categorySet(categoryGitChanged), "git changed", true
+	default:
+		return nil, "", false
+	}
+}
+
+func categorySet(categories ...string) map[string]bool {
+	set := make(map[string]bool, len(categories))
+	for _, category := range categories {
+		set[category] = true
+	}
+	return set
+}
+
+func sourceLabelForCategories(categories map[string]bool) string {
+	if len(categories) != 1 {
+		return ""
+	}
+	switch {
+	case categories[categoryFile]:
+		return "files"
+	case categories[categoryDirectory]:
+		return "directories"
+	case categories[categoryCommand]:
+		return "commands"
+	case categories[categoryBookmark]:
+		return "bookmarks"
+	case categories[categoryGitChanged]:
+		return "git changed"
+	default:
+		return ""
+	}
 }
 
 // rerank re-sorts fuzzy matches so that filename-level hits rank higher
@@ -219,6 +311,9 @@ func (ff *FuzzyFinder) View(width, height int) string {
 	}
 	// Status bar
 	status := fmt.Sprintf(" %d/%d", len(ff.matches), len(ff.items))
+	if ff.activeSourceLabel != "" {
+		status = fmt.Sprintf(" %s · %d/%d", ff.activeSourceLabel, len(ff.matches), len(ff.items))
+	}
 	statusLine := ff.statusStyle.Width(width).Render(status)
 	lines = append(lines, statusLine)
 	return strings.Join(lines, "\n")

--- a/internal/panels/fuzzyfinder/fuzzyfinder.go
+++ b/internal/panels/fuzzyfinder/fuzzyfinder.go
@@ -145,15 +145,15 @@ func (ff *FuzzyFinder) parseSourceFilter() (string, map[string]bool, string) {
 func categoriesForPrefix(prefix byte) (map[string]bool, string, bool) {
 	switch prefix {
 	case 'f', 'F':
-		return categorySet(categoryFile), "files", true
+		return categorySet(categoryFile), sourceNameFiles, true
 	case 'd', 'D':
-		return categorySet(categoryDirectory), "directories", true
+		return categorySet(categoryDirectory), sourceNameDirectories, true
 	case 'c', 'C':
-		return categorySet(categoryCommand), "commands", true
+		return categorySet(categoryCommand), sourceNameCommands, true
 	case 'b', 'B':
-		return categorySet(categoryBookmark), "bookmarks", true
+		return categorySet(categoryBookmark), sourceNameBookmarks, true
 	case 'g', 'G':
-		return categorySet(categoryGitChanged), "git changed", true
+		return categorySet(categoryGitChanged), sourceNameGitChanged, true
 	default:
 		return nil, "", false
 	}
@@ -173,15 +173,15 @@ func sourceLabelForCategories(categories map[string]bool) string {
 	}
 	switch {
 	case categories[categoryFile]:
-		return "files"
+		return sourceNameFiles
 	case categories[categoryDirectory]:
-		return "directories"
+		return sourceNameDirectories
 	case categories[categoryCommand]:
-		return "commands"
+		return sourceNameCommands
 	case categories[categoryBookmark]:
-		return "bookmarks"
+		return sourceNameBookmarks
 	case categories[categoryGitChanged]:
-		return "git changed"
+		return sourceNameGitChanged
 	default:
 		return ""
 	}

--- a/internal/panels/fuzzyfinder/fuzzyfinder_test.go
+++ b/internal/panels/fuzzyfinder/fuzzyfinder_test.go
@@ -3,6 +3,7 @@ package fuzzyfinder
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -228,6 +229,39 @@ func TestCommandSourceEmpty(t *testing.T) {
 	assert.Empty(t, items)
 }
 
+func TestGitChangedSourceListsStatusFiles(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test User")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("one\n"), 0o644))
+	runGit(t, dir, "add", "tracked.txt")
+	runGit(t, dir, "commit", "-m", "initial")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("two\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new.txt"), []byte("new\n"), 0o644))
+
+	items := NewGitChangedSource(dir).Items()
+	texts := make([]string, len(items))
+	for i, item := range items {
+		texts[i] = item.Text
+		assert.Equal(t, categoryGitChanged, item.Category)
+	}
+
+	assert.Contains(t, texts, "tracked.txt")
+	assert.Contains(t, texts, "new.txt")
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+}
+
 // ---------------------------------------------------------------------------
 // FuzzyFinder construction tests
 // ---------------------------------------------------------------------------
@@ -250,6 +284,74 @@ func TestNewWithMultipleSources(t *testing.T) {
 
 	ff := New(nil, files, cmds)
 	assert.Equal(t, 2, ff.matchCount(), "should combine items from all sources")
+}
+
+func TestDefaultCategoriesKeepNoPrefixBehavior(t *testing.T) {
+	files := &staticSource{name: "files", items: []Item{
+		{Text: "main.go", Category: categoryFile, Value: "main.go"},
+	}}
+	cmds := &staticSource{name: "commands", items: []Item{
+		{Text: "quit", Category: categoryCommand, Value: "quit"},
+	}}
+
+	ff := NewWithDefaultCategories(nil, []string{categoryFile}, files, cmds)
+
+	assert.Equal(t, 1, ff.matchCount())
+	assert.Equal(t, "main.go", ff.selectedItem().Text)
+}
+
+func TestSourcePrefixFiltersItems(t *testing.T) {
+	src := &staticSource{name: "mixed", items: []Item{
+		{Text: "main.go", Category: categoryFile, Value: "main.go"},
+		{Text: "internal", Category: categoryDirectory, Value: "internal"},
+		{Text: "commit", Category: categoryCommand, Value: "commit"},
+		{Text: "src", Category: categoryBookmark, Value: "src"},
+		{Text: "README.md", Category: categoryGitChanged, Value: "README.md"},
+	}}
+	ff := NewWithDefaultCategories(nil, []string{categoryFile}, src)
+
+	for _, tc := range []struct {
+		query string
+		want  string
+	}{
+		{"f:main", "main.go"},
+		{"d:int", "internal"},
+		{"c:com", "commit"},
+		{"b:src", "src"},
+		{"g:read", "README.md"},
+	} {
+		ff.query = tc.query
+		ff.filter()
+		require.Equal(t, 1, ff.matchCount(), tc.query)
+		assert.Equal(t, tc.want, ff.selectedItem().Text)
+	}
+}
+
+func TestUnknownSourcePrefixIsQueryText(t *testing.T) {
+	src := &staticSource{name: "files", items: []Item{
+		{Text: "x:main.go", Category: categoryFile, Value: "x:main.go"},
+		{Text: "main.go", Category: categoryFile, Value: "main.go"},
+	}}
+	ff := NewWithDefaultCategories(nil, []string{categoryFile}, src)
+
+	ff.query = "x:main"
+	ff.filter()
+
+	require.Equal(t, 1, ff.matchCount())
+	assert.Equal(t, "x:main.go", ff.selectedItem().Text)
+}
+
+func TestSourceFilterStatusLine(t *testing.T) {
+	src := &staticSource{name: "mixed", items: []Item{
+		{Text: "main.go", Category: categoryFile, Value: "main.go"},
+		{Text: "commit", Category: categoryCommand, Value: "commit"},
+	}}
+	ff := NewWithDefaultCategories(nil, []string{categoryFile}, src)
+	ff.query = "c:com"
+	ff.filter()
+
+	view := ff.View(40, 5)
+	assert.Contains(t, view, "commands")
 }
 
 func TestNewEmptySource(t *testing.T) {

--- a/internal/panels/fuzzyfinder/source.go
+++ b/internal/panels/fuzzyfinder/source.go
@@ -4,12 +4,16 @@
 package fuzzyfinder
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	bm "github.com/jongio/grut/internal/bookmarks"
+	"github.com/jongio/grut/internal/git"
 	"github.com/jongio/grut/internal/keymap"
 	ignore "github.com/sabhiram/go-gitignore"
 )
@@ -276,7 +280,7 @@ func (ds *DirectorySource) Items() []Item {
 		items = append(items, Item{
 			Text:        "..",
 			Description: parent,
-			Category:    "directory",
+			Category:    categoryDirectory,
 			Value:       parent,
 		})
 	}
@@ -331,11 +335,93 @@ func (ds *DirectorySource) Items() []Item {
 		}
 		items = append(items, Item{
 			Text:     rel,
-			Category: "directory",
+			Category: categoryDirectory,
 			Value:    path,
 		})
 		return nil
 	})
+	return items
+}
+
+// ---------------------------------------------------------------------------
+// BookmarkSource
+// ---------------------------------------------------------------------------
+
+// BookmarkSource exposes saved directory bookmarks to the fuzzy finder.
+type BookmarkSource struct {
+	manager *bm.Manager
+}
+
+// NewBookmarkSource creates a source backed by the bookmark manager.
+func NewBookmarkSource(manager *bm.Manager) *BookmarkSource {
+	return &BookmarkSource{manager: manager}
+}
+
+// Name implements Source.
+func (bs *BookmarkSource) Name() string { return "bookmarks" }
+
+// Items implements Source.
+func (bs *BookmarkSource) Items() []Item {
+	if bs == nil || bs.manager == nil {
+		return nil
+	}
+	bookmarks := bs.manager.List()
+	items := make([]Item, 0, len(bookmarks))
+	for _, b := range bookmarks {
+		text := b.Name
+		if text == "" {
+			text = filepath.Base(b.Path)
+		}
+		items = append(items, Item{
+			Text:        text,
+			Description: b.Path,
+			Category:    categoryBookmark,
+			Value:       b.Path,
+		})
+	}
+	return items
+}
+
+// ---------------------------------------------------------------------------
+// GitChangedSource
+// ---------------------------------------------------------------------------
+
+// GitChangedSource exposes files with git status changes.
+type GitChangedSource struct {
+	root string
+}
+
+// NewGitChangedSource creates a source backed by git status.
+func NewGitChangedSource(root string) *GitChangedSource {
+	return &GitChangedSource{root: root}
+}
+
+// Name implements Source.
+func (gs *GitChangedSource) Name() string { return "git changed" }
+
+// Items implements Source.
+func (gs *GitChangedSource) Items() []Item {
+	if gs == nil || gs.root == "" {
+		return nil
+	}
+	client, err := git.NewClient(gs.root)
+	if err != nil {
+		return nil
+	}
+	statuses, err := client.Status(context.Background())
+	if err != nil {
+		return nil
+	}
+	items := make([]Item, 0, len(statuses))
+	for _, st := range statuses {
+		rel := filepath.ToSlash(st.Path)
+		items = append(items, Item{
+			Text:        rel,
+			Description: fmt.Sprintf("%s%s", st.StagedStatus, st.WorktreeStatus),
+			Category:    categoryGitChanged,
+			Value:       filepath.Join(gs.root, filepath.FromSlash(st.Path)),
+		})
+	}
 	return items
 }
 

--- a/internal/panels/fuzzyfinder/source.go
+++ b/internal/panels/fuzzyfinder/source.go
@@ -184,7 +184,7 @@ func NewFileSource(root string) *FileSource {
 }
 
 // Name implements Source.
-func (fs *FileSource) Name() string { return "files" }
+func (fs *FileSource) Name() string { return sourceNameFiles }
 
 // Items implements Source. It checks the global cache first and falls back
 // to walking the directory tree rooted at fs.root, filtering entries via
@@ -267,7 +267,7 @@ func NewDirectorySource(root string, maxDepth int) *DirectorySource {
 }
 
 // Name implements Source.
-func (ds *DirectorySource) Name() string { return "directories" }
+func (ds *DirectorySource) Name() string { return sourceNameDirectories }
 
 // Items implements Source. It walks the directory tree rooted at ds.root
 // and returns subdirectories as searchable items, skipping hidden and
@@ -358,7 +358,7 @@ func NewBookmarkSource(manager *bm.Manager) *BookmarkSource {
 }
 
 // Name implements Source.
-func (bs *BookmarkSource) Name() string { return "bookmarks" }
+func (bs *BookmarkSource) Name() string { return sourceNameBookmarks }
 
 // Items implements Source.
 func (bs *BookmarkSource) Items() []Item {
@@ -397,7 +397,7 @@ func NewGitChangedSource(root string) *GitChangedSource {
 }
 
 // Name implements Source.
-func (gs *GitChangedSource) Name() string { return "git changed" }
+func (gs *GitChangedSource) Name() string { return sourceNameGitChanged }
 
 // Items implements Source.
 func (gs *GitChangedSource) Items() []Item {
@@ -441,7 +441,7 @@ func NewCommandSource(bindings []keymap.Binding) *CommandSource {
 }
 
 // Name implements Source.
-func (cs *CommandSource) Name() string { return "commands" }
+func (cs *CommandSource) Name() string { return sourceNameCommands }
 
 // Items implements Source. It returns deduplicated command bindings
 // as searchable items, with the action as text and the key combination


### PR DESCRIPTION
Closes #191

Adds source prefixes for files, directories, commands, bookmarks, and git-changed files in the fuzzy finder. No-prefix queries keep the current default source for each launcher.

Validation:
- go build ./...
- go test ./internal/panels/fuzzyfinder ./internal/overlayreg

Note: go test ./internal/tui did not finish after 5 minutes. Baseline go test ./... also stalled after internal/extension/runtime.