### PR TITLE
Add config check command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/jongio/grut/internal/config"
+	"github.com/spf13/cobra"
+)
+
+type configLoadFunc func() (*config.Config, error)
+type configPathFunc func() string
+
+func newConfigCmd() *cobra.Command {
+	return newConfigCmdWithDeps(config.Load, config.UserConfigFilePath)
+}
+
+func newConfigCmdWithDeps(load configLoadFunc, path configPathFunc) *cobra.Command {
+	configCmd := &cobra.Command{
+		Use:   "config",
+		Short: "Inspect grut configuration",
+	}
+	configCmd.AddCommand(newConfigCheckCmd(load, path))
+	return configCmd
+}
+
+func newConfigCheckCmd(load configLoadFunc, path configPathFunc) *cobra.Command {
+	return &cobra.Command{
+		Use:   "check",
+		Short: "Validate the active grut configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfgPath := path()
+			if _, err := load(); err != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "Config: %s\n", cfgPath)
+				return fmt.Errorf("config check failed: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Config: %s\nOK\n", cfgPath)
+			return nil
+		},
+	}
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -7,8 +7,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type configLoadFunc func() (*config.Config, error)
-type configPathFunc func() string
+type (
+	configLoadFunc func() (*config.Config, error)
+	configPathFunc func() string
+)
 
 func newConfigCmd() *cobra.Command {
 	return newConfigCmdWithDeps(config.Load, config.UserConfigFilePath)
@@ -16,7 +18,7 @@ func newConfigCmd() *cobra.Command {
 
 func newConfigCmdWithDeps(load configLoadFunc, path configPathFunc) *cobra.Command {
 	configCmd := &cobra.Command{
-		Use:   "config",
+		Use:   cmdConfig,
 		Short: "Inspect grut configuration",
 	}
 	configCmd.AddCommand(newConfigCheckCmd(load, path))

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/jongio/grut/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigCheckSuccess(t *testing.T) {
+	cmd := newConfigCheckCmd(
+		func() (*config.Config, error) { return &config.Config{}, nil },
+		func() string { return `C:\Users\me\AppData\Roaming\grut\config.toml` },
+	)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), `C:\Users\me\AppData\Roaming\grut\config.toml`)
+	assert.Contains(t, out.String(), "OK")
+}
+
+func TestConfigCheckFailure(t *testing.T) {
+	cmd := newConfigCheckCmd(
+		func() (*config.Config, error) { return nil, errors.New("config preview.width: must be 1-100") },
+		func() string { return `C:\Users\me\AppData\Roaming\grut\config.toml` },
+	)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config check failed")
+	assert.Contains(t, err.Error(), "preview.width")
+	assert.Contains(t, out.String(), `C:\Users\me\AppData\Roaming\grut\config.toml`)
+}
+
+func TestRootRegistersConfigCheck(t *testing.T) {
+	root, cleanup := newRootCommand()
+	defer cleanup()
+
+	configCmd, _, err := root.Find([]string{"config"})
+	require.NoError(t, err)
+	require.NotNil(t, configCmd)
+	assert.Equal(t, "config", configCmd.Name())
+
+	checkCmd, _, err := root.Find([]string{"config", "check"})
+	require.NoError(t, err)
+	require.NotNil(t, checkCmd)
+	assert.Equal(t, "check", checkCmd.Name())
+}

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -2,6 +2,7 @@ package cmd
 
 // Cobra subcommand name constants.
 const (
+	cmdConfig  = "config"
 	cmdList    = "list"
 	cmdVersion = "version"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -345,6 +345,7 @@ Environment:
 	rootCmd.AddCommand(newExtCmd())
 	rootCmd.AddCommand(newRunCmd())
 	rootCmd.AddCommand(newReportCmd())
+	rootCmd.AddCommand(newConfigCmd())
 
 	// cleanup releases profiling resources. It is idempotent — safe to call
 	// multiple times (subsequent calls are no-ops).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -312,6 +312,11 @@ func configFilePath() string {
 	return filepath.Join(ConfigDir(), "config.toml")
 }
 
+// UserConfigFilePath returns the full path to the user's config file.
+func UserConfigFilePath() string {
+	return configFilePath()
+}
+
 // LoadDefaults returns a Config built solely from the embedded defaults
 // (defaults.toml), without reading any user config file. This is safe to
 // call from multiple goroutines and does not touch the filesystem, making

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -355,6 +355,10 @@ func TestConfigFilePath(t *testing.T) {
 	assert.True(t, strings.HasSuffix(path, "config.toml"))
 }
 
+func TestUserConfigFilePath(t *testing.T) {
+	assert.Equal(t, configFilePath(), UserConfigFilePath())
+}
+
 func TestWarnIfWorldReadableNoOp(t *testing.T) {
 	// On Windows this is a no-op; on Unix it should not panic.
 	// Just ensure it doesn't crash.


### PR DESCRIPTION
Closes #195

Adds a read-only grut config check command that loads and validates the active config, prints the config path, and exits with an error on invalid settings.

Validation:
- go test ./cmd ./internal/config
- go build ./...