### PR TITLE
feat(gitstatus): copy the current diff hunk to the clipboard

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -81,6 +81,7 @@ Active when the file tree is in git filter mode (press f to cycle).
 | `s` | Stage file/hunk/line |
 | `u` | Unstage file/hunk/line |
 | `d` | Discard unstaged changes |
+| `y` | Copy the current diff hunk (or file path) to the clipboard |
 | `c` | Commit staged changes |
 | `p` | Pull from remote |
 | `a` | Stage all |

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -65,6 +65,7 @@
         { "key": "s", "action": "Stage file/hunk/line" },
         { "key": "u", "action": "Unstage file/hunk/line" },
         { "key": "d", "action": "Discard unstaged changes" },
+        { "key": "y", "action": "Copy the current diff hunk (or file path) to the clipboard" },
         { "key": "c", "action": "Commit staged changes" },
         { "key": "p", "action": "Pull from remote" },
         { "key": "a", "action": "Stage all" },

--- a/internal/panels/gitstatus/copy_hunk_test.go
+++ b/internal/panels/gitstatus/copy_hunk_test.go
@@ -1,0 +1,113 @@
+package gitstatus
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/jongio/grut/internal/git"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHunkText(t *testing.T) {
+	h := git.Hunk{
+		Header: "@@ -1,3 +1,4 @@ func main()",
+		Lines: []git.DiffLine{
+			{Type: git.DiffLineContext, Content: "ctx"},
+			{Type: git.DiffLineRemoved, Content: "old"},
+			{Type: git.DiffLineAdded, Content: "new1"},
+			{Type: git.DiffLineAdded, Content: "new2"},
+		},
+	}
+	want := "@@ -1,3 +1,4 @@ func main()\n ctx\n-old\n+new1\n+new2\n"
+	assert.Equal(t, want, hunkText(h))
+}
+
+func TestHunkTextRebuildsMissingHeader(t *testing.T) {
+	h := git.Hunk{
+		OldStart: 2, OldLines: 1, NewStart: 2, NewLines: 2,
+		Lines: []git.DiffLine{{Type: git.DiffLineAdded, Content: "x"}},
+	}
+	got := hunkText(h)
+	assert.True(t, strings.HasPrefix(got, "@@ -2,1 +2,2 @@\n"), "got %q", got)
+}
+
+func TestHunkTextNoNewlineEOF(t *testing.T) {
+	h := git.Hunk{
+		Header:       "@@ -1 +1 @@",
+		NoNewlineEOF: true,
+		Lines:        []git.DiffLine{{Type: git.DiffLineAdded, Content: "a"}},
+	}
+	assert.Contains(t, hunkText(h), "\\ No newline at end of file\n")
+}
+
+func TestHunkAtCursor(t *testing.T) {
+	p := New(&mockGitClient{}, nil)
+	file := &git.FileStatus{Path: "main.go"}
+	hunks := []git.Hunk{{
+		Header: "@@ -1,1 +1,2 @@",
+		Lines:  []git.DiffLine{{Type: git.DiffLineAdded, Content: "a"}},
+	}}
+	p.diffCache["main.go:unstaged"] = hunks
+	p.rows = []row{
+		{kind: rowSection, section: sectionUnstaged},
+		{kind: rowFile, section: sectionUnstaged, file: file},
+		{kind: rowHunk, section: sectionUnstaged, file: file, hunkIdx: 0, hunkEntry: &hunks[0]},
+		{kind: rowDiffLine, section: sectionUnstaged, file: file, hunkIdx: 0, lineIdx: 0},
+	}
+
+	p.cursor = 2 // hunk header row
+	h, ok := p.hunkAtCursor()
+	require.True(t, ok)
+	assert.Equal(t, "@@ -1,1 +1,2 @@", h.Header)
+
+	p.cursor = 3 // diff line row resolves to its parent hunk
+	h, ok = p.hunkAtCursor()
+	require.True(t, ok)
+	assert.Equal(t, "@@ -1,1 +1,2 @@", h.Header)
+
+	p.cursor = 1 // file row has no single hunk
+	_, ok = p.hunkAtCursor()
+	assert.False(t, ok)
+
+	p.cursor = 0 // section header row has no hunk
+	_, ok = p.hunkAtCursor()
+	assert.False(t, ok)
+}
+
+func TestCopyHunkKey(t *testing.T) {
+	p := New(&mockGitClient{}, nil)
+	p.ctx = context.Background()
+	p.Focus()
+	file := &git.FileStatus{Path: "main.go"}
+	hunks := []git.Hunk{{
+		Header: "@@ -1,1 +1,2 @@",
+		Lines:  []git.DiffLine{{Type: git.DiffLineAdded, Content: "a"}},
+	}}
+	p.diffCache["main.go:unstaged"] = hunks
+	p.rows = []row{
+		{kind: rowHunk, section: sectionUnstaged, file: file, hunkIdx: 0, hunkEntry: &hunks[0]},
+	}
+	p.cursor = 0
+
+	_, cmd := p.Update(tea.KeyPressMsg{Code: 'y'})
+	require.NotNil(t, cmd, "expected a command from y on a hunk row")
+}
+
+func TestCopyAtCursorFallsBackToPath(t *testing.T) {
+	p := New(&mockGitClient{}, nil)
+	p.ctx = context.Background()
+	p.Focus()
+	file := &git.FileStatus{Path: "main.go"}
+	p.rows = []row{
+		{kind: rowFile, section: sectionUnstaged, file: file},
+	}
+	p.cursor = 0
+
+	// On a file row there is no hunk, so copyAtCursor should still return a
+	// command (the copy-path path).
+	_, cmd := p.copyAtCursor()
+	require.NotNil(t, cmd)
+}

--- a/internal/panels/gitstatus/gitstatus.go
+++ b/internal/panels/gitstatus/gitstatus.go
@@ -398,6 +398,7 @@ func (p *GitStatus) KeyBindings() []panels.KeyBinding {
 		{Key: "enter/l", Description: "Expand file diff", Action: "expand"},
 		{Key: "h", Description: "Enter hunk mode", Action: "hunk_mode"},
 		{Key: "d", Description: "Discard unstaged changes", Action: "discard"},
+		{Key: "y", Description: "Copy hunk (or file path) to clipboard", Action: "copy"},
 		{Key: "space", Description: "Toggle select for bulk", Action: "toggle_select"},
 		{Key: "a", Description: "Stage all", Action: "stage_all"},
 		{Key: "U", Description: "Unstage all", Action: "unstage_all"},
@@ -774,6 +775,87 @@ func (p *GitStatus) copyPath() (panels.Panel, tea.Cmd) {
 	}
 }
 
+// copyAtCursor copies the hunk under the cursor when the cursor is on a hunk
+// or diff line, and otherwise falls back to copying the file path. This keeps
+// "y" consistent with the copy-path binding used elsewhere while adding hunk
+// copying inside an expanded diff.
+func (p *GitStatus) copyAtCursor() (panels.Panel, tea.Cmd) {
+	if hunk, ok := p.hunkAtCursor(); ok {
+		return p.copyHunk(hunk)
+	}
+	return p.copyPath()
+}
+
+// hunkAtCursor returns the hunk the cursor is currently on, whether the cursor
+// sits on the hunk header row or one of its diff lines.
+func (p *GitStatus) hunkAtCursor() (git.Hunk, bool) {
+	if p.cursor < 0 || p.cursor >= len(p.rows) {
+		return git.Hunk{}, false
+	}
+	r := &p.rows[p.cursor]
+	switch r.kind {
+	case rowHunk:
+		if r.hunkEntry != nil {
+			return *r.hunkEntry, true
+		}
+	case rowDiffLine:
+		hunks := p.diffCache[p.fileKey(r)]
+		if r.hunkIdx >= 0 && r.hunkIdx < len(hunks) {
+			return hunks[r.hunkIdx], true
+		}
+	case rowSection, rowFile:
+		return git.Hunk{}, false
+	}
+	return git.Hunk{}, false
+}
+
+// copyHunk writes the hunk as a unified diff to the OS clipboard.
+func (p *GitStatus) copyHunk(hunk git.Hunk) (panels.Panel, tea.Cmd) {
+	text := hunkText(hunk)
+	if err := panels.CopyToClipboard(p.ctx, text); err != nil {
+		errMsg := err.Error()
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{Message: "Copy failed: " + errMsg, Level: notify.Error}
+		}
+	}
+	n := len(hunk.Lines)
+	return p, func() tea.Msg {
+		return notify.ShowToastMsg{
+			Message: fmt.Sprintf("Copied hunk (%d lines)", n),
+			Level:   notify.Success,
+		}
+	}
+}
+
+// hunkText renders a hunk back into unified diff text, restoring the leading
+// space, "+" or "-" that identifies each line. When the parsed header is
+// missing it is rebuilt from the hunk's line ranges.
+func hunkText(h git.Hunk) string {
+	header := h.Header
+	if header == "" {
+		header = fmt.Sprintf("@@ -%d,%d +%d,%d @@", h.OldStart, h.OldLines, h.NewStart, h.NewLines)
+	}
+	var b strings.Builder
+	b.WriteString(header)
+	b.WriteString("\n")
+	for _, line := range h.Lines {
+		switch line.Type {
+		case git.DiffLineContext:
+			b.WriteString(" ")
+		case git.DiffLineAdded:
+			b.WriteString("+")
+		case git.DiffLineRemoved:
+			b.WriteString("-")
+		}
+		b.WriteString(line.Content)
+		b.WriteString("\n")
+	}
+	if h.NoNewlineEOF {
+		b.WriteString("\\ No newline at end of file\n")
+	}
+	return b.String()
+}
+
 // handleMouseWheel scrolls the git status viewport.
 func (p *GitStatus) handleMouseWheel(msg tea.MouseWheelMsg) (panels.Panel, tea.Cmd) {
 	m := msg.Mouse()
@@ -838,6 +920,8 @@ func (p *GitStatus) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		return p.unstageAll()
 	case "d":
 		return p.discardAtCursor()
+	case "y":
+		return p.copyAtCursor()
 	case "R":
 		p.loading = true
 		p.expandedFiles = make(map[string]bool)


### PR DESCRIPTION
## Summary

Adds `y` in the git status panel to copy the current diff hunk to the clipboard.

- When the cursor is on a hunk header or one of its diff lines, the whole hunk is copied as unified diff text: the `@@ ... @@` header followed by the space / `+` / `-` prefixed lines.
- On a file row, `y` falls back to copying the file path, so the key matches the copy-path binding already used in the file tree and commits panels.
- A missing parsed header is rebuilt from the hunk line ranges, and the `\ No newline at end of file` marker is preserved.

## Why

When reviewing changes, it is common to want to drop a hunk into a pull request comment, a chat message, or a scratch file. Today that means selecting the text by hand or leaving the panel. Copying the hunk you are already looking at is one keypress.

## Testing

- `go build ./...`
- `go test ./internal/panels/gitstatus/ ./internal/keybindings/`
- `golangci-lint run ./internal/panels/gitstatus/...` (0 issues)
- `gofumpt -l` clean

New tests cover the unified-diff rendering (context, added, removed, rebuilt header, no-newline marker), hunk resolution from both a hunk row and a diff-line row, the no-hunk cases on file and section rows, and the key wiring.

Keybinding is synced across the panel `KeyBindings()` method, `keybindings.json`, and the generated `docs/keybindings.md`.

Closes #230
