### PR TITLE
deps: upgrade all dependencies to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.4
 	github.com/adrg/xdg v0.5.3
 	github.com/alecthomas/chroma/v2 v2.27.0
-	github.com/anthropics/anthropic-sdk-go v1.55.0
+	github.com/anthropics/anthropic-sdk-go v1.55.1
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gabriel-vasile/mimetype v1.4.13

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/alecthomas/chroma/v2 v2.27.0 h1:FodwmyOBgJULFYmDqibcp9pvfDLWdtPRh9v/r
 github.com/alecthomas/chroma/v2 v2.27.0/go.mod h1:NjJ3ciIgrqBNeIkWZ4e46nseoLDslxU1LmfCoL+wcY8=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/anthropics/anthropic-sdk-go v1.55.0 h1:bBAuqAsRQaDQADZ3FqsJex1qMOdUr/kgZELLk/vnu/c=
-github.com/anthropics/anthropic-sdk-go v1.55.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
+github.com/anthropics/anthropic-sdk-go v1.55.1 h1:GxukHUVou6AFIngxa/Aw1z79hmwg13Hmn++KE9werbM=
+github.com/anthropics/anthropic-sdk-go v1.55.1/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=


### PR DESCRIPTION
## Summary

Automated dependency upgrade across all package managers in the repo.

### Go modules (`go.mod` / `go.sum`)
- `github.com/anthropics/anthropic-sdk-go` `v1.55.0` → `v1.55.1`
- All other direct and indirect modules were already at the latest version within their current major (verified via `go get -u -t ./...` + `go mod tidy`). `github.com/google/go-github` has no `v89` (v88 is latest major).

### npm packages
- `web/` (astro, @astrojs/check, typescript) — already at latest under the 7-day `min-release-age` cooldown; no changes.
- `cmd/screenshots/` (@xterm/xterm, @xterm/addon-unicode11, playwright) — already at latest; no changes.

### Extension templates
- `internal/extension/templates/mcp-node/package.json` and `mcp-python/requirements.txt` have no pinned dependencies to upgrade.

> Note: `@jongio`'s npm is configured with a global `min-release-age=7 days`, so packages published within the last 7 days are intentionally skipped.

### Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./...` ✓ (the `internal/tui` package takes ~12 min locally and exceeded the default 10m per-package timeout on this loaded machine; it passes cleanly with a longer timeout, and CI runs the same suite on windows-latest)
- `gofmt` clean, `go mod tidy` stable

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>