### PR TITLE
Add jump to line number in preview

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -166,6 +166,7 @@ Preview panel (panel 5).
 | `f` | Toggle diff view |
 | `j/k` | Scroll content |
 | `g/G` | Jump to top/bottom |
+| `L` | Go to line |
 | `PgDn/PgUp` | Page down/up |
 | `W` | Toggle word wrap |
 | `n` | Toggle line numbers |

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -142,6 +142,7 @@
         { "key": "f", "action": "Toggle diff view" },
         { "key": "j/k", "action": "Scroll content" },
         { "key": "g/G", "action": "Jump to top/bottom" },
+        { "key": "L", "action": "Go to line" },
         { "key": "PgDn/PgUp", "action": "Page down/up" },
         { "key": "W", "action": "Toggle word wrap" },
         { "key": "n", "action": "Toggle line numbers" },

--- a/internal/panels/messages.go
+++ b/internal/panels/messages.go
@@ -830,6 +830,16 @@ type EditModeExitedMsg struct {
 	Path string
 }
 
+// PreviewInputStartedMsg notifies the app that the preview panel opened an
+// inline text prompt (for example, the go-to-line prompt). While a prompt is
+// open the app routes all key presses directly to the preview so digits and
+// Enter/Esc are not intercepted by global bindings.
+type PreviewInputStartedMsg struct{}
+
+// PreviewInputEndedMsg notifies the app that the preview panel closed its
+// inline text prompt, so normal key routing should resume.
+type PreviewInputEndedMsg struct{}
+
 // ---------------------------------------------------------------------------
 // Overlay panel messages
 // ---------------------------------------------------------------------------

--- a/internal/panels/preview/editor.go
+++ b/internal/panels/preview/editor.go
@@ -19,7 +19,9 @@ import (
 
 // Key name constants for KeyPressMsg.String() comparisons.
 const (
-	keyDown = "down"
+	keyDown   = "down"
+	keyEsc    = "esc"
+	keyEscape = "escape"
 
 	// clipboardTimeout bounds how long clipboard subprocess calls may block.
 	clipboardTimeout = 2 * time.Second
@@ -241,7 +243,7 @@ func handleEditKeyPress(p *Preview, msg tea.KeyPressMsg) (panels.Panel, tea.Cmd)
 	key := msg.String()
 	switch key {
 	// --- Mode transitions ---
-	case "escape", "esc":
+	case keyEscape, keyEsc:
 		if p.editBuf != nil && p.editBuf.Dirty() {
 			return p, dirtyGuardCmd(p, "exit")
 		}

--- a/internal/panels/preview/gotoline_test.go
+++ b/internal/panels/preview/gotoline_test.go
@@ -1,0 +1,151 @@
+package preview
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/jongio/grut/internal/panels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeLines returns n placeholder content lines for scroll math tests.
+func makeLines(n int) []string {
+	lines := make([]string, n)
+	for i := range lines {
+		lines[i] = "line"
+	}
+	return lines
+}
+
+func TestGotoLine_CentersAndClamps(t *testing.T) {
+	// newTestPreview sets height = 24, so viewportHeight() = 23 and the
+	// centering offset is viewportHeight()/2 = 11.
+	tests := []struct {
+		name    string
+		lines   int
+		target  int
+		wantTop int
+	}{
+		{name: "centers a middle line", lines: 100, target: 50, wantTop: 38},
+		{name: "clamps below first line to top", lines: 100, target: 1, wantTop: 0},
+		{name: "near-top line clamps to top", lines: 100, target: 5, wantTop: 0},
+		{name: "clamps past last line to bottom", lines: 100, target: 1000, wantTop: 77},
+		{name: "negative input clamps to top", lines: 100, target: -5, wantTop: 0},
+		{name: "content shorter than viewport stays at top", lines: 5, target: 3, wantTop: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newTestPreview(makeLines(tt.lines))
+			p.gotoLine(tt.target)
+			assert.Equal(t, tt.wantTop, p.scrollY)
+		})
+	}
+}
+
+func TestGotoLine_EmptyContentNoChange(t *testing.T) {
+	p := newTestPreview(nil)
+	p.scrollY = 0
+	p.gotoLine(42)
+	assert.Equal(t, 0, p.scrollY)
+}
+
+func TestGotoLine_IndependentOfWrapAndLineNumbers(t *testing.T) {
+	// The target offset is computed from source line indices, so it must be
+	// the same whether word-wrap or line-number display is on or off.
+	p := newTestPreview(makeLines(100))
+	p.wordWrap = true
+	p.lineNumbers = false
+	p.gotoLine(50)
+	assert.Equal(t, 38, p.scrollY)
+
+	p.wordWrap = false
+	p.lineNumbers = true
+	p.gotoLine(50)
+	assert.Equal(t, 38, p.scrollY)
+}
+
+func TestGotoLinePrompt_OpenTypeCommit(t *testing.T) {
+	p := newTestPreview(makeLines(100))
+
+	// Open the prompt with "L".
+	_, cmd := p.Update(keyMsg("L"))
+	require.True(t, p.gotoLineActive, "prompt should be active after L")
+	require.NotNil(t, cmd)
+	_, ok := cmd().(panels.PreviewInputStartedMsg)
+	assert.True(t, ok, "opening should emit PreviewInputStartedMsg")
+
+	// Type "42".
+	p.Update(keyMsg("4"))
+	p.Update(keyMsg("2"))
+	assert.Equal(t, "42", p.gotoLineInput)
+
+	// Backspace removes the last digit, then retype.
+	p.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	assert.Equal(t, "4", p.gotoLineInput)
+	p.Update(keyMsg("2"))
+	assert.Equal(t, "42", p.gotoLineInput)
+
+	// Enter commits: scroll to line 42, centered (42-1-11 = 30), and close.
+	_, cmd = p.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assert.False(t, p.gotoLineActive, "prompt should close after Enter")
+	assert.Equal(t, "", p.gotoLineInput)
+	assert.Equal(t, 30, p.scrollY)
+	require.NotNil(t, cmd)
+	_, ok = cmd().(panels.PreviewInputEndedMsg)
+	assert.True(t, ok, "closing should emit PreviewInputEndedMsg")
+}
+
+func TestGotoLinePrompt_EscapeCancels(t *testing.T) {
+	p := newTestPreview(makeLines(100))
+	p.scrollY = 7
+
+	p.Update(keyMsg("L"))
+	p.Update(keyMsg("5"))
+	require.True(t, p.gotoLineActive)
+
+	_, cmd := p.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	assert.False(t, p.gotoLineActive, "Escape should close the prompt")
+	assert.Equal(t, "", p.gotoLineInput)
+	assert.Equal(t, 7, p.scrollY, "Escape must not change the scroll position")
+	require.NotNil(t, cmd)
+	_, ok := cmd().(panels.PreviewInputEndedMsg)
+	assert.True(t, ok)
+}
+
+func TestGotoLinePrompt_EmptyInputRejected(t *testing.T) {
+	p := newTestPreview(makeLines(100))
+	p.scrollY = 12
+
+	p.Update(keyMsg("L"))
+	// Commit with no digits entered.
+	p.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assert.False(t, p.gotoLineActive)
+	assert.Equal(t, 12, p.scrollY, "empty input must not change the view")
+}
+
+func TestGotoLinePrompt_NonDigitsIgnored(t *testing.T) {
+	p := newTestPreview(makeLines(100))
+	p.Update(keyMsg("L"))
+	// Letters should not be added to the numeric entry.
+	p.Update(keyMsg("a"))
+	p.Update(keyMsg("z"))
+	assert.Equal(t, "", p.gotoLineInput)
+}
+
+func TestGotoLinePrompt_RendersInView(t *testing.T) {
+	p := newTestPreview(makeLines(100))
+	p.filePath = "test.go"
+	p.Update(keyMsg("L"))
+	p.Update(keyMsg("7"))
+	out := p.View(80, 24)
+	assert.Contains(t, out, "Go to line: 7")
+}
+
+func TestGotoLine_NotAvailableInGitHubMode(t *testing.T) {
+	p := newTestPreview(makeLines(100))
+	p.ghMode = true
+	_, cmd := p.Update(keyMsg("L"))
+	assert.False(t, p.gotoLineActive, "prompt should not open in GitHub content mode")
+	assert.Nil(t, cmd)
+}

--- a/internal/panels/preview/preview.go
+++ b/internal/panels/preview/preview.go
@@ -519,7 +519,7 @@ func (p *Preview) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 			if p.hasSelection() {
 				return p.copySelection()
 			}
-		case "escape", "esc":
+		case keyEscape, keyEsc:
 			if p.hasSelection() {
 				p.clearSelection()
 			}
@@ -556,7 +556,7 @@ func (p *Preview) closeGotoLine() tea.Cmd {
 // Non-numeric input is ignored so the view never changes unexpectedly.
 func (p *Preview) handleGotoLineKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 	switch msg.String() {
-	case "escape", "esc":
+	case keyEscape, keyEsc:
 		return p, p.closeGotoLine()
 	case "enter":
 		p.commitGotoLine()

--- a/internal/panels/preview/preview.go
+++ b/internal/panels/preview/preview.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -59,6 +60,10 @@ type Preview struct {
 	renderMarkdown bool
 	// Blame mode
 	blameMode bool
+	// Go-to-line prompt state. When active, the panel captures key presses
+	// as a line-number entry and scrolls to the entered line on Enter.
+	gotoLineActive bool
+	gotoLineInput  string
 	// GitHub content mode – when a GitHub item (issue/PR/action run) is
 	// selected, the preview shows the item detail instead of a file.
 	ghMode      bool // true when showing GitHub content instead of file
@@ -462,6 +467,10 @@ func (p *Preview) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 		if p.editMode {
 			return handleEditKeyPress(p, msg)
 		}
+		// Go-to-line prompt captures all input until it is committed or cancelled.
+		if p.gotoLineActive {
+			return p.handleGotoLineKey(msg)
+		}
 		switch msg.String() {
 		case "e":
 			// Edit is only allowed in file mode (not diff) and for local files.
@@ -485,6 +494,8 @@ func (p *Preview) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 			p.scrollY = 0
 		case "G":
 			p.scrollToBottom()
+		case "L":
+			return p, p.openGotoLine()
 		case "W":
 			p.wordWrap = !p.wordWrap
 		case "n":
@@ -517,8 +528,83 @@ func (p *Preview) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 	return p, nil
 }
 
-// View implements panels.Panel. It renders the preview content into the
-// given width×height area.
+// openGotoLine activates the go-to-line prompt when there is scrollable file
+// or diff content. It returns a command that tells the app to route all key
+// presses to the preview until the prompt closes. It is a no-op (returns nil)
+// for GitHub content, blame, binary, or oversized views where line numbers do
+// not apply.
+func (p *Preview) openGotoLine() tea.Cmd {
+	if p.ghMode || p.blameMode || p.isBinary || p.isLarge || p.contentLineCount() == 0 {
+		return nil
+	}
+	p.gotoLineActive = true
+	p.gotoLineInput = ""
+	return func() tea.Msg { return panels.PreviewInputStartedMsg{} }
+}
+
+// closeGotoLine deactivates the prompt and clears the entered text. It returns
+// a command that tells the app to resume normal key routing.
+func (p *Preview) closeGotoLine() tea.Cmd {
+	p.gotoLineActive = false
+	p.gotoLineInput = ""
+	return func() tea.Msg { return panels.PreviewInputEndedMsg{} }
+}
+
+// handleGotoLineKey processes a key press while the go-to-line prompt is open.
+// Digits are appended to the entry, Backspace removes the last digit, Enter
+// commits (scrolls to the clamped line), and Esc cancels with no change.
+// Non-numeric input is ignored so the view never changes unexpectedly.
+func (p *Preview) handleGotoLineKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
+	switch msg.String() {
+	case "escape", "esc":
+		return p, p.closeGotoLine()
+	case "enter":
+		p.commitGotoLine()
+		return p, p.closeGotoLine()
+	case "backspace":
+		if r := []rune(p.gotoLineInput); len(r) > 0 {
+			p.gotoLineInput = string(r[:len(r)-1])
+		}
+		return p, nil
+	default:
+		if s := msg.String(); len(s) == 1 && s[0] >= '0' && s[0] <= '9' {
+			// Cap the length to avoid overflow and nonsensical input.
+			if len(p.gotoLineInput) < 9 {
+				p.gotoLineInput += s
+			}
+		}
+		return p, nil
+	}
+}
+
+// commitGotoLine parses the entered text and scrolls to that line. Empty or
+// non-numeric input is rejected without changing the view.
+func (p *Preview) commitGotoLine() {
+	n, err := strconv.Atoi(strings.TrimSpace(p.gotoLineInput))
+	if err != nil {
+		return
+	}
+	p.gotoLine(n)
+}
+
+// gotoLine scrolls so that line n (1-based) is centered in the viewport when
+// there is room. Out-of-range values are clamped to the first or last line.
+func (p *Preview) gotoLine(n int) {
+	total := p.contentLineCount()
+	if total == 0 {
+		return
+	}
+	if n < 1 {
+		n = 1
+	}
+	if n > total {
+		n = total
+	}
+	// Center the target line; clampScroll keeps the offset in valid bounds.
+	p.scrollY = (n - 1) - p.viewportHeight()/2
+	p.clampScroll()
+}
+
 func (p *Preview) View(width, height int) string {
 	if width <= 0 || height <= 0 {
 		return ""
@@ -627,6 +713,7 @@ func (p *Preview) KeyBindings() []panels.KeyBinding {
 		{Key: "PgUp", Description: "Page up", Action: "page_up"},
 		{Key: "g", Description: "Go to top", Action: "goto_top"},
 		{Key: "G", Description: "Go to bottom", Action: "goto_bottom"},
+		{Key: "L", Description: "Go to line", Action: "goto_line"},
 		{Key: "W", Description: "Toggle word wrap", Action: "toggle_wrap"},
 		{Key: "n", Description: "Toggle line numbers", Action: "toggle_line_numbers"},
 		{Key: "m", Description: "Toggle markdown render", Action: "toggle_markdown_render"},
@@ -1164,8 +1251,11 @@ func (p *Preview) renderContent(width, height int) string {
 		}
 	}
 	content := strings.Join(rendered, "\n")
-	// Add scroll indicator
+	// Add scroll indicator, or the go-to-line prompt when it is active.
 	scrollInfo := p.scrollIndicator(totalLines, height)
+	if p.gotoLineActive {
+		scrollInfo = "Go to line: " + p.gotoLineInput
+	}
 	scrollLine := ansi.Truncate(p.newDimStyle().Render(scrollInfo), width, "")
 	content += "\n" + scrollLine
 	return content

--- a/internal/panels/preview/preview_test.go
+++ b/internal/panels/preview/preview_test.go
@@ -778,7 +778,7 @@ func TestKeyBindings(t *testing.T) {
 	bindings := p.KeyBindings()
 
 	assert.NotEmpty(t, bindings)
-	assert.Len(t, bindings, 13)
+	assert.Len(t, bindings, 14)
 
 	// Verify all expected bindings are present
 	actions := make([]string, len(bindings))
@@ -794,6 +794,7 @@ func TestKeyBindings(t *testing.T) {
 	assert.Contains(t, actions, "page_up")
 	assert.Contains(t, actions, "goto_top")
 	assert.Contains(t, actions, "goto_bottom")
+	assert.Contains(t, actions, "goto_line")
 	assert.Contains(t, actions, "toggle_wrap")
 	assert.Contains(t, actions, "toggle_line_numbers")
 	assert.Contains(t, actions, "toggle_markdown_render")

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -80,6 +80,7 @@ type Model struct {
 	ready              bool   // true after first WindowSizeMsg
 	cwdEditing         bool   // true when status bar CWD is in inline-edit mode
 	previewEditing     bool   // true when preview panel is in edit mode
+	previewInput       bool   // true when preview panel has an inline prompt open (e.g. go-to-line)
 }
 
 // New creates a new TUI model with the given panel manager, theme, keymap,
@@ -278,6 +279,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case panels.EditModeExitedMsg:
 		m.previewEditing = false
 		return m.handleDefaultMsg(msg)
+
+	// Inline preview prompt tracking — the preview panel broadcasts these
+	// when it opens or closes an inline text prompt (e.g. go-to-line) so we
+	// route all keys to it and skip global bindings while it is open.
+	case panels.PreviewInputStartedMsg:
+		m.previewInput = true
+		return m, nil
+	case panels.PreviewInputEndedMsg:
+		m.previewInput = false
+		return m, nil
 
 	// Mouse events — may fall through to default broadcast.
 	case tea.MouseClickMsg, tea.MouseReleaseMsg, tea.MouseWheelMsg:

--- a/internal/tui/app_update.go
+++ b/internal/tui/app_update.go
@@ -430,6 +430,13 @@ func (m Model) handleKeyPressMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.cwdEditing {
 		return m.handleCWDEditKey(msg)
 	}
+	// If the preview panel has an inline prompt open (e.g. go-to-line),
+	// route every key straight to it so digits and Enter/Esc are not
+	// intercepted by global bindings.
+	if m.previewInput {
+		cmd := m.engine.Update(msg)
+		return m, cmd
+	}
 	// If an async operation is running, Esc cancels it.
 	if msg.String() == "esc" && m.asyncCancel != nil {
 		return m.cancelAsyncOp()


### PR DESCRIPTION
## What

Adds a jump to line number feature to the preview panel. Press `L` to open a prompt, type a line number, and press Enter to jump straight there. The target line is centered in the viewport when there is room.

## Why

Scrolling to a specific line in a long file or diff is slow. When a build error or review comment points at a line number, you want to go there directly instead of paging through the file.

## How

- `L` opens an inline prompt at the bottom of the preview (`Go to line: `).
- Digits build the number, Backspace edits, Enter jumps, Esc cancels.
- The jump indexes source lines, so it lands on the right line whether word wrap or line numbers are on or off, and in file, diff, or blame views.
- While the prompt is open, all keys route to the preview so digits are captured as input rather than triggering panel focus shortcuts.

## Testing

- New `gotoline_test.go` covers clamping, centering offset, prompt open/type/commit, escape cancel, empty and non-digit rejection, and prompt rendering.
- `go build ./...`, `go vet ./...`, preview and keybindings packages pass, gofumpt clean.

Closes #223
