### PR TITLE
deps: upgrade go-github v68 to v88

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gabriel-vasile/mimetype v1.4.13
 	github.com/github/copilot-sdk/go v1.0.4
-	github.com/google/go-github/v68 v68.0.0
+	github.com/google/go-github/v88 v88.0.0
 	github.com/mark3labs/mcp-go v0.55.1
 	github.com/mattn/go-runewidth v0.0.24
 	github.com/pelletier/go-toml/v2 v2.4.2

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v68 v68.0.0 h1:ZW57zeNZiXTdQ16qrDiZ0k6XucrxZ2CGmoTvcCyQG6s=
-github.com/google/go-github/v68 v68.0.0/go.mod h1:K9HAUBovM2sLwM408A18h+wd9vqdLOEqTUCbnRIcx68=
+github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
+github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=

--- a/internal/github/auth.go
+++ b/internal/github/auth.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	gh "github.com/google/go-github/v68/github"
+	gh "github.com/google/go-github/v88/github"
 )
 
 // ghCLITimeout is the maximum time to wait for the `gh` CLI to return an
@@ -24,7 +24,10 @@ func NewClient(ctx context.Context) (*clientImpl, error) {
 	if err != nil {
 		return nil, err
 	}
-	ghClient := gh.NewClient(nil).WithAuthToken(token)
+	ghClient, err := gh.NewClient(gh.WithAuthToken(token))
+	if err != nil {
+		return nil, fmt.Errorf("create github client: %w", err)
+	}
 	return &clientImpl{gh: ghClient, cache: newCache()}, nil
 }
 

--- a/internal/github/cache.go
+++ b/internal/github/cache.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	gh "github.com/google/go-github/v68/github"
+	gh "github.com/google/go-github/v88/github"
 )
 
 const (

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	gh "github.com/google/go-github/v68/github"
+	gh "github.com/google/go-github/v88/github"
 )
 
 // clientImpl implements the Client interface using the google/go-github SDK.
@@ -41,7 +41,7 @@ func (c *clientImpl) ListIssues(ctx context.Context, owner, repo string, opts *g
 	if opts != nil {
 		local = *opts
 	}
-	local.Page = 0
+	local.ListOptions.Page = 0
 	key := fmt.Sprintf("issues:%s/%s:%+v", owner, repo, local)
 	if v, ok := c.cache.Get(key); ok {
 		issues, ok := v.([]*gh.Issue)
@@ -51,7 +51,7 @@ func (c *clientImpl) ListIssues(ctx context.Context, owner, repo string, opts *g
 		return issues, nil
 	}
 
-	local.Page = 1
+	local.ListOptions.Page = 1
 	allIssues := make([]*gh.Issue, 0, 30)
 	for page := 0; page < maxPaginationPages; page++ {
 		issues, resp, err := c.gh.Issues.ListByRepo(ctx, owner, repo, &local)
@@ -66,7 +66,7 @@ func (c *clientImpl) ListIssues(ctx context.Context, owner, repo string, opts *g
 		if resp.NextPage == 0 {
 			break
 		}
-		local.Page = resp.NextPage
+		local.ListOptions.Page = resp.NextPage
 	}
 
 	c.cache.Set(key, allIssues)
@@ -78,8 +78,8 @@ func (c *clientImpl) ListIssuesPage(ctx context.Context, owner, repo string, opt
 	if opts != nil {
 		local = *opts
 	}
-	if local.Page == 0 {
-		local.Page = 1
+	if local.ListOptions.Page == 0 {
+		local.ListOptions.Page = 1
 	}
 	key := fmt.Sprintf("issues-page:%s/%s:%+v", owner, repo, local)
 	return listPage[*gh.Issue](c, key, "list issues page", func() ([]*gh.Issue, *gh.Response, int, error) {
@@ -629,7 +629,7 @@ func (c *clientImpl) DispatchWorkflow(ctx context.Context, owner, repo string, w
 		Ref:    ref,
 		Inputs: inputs,
 	}
-	resp, err := c.gh.Actions.CreateWorkflowDispatchEventByID(ctx, owner, repo, workflowID, event)
+	_, resp, err := c.gh.Actions.CreateWorkflowDispatchEventByID(ctx, owner, repo, workflowID, event)
 	if err != nil {
 		// Surface specific auth scope issues clearly.
 		if resp != nil && resp.StatusCode == 403 {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	gh "github.com/google/go-github/v68/github"
+	gh "github.com/google/go-github/v88/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,6 +21,18 @@ import (
 // Test helpers
 // ---------------------------------------------------------------------------
 
+// urlRewriteTransport redirects all outgoing requests to the test server,
+// preserving the request path so existing mock handlers keep matching.
+type urlRewriteTransport struct {
+	base *url.URL
+}
+
+func (t *urlRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = t.base.Scheme
+	req.URL.Host = t.base.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
 // setupMockClient creates a clientImpl backed by an httptest server.
 // The server is cleaned up automatically via t.Cleanup.
 func setupMockClient(t *testing.T, handler http.HandlerFunc) (*clientImpl, *httptest.Server) {
@@ -28,12 +40,12 @@ func setupMockClient(t *testing.T, handler http.HandlerFunc) (*clientImpl, *http
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	ghClient := gh.NewClient(nil).WithAuthToken("test-token")
 	baseURL, err := url.Parse(server.URL + "/")
 	require.NoError(t, err)
-	ghClient.BaseURL = baseURL
-	// Point upload URL at the mock too so PR diff etc. work.
-	ghClient.UploadURL = baseURL
+
+	httpClient := &http.Client{Transport: &urlRewriteTransport{base: baseURL}}
+	ghClient, err := gh.NewClient(gh.WithHTTPClient(httpClient), gh.WithAuthToken("test-token"))
+	require.NoError(t, err)
 
 	return &clientImpl{gh: ghClient, cache: newCache()}, server
 }

--- a/internal/github/coverage_test.go
+++ b/internal/github/coverage_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	gh "github.com/google/go-github/v68/github"
+	gh "github.com/google/go-github/v88/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/github/github_extra_test.go
+++ b/internal/github/github_extra_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	gh "github.com/google/go-github/v68/github"
+	gh "github.com/google/go-github/v88/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -662,7 +662,7 @@ func TestClient_ListIssues_CacheTypeError(t *testing.T) {
 	})
 
 	local := gh.IssueListByRepoOptions{}
-	local.Page = 0
+	local.ListOptions.Page = 0
 	key := fmt.Sprintf("issues:%s/%s:%+v", "owner", "repo", local)
 	client.cache.Set(key, "wrong type")
 

--- a/internal/github/interfaces.go
+++ b/internal/github/interfaces.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	gh "github.com/google/go-github/v68/github"
+	gh "github.com/google/go-github/v88/github"
 )
 
 // PageResult holds pagination metadata for paged list operations.

--- a/internal/github/pagination.go
+++ b/internal/github/pagination.go
@@ -3,7 +3,7 @@ package github
 import (
 	"fmt"
 
-	gh "github.com/google/go-github/v68/github"
+	gh "github.com/google/go-github/v88/github"
 )
 
 // pageEntry is a generic cache wrapper for a single page of results.

--- a/internal/github/workflow.go
+++ b/internal/github/workflow.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	gh "github.com/google/go-github/v68/github"
+	gh "github.com/google/go-github/v88/github"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/panels/gitinfo/gitinfo_coverage_test.go
+++ b/internal/panels/gitinfo/gitinfo_coverage_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-	gh "github.com/google/go-github/v68/github"
+	gh "github.com/google/go-github/v88/github"
 	"github.com/jongio/grut/internal/config"
 	"github.com/jongio/grut/internal/panels"
 	"github.com/stretchr/testify/assert"

--- a/internal/panels/gitinfo/gitinfo_github.go
+++ b/internal/panels/gitinfo/gitinfo_github.go
@@ -10,7 +10,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	gh "github.com/google/go-github/v68/github"
+	gh "github.com/google/go-github/v88/github"
 	ghclient "github.com/jongio/grut/internal/github"
 	"github.com/jongio/grut/internal/notify"
 	"github.com/jongio/grut/internal/panels"

--- a/internal/panels/gitinfo/gitinfo_test.go
+++ b/internal/panels/gitinfo/gitinfo_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-	gh "github.com/google/go-github/v68/github"
+	gh "github.com/google/go-github/v88/github"
 	"github.com/jongio/grut/internal/actions"
 	"github.com/jongio/grut/internal/config"
 	"github.com/jongio/grut/internal/git"


### PR DESCRIPTION
Follow-up to #216 (already merged), which upgraded most dependencies but left `github.com/google/go-github` at **v68**. This PR completes the upgrade by bumping it to the latest major, **v88**, and adapts the code to the breaking API changes.

`anthropics/anthropic-sdk-go` is already at `v1.54.0` on `main` (from #216); the npm projects (`web/`, `cmd/screenshots`) are already at their latest versions under the repo's 7-day release-age cooldown, so no further changes were needed there.

### Dependency change
- `github.com/google/go-github/v68` -> `v88` (major, breaking API)

### go-github v88 API migrations
- `NewClient` now returns `(*Client, error)` and accepts `ClientOptionsFunc` options. Replaced the removed `(*Client).WithAuthToken` method with the `gh.WithAuthToken(...)` option and added error handling.
- `IssueListByRepoOptions` now embeds both `ListCursorOptions` and `ListOptions`, making the bare `Page` selector ambiguous - qualified as `ListOptions.Page`.
- `CreateWorkflowDispatchEventByID` now returns three values.
- `BaseURL`/`UploadURL` client fields are now unexported. The test helper routes requests through a small URL-rewriting `http.Client` transport so existing mock handlers keep matching.

### Verification
- `go build ./...`, `go vet ./...`, `go mod tidy` (clean), `gofmt`/`gofumpt` clean
- `go test ./internal/github/...` and `go test ./internal/panels/gitinfo/...` pass (the two packages consuming the go-github API)
- Full suite + lint validated by CI

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>