### PR TITLE
deps: upgrade all dependencies to latest

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -47,12 +47,12 @@ jobs:
         with:
           fetch-depth: 0   # needed for git push on main
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26.x"
 
       - name: Install benchstat
-        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260312031701-16a31bc5fbd0
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260615155930-9e4b9ddef5b6
 
       # Compute a stable platform key (e.g. linux-amd64, darwin-arm64).
       # Used for artifact names and baseline paths.
@@ -145,7 +145,7 @@ jobs:
       # Each platform gets its own sticky comment (keyed by platform).
       - name: Post PR comment
         if: github.event_name == 'pull_request' && env.no_baseline != 'true'
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v2
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: benchmarks-${{ env.PLATFORM }}
           path: bench-comment.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       # Pin actions to full SHA for supply-chain security.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26.x"
 
@@ -73,7 +73,7 @@ jobs:
       - name: Check strict formatting (gofumpt)
         if: runner.os == 'Linux'
         run: |
-          go install mvdan.cc/gofumpt@v0.9.2 || { echo "gofumpt install failed, skipping"; exit 0; }
+          go install mvdan.cc/gofumpt@v0.10.0 || { echo "gofumpt install failed, skipping"; exit 0; }
           unformatted=$(gofumpt -l .)
           if [ -n "$unformatted" ]; then
             echo "::error::Files need strict formatting (gofumpt):"
@@ -84,8 +84,8 @@ jobs:
       - name: Check dead code
         if: runner.os == 'Linux'
         run: |
-          go install golang.org/x/tools/cmd/deadcode@v0.43.0
-          go install github.com/magefile/mage@v1.16.0
+          go install golang.org/x/tools/cmd/deadcode@v0.47.0
+          go install github.com/magefile/mage@v1.17.2
           mage deadcode
 
       - run: go build ./...
@@ -94,9 +94,9 @@ jobs:
 
       - name: golangci-lint
         if: runner.os == 'Linux'
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        uses: golangci/golangci-lint-action@d583c34f0599d37dbac4a198b9c83201be380893 # v9.3.0
         with:
-          version: v2.11.3
+          version: v2.12.2
           install-mode: goinstall
 
       - name: Test with coverage
@@ -139,7 +139,7 @@ jobs:
       - name: govulncheck
         if: runner.os == 'Linux'
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+          go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
           govulncheck ./...
 
   # Verify the binary compiles for all release platforms.
@@ -153,7 +153,7 @@ jobs:
       # Pin actions to full SHA for supply-chain security.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26.x"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,16 +34,16 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26.x"
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
+      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Install benchstat
-        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260312031701-16a31bc5fbd0
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260615155930-9e4b9ddef5b6
 
       - name: Compute next version
         id: version
@@ -218,9 +218,9 @@ jobs:
           git tag -fa "$VERSION" -m "$VERSION"
           git push --force origin "$VERSION"
 
-      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
-          version: "v2.9.0"
+          version: "v2.16.0"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.4
 	github.com/adrg/xdg v0.5.3
 	github.com/alecthomas/chroma/v2 v2.27.0
-	github.com/anthropics/anthropic-sdk-go v1.53.0
+	github.com/anthropics/anthropic-sdk-go v1.54.0
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gabriel-vasile/mimetype v1.4.13

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/alecthomas/chroma/v2 v2.27.0 h1:FodwmyOBgJULFYmDqibcp9pvfDLWdtPRh9v/r
 github.com/alecthomas/chroma/v2 v2.27.0/go.mod h1:NjJ3ciIgrqBNeIkWZ4e46nseoLDslxU1LmfCoL+wcY8=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/anthropics/anthropic-sdk-go v1.53.0 h1:R/99NOmSXlfha2kwVVDUBiDxfoG5eHaxfQ9omcKgITM=
-github.com/anthropics/anthropic-sdk-go v1.53.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
+github.com/anthropics/anthropic-sdk-go v1.54.0 h1:DEoaPveWCU+pMlfORd5s8ZWuS+jQK0Im1N8rsgeVFV8=
+github.com/anthropics/anthropic-sdk-go v1.54.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=


### PR DESCRIPTION
## Summary
- Updated GitHub Actions and workflow toolchain dependency pins to latest available versions.
- actions/setup-go v6.4.0 -> v6.5.0.
- golangci-lint-action v9.2.1 -> v9.3.0 and golangci-lint v2.11.3 -> v2.12.2.
- Go CI tools: gofumpt v0.10.0, deadcode/x-tools v0.47.0, mage v1.17.2, govulncheck v1.5.0, benchstat 20260615.
- goreleaser-action v7.2.2 -> v7.2.3 and GoReleaser v2.9.0 -> v2.16.0.

## Validation
- go build ./...: pass
- go vet ./...: pass
- go test ./... -count=1: pass
- web npm test: pass
- mage preflight: pass