### PR TITLE
Add diff stat summary to commit and PR previews

### DIFF
--- a/internal/git/stat.go
+++ b/internal/git/stat.go
@@ -1,0 +1,49 @@
+package git
+
+import "fmt"
+
+// DiffStat summarizes the size of a set of file diffs.
+type DiffStat struct {
+	FilesChanged int
+	Insertions   int
+	Deletions    int
+}
+
+// Stat computes a DiffStat from parsed file diffs. FilesChanged counts every
+// file with a diff entry (including binary files); Insertions and Deletions
+// count added and removed lines, matching the totals reported by
+// `git diff --shortstat` for the same range.
+func Stat(diffs []FileDiff) DiffStat {
+	s := DiffStat{FilesChanged: len(diffs)}
+	for _, d := range diffs {
+		for _, h := range d.Hunks {
+			for _, l := range h.Lines {
+				switch l.Type {
+				case DiffLineAdded:
+					s.Insertions++
+				case DiffLineRemoved:
+					s.Deletions++
+				}
+			}
+		}
+	}
+	return s
+}
+
+// IsZero reports whether the stat represents no changes.
+func (s DiffStat) IsZero() bool {
+	return s.FilesChanged == 0 && s.Insertions == 0 && s.Deletions == 0
+}
+
+// Summary returns a plain-text one-line summary such as
+// "5 files changed, +128 -34". It returns an empty string for a zero stat.
+func (s DiffStat) Summary() string {
+	if s.IsZero() {
+		return ""
+	}
+	noun := "files"
+	if s.FilesChanged == 1 {
+		noun = "file"
+	}
+	return fmt.Sprintf("%d %s changed, +%d -%d", s.FilesChanged, noun, s.Insertions, s.Deletions)
+}

--- a/internal/git/stat.go
+++ b/internal/git/stat.go
@@ -23,6 +23,8 @@ func Stat(diffs []FileDiff) DiffStat {
 					s.Insertions++
 				case DiffLineRemoved:
 					s.Deletions++
+				default:
+					// Context and other line types don't affect the counts.
 				}
 			}
 		}

--- a/internal/git/stat_test.go
+++ b/internal/git/stat_test.go
@@ -1,0 +1,124 @@
+package git
+
+import "testing"
+
+func hunk(lines ...DiffLine) Hunk {
+	return Hunk{Lines: lines}
+}
+
+func line(t DiffLineType) DiffLine {
+	return DiffLine{Type: t}
+}
+
+func TestStat(t *testing.T) {
+	tests := []struct {
+		name  string
+		diffs []FileDiff
+		want  DiffStat
+	}{
+		{
+			name:  "no diffs",
+			diffs: nil,
+			want:  DiffStat{},
+		},
+		{
+			name: "single file additions and deletions",
+			diffs: []FileDiff{
+				{
+					Path: "a.go",
+					Hunks: []Hunk{
+						hunk(
+							line(DiffLineContext),
+							line(DiffLineAdded),
+							line(DiffLineAdded),
+							line(DiffLineRemoved),
+						),
+					},
+				},
+			},
+			want: DiffStat{FilesChanged: 1, Insertions: 2, Deletions: 1},
+		},
+		{
+			name: "multiple files across multiple hunks",
+			diffs: []FileDiff{
+				{
+					Path: "a.go",
+					Hunks: []Hunk{
+						hunk(line(DiffLineAdded), line(DiffLineAdded)),
+						hunk(line(DiffLineRemoved)),
+					},
+				},
+				{
+					Path: "b.go",
+					Hunks: []Hunk{
+						hunk(line(DiffLineAdded), line(DiffLineRemoved), line(DiffLineContext)),
+					},
+				},
+			},
+			want: DiffStat{FilesChanged: 2, Insertions: 3, Deletions: 2},
+		},
+		{
+			name: "binary file counts as changed with no line counts",
+			diffs: []FileDiff{
+				{Path: "image.png", IsBinary: true},
+			},
+			want: DiffStat{FilesChanged: 1, Insertions: 0, Deletions: 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Stat(tt.diffs)
+			if got != tt.want {
+				t.Fatalf("Stat() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiffStatIsZero(t *testing.T) {
+	if !(DiffStat{}).IsZero() {
+		t.Error("empty DiffStat should be zero")
+	}
+	if (DiffStat{FilesChanged: 1}).IsZero() {
+		t.Error("DiffStat with a changed file should not be zero")
+	}
+	if (DiffStat{Insertions: 1}).IsZero() {
+		t.Error("DiffStat with insertions should not be zero")
+	}
+	if (DiffStat{Deletions: 1}).IsZero() {
+		t.Error("DiffStat with deletions should not be zero")
+	}
+}
+
+func TestDiffStatSummary(t *testing.T) {
+	tests := []struct {
+		name string
+		stat DiffStat
+		want string
+	}{
+		{
+			name: "zero stat is empty",
+			stat: DiffStat{},
+			want: "",
+		},
+		{
+			name: "single file uses singular noun",
+			stat: DiffStat{FilesChanged: 1, Insertions: 3, Deletions: 0},
+			want: "1 file changed, +3 -0",
+		},
+		{
+			name: "multiple files use plural noun",
+			stat: DiffStat{FilesChanged: 5, Insertions: 128, Deletions: 34},
+			want: "5 files changed, +128 -34",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.stat.Summary(); got != tt.want {
+				t.Fatalf("Summary() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/panels/preview/preview.go
+++ b/internal/panels/preview/preview.go
@@ -784,8 +784,43 @@ func (p *Preview) loadContextDiffCmd(path string, dc *panels.DiffContext) tea.Cm
 		if err != nil || len(diffs) == 0 {
 			return diffLoadedMsg{path: path}
 		}
-		return diffLoadedMsg{path: path, lines: renderDiffLines(diffs, tc)}
+		lines := renderDiffLines(diffs, tc)
+		// Prepend an at-a-glance summary of the whole change (all files in the
+		// range), so commit and PR diffs show how big the change is without
+		// scrolling. The extra fetch is best-effort; on error the diff still
+		// renders without a summary.
+		if all, serr := gc.Diff(ctx, git.DiffOpts{
+			CommitA:  commitA,
+			CommitB:  commitB,
+			ThreeDot: threeDot,
+		}); serr == nil {
+			if summary := diffStatSummaryLine(git.Stat(all), tc); summary != "" {
+				lines = append([]string{summary, ""}, lines...)
+			}
+		}
+		return diffLoadedMsg{path: path, lines: lines}
 	}
+}
+
+// diffStatSummaryLine renders a compact, styled one-line change summary such as
+// "5 files changed, +128 -34". Insertions are colored like additions and
+// deletions like removals; the file count uses the diff header color. It
+// returns an empty string when there are no changes.
+func diffStatSummaryLine(s git.DiffStat, tc theme.Colors) string {
+	if s.IsZero() {
+		return ""
+	}
+	labelStyle := lipgloss.NewStyle().Foreground(panels.ColorOf(tc.DiffHeader, "#7A9EBF"))
+	addStyle := lipgloss.NewStyle().Foreground(panels.ColorOf(tc.DiffAdded, "#6B9E56"))
+	delStyle := lipgloss.NewStyle().Foreground(panels.ColorOf(tc.DiffRemoved, "#C44B4B"))
+	noun := "files"
+	if s.FilesChanged == 1 {
+		noun = "file"
+	}
+	label := labelStyle.Render(fmt.Sprintf("%d %s changed, ", s.FilesChanged, noun))
+	ins := addStyle.Render(fmt.Sprintf("+%d", s.Insertions))
+	del := delStyle.Render(fmt.Sprintf("-%d", s.Deletions))
+	return label + ins + " " + del
 }
 
 // renderDiffLines converts parsed diff hunks to styled display lines.

--- a/magefile.go
+++ b/magefile.go
@@ -347,6 +347,10 @@ var deadcodeAllowlist = []string{
 	"MockClient.RevertContinue",
 	"MockClient.RevertAbort",
 	"MockClient.Reset",
+
+	// git — exported plain-text summary method on DiffStat (public package API;
+	// the preview renders a colored variant, so this is unused internally)
+	"DiffStat.Summary",
 }
 
 // Default target when running `mage` with no args.


### PR DESCRIPTION
Commit, branch, and PR diffs in the preview panel now start with a one-line summary of the whole change, so you can see how big it is without scrolling.

## What changed
- Added `git.DiffStat` with `Stat`, `IsZero`, and `Summary` helpers in `internal/git/stat.go`.
- The preview panel prepends a colored summary line (files changed, insertions, deletions) to ref-based diffs.
- The whole-range stat is fetched best-effort next to the existing path-scoped diff, so the diff still renders if the stat fetch fails.

## Testing
- `go build ./...`
- `go test ./internal/git/ -run 'TestStat|TestDiffStat'` and `go test ./internal/panels/preview/...`
- `gofumpt` clean

Closes #222