### PR TITLE
Word-level (intra-line) highlighting in diff views

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,7 @@ auto_fetch_interval = "5m"       # Automatic fetch interval
 show_commit_graph = true         # Display commit graph in git log
 max_log_entries = 500            # Maximum git log entries to display (≥ 1)
 sign_commits = false             # Sign commits with GPG
+diff_word_highlight = true       # Highlight changed words within lines in the diff view (toggle with w)
 ```
 
 ---

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,6 +94,7 @@ type GitConfig struct {
 	WorktreeFirst           bool     `toml:"worktree_first"`
 	ShowCommitGraph         bool     `toml:"show_commit_graph"`
 	SignCommits             bool     `toml:"sign_commits"`
+	DiffWordHighlight       bool     `toml:"diff_word_highlight"`
 }
 
 // GitHubConfig holds GitHub integration settings.

--- a/internal/config/defaults.toml
+++ b/internal/config/defaults.toml
@@ -41,6 +41,7 @@ auto_fetch_interval = "5m"
 show_commit_graph = true
 max_log_entries = 500
 sign_commits = false
+diff_word_highlight = true
 
 [github]
 owner = ""

--- a/internal/panels/gitdiff/gitdiff.go
+++ b/internal/panels/gitdiff/gitdiff.go
@@ -68,6 +68,7 @@ type GitDiff struct {
 	staged                bool // whether viewing staged (index) changes
 	loading               bool // true while async diff fetch is in progress
 	showReviewAnnotations bool // toggle for inline annotation display
+	wordHighlight         bool // toggle for intra-line (word-level) diff emphasis
 }
 
 // diffLoadedMsg is the result of an async diff fetch (F01: no blocking in Update).
@@ -95,6 +96,18 @@ func New(gitClient git.StatusReader, th *theme.Theme) *GitDiff {
 // SetActionsCfg stores the right-click context menu configuration.
 func (d *GitDiff) SetActionsCfg(cfg config.ActionsConfig) {
 	d.actionsCfg = cfg
+}
+
+// SetWordHighlight sets whether intra-line (word-level) emphasis is applied to
+// changed lines in the inline diff view. It is wired from the git config at
+// startup; the "w" key toggles it for the session.
+func (d *GitDiff) SetWordHighlight(enabled bool) {
+	if d.wordHighlight == enabled {
+		return
+	}
+	d.wordHighlight = enabled
+	d.rebuildLines()
+	d.clampScroll()
 }
 
 // Init implements panels.Panel.
@@ -282,6 +295,8 @@ func (d *GitDiff) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		d.prevFile()
 	case "R":
 		d.toggleReviewAnnotations()
+	case "w":
+		d.toggleWordHighlight()
 	}
 	return d, nil
 }
@@ -355,6 +370,7 @@ func (d *GitDiff) KeyBindings() []panels.KeyBinding {
 		{Key: "n/N", Description: "Next/previous hunk", Action: "hunk_nav"},
 		{Key: "[/]", Description: "Previous/next file", Action: "file_nav"},
 		{Key: "R", Description: "Toggle review annotations", Action: "toggle_review"},
+		{Key: "w", Description: "Toggle word-level diff", Action: "toggle_word_diff"},
 	}
 }
 
@@ -457,7 +473,11 @@ func (d *GitDiff) buildInlineLines() {
 		for _, hunk := range fd.Hunks {
 			d.hunkStarts = append(d.hunkStarts, len(d.lines))
 			d.lines = append(d.lines, d.headerStyle().Render(hunk.Header))
-			for _, line := range hunk.Lines {
+			var emph map[int][]wordSeg
+			if d.wordHighlight {
+				emph = computeHunkWordEmphasis(hunk.Lines)
+			}
+			for li, line := range hunk.Lines {
 				if len(d.lines) >= maxRenderedLines {
 					d.lines = append(d.lines, d.dimStyle().Render("[Diff truncated — too large to display]"))
 					return
@@ -465,9 +485,17 @@ func (d *GitDiff) buildInlineLines() {
 				var rendered string
 				switch line.Type {
 				case git.DiffLineAdded:
-					rendered = d.addedStyle().Render("+ " + line.Content)
+					if segs := emph[li]; len(segs) > 0 {
+						rendered = d.renderWordLine("+ ", d.addedStyle(), segs)
+					} else {
+						rendered = d.addedStyle().Render("+ " + line.Content)
+					}
 				case git.DiffLineRemoved:
-					rendered = d.removedStyle().Render("- " + line.Content)
+					if segs := emph[li]; len(segs) > 0 {
+						rendered = d.renderWordLine("- ", d.removedStyle(), segs)
+					} else {
+						rendered = d.removedStyle().Render("- " + line.Content)
+					}
 				default:
 					rendered = d.contextStyle().Render("  " + line.Content)
 				}
@@ -798,6 +826,14 @@ func (d *GitDiff) toggleReviewAnnotations() {
 	d.clampScroll()
 }
 
+// toggleWordHighlight toggles intra-line (word-level) emphasis for the session
+// and rebuilds lines. The startup default comes from git.diff_word_highlight.
+func (d *GitDiff) toggleWordHighlight() {
+	d.wordHighlight = !d.wordHighlight
+	d.rebuildLines()
+	d.clampScroll()
+}
+
 // filterFindingsForFile returns only findings whose File matches the
 // currently displayed path. If path is empty, no findings are returned.
 func (d *GitDiff) filterFindingsForFile(all []panels.AIReviewFinding) []panels.AIReviewFinding {
@@ -904,6 +940,23 @@ func (d *GitDiff) contextStyle() lipgloss.Style {
 		return d.theme.Styles.DiffContext
 	}
 	return lipgloss.NewStyle().Foreground(panels.ColorOf(d.themeColors().DiffContext, "#999999"))
+}
+
+// renderWordLine renders a changed diff line with intra-line emphasis. The
+// prefix ("+ " or "- ") and unchanged segments use base; changed segments are
+// reversed so the emphasis reads on any theme without guessing colors.
+func (d *GitDiff) renderWordLine(prefix string, base lipgloss.Style, segs []wordSeg) string {
+	emph := base.Reverse(true)
+	var b strings.Builder
+	b.WriteString(base.Render(prefix))
+	for _, s := range segs {
+		if s.Changed {
+			b.WriteString(emph.Render(s.Text))
+		} else {
+			b.WriteString(base.Render(s.Text))
+		}
+	}
+	return b.String()
 }
 
 func (d *GitDiff) headerStyle() lipgloss.Style {

--- a/internal/panels/gitdiff/register.go
+++ b/internal/panels/gitdiff/register.go
@@ -7,6 +7,10 @@ import (
 
 func init() {
 	panelreg.Register("gitdiff", func(deps panelreg.Deps) panels.Panel {
-		return deps.ApplyActionsCfg(New(deps.GitClient, deps.Theme))
+		d := New(deps.GitClient, deps.Theme)
+		if deps.Config != nil {
+			d.SetWordHighlight(deps.Config.Git.DiffWordHighlight)
+		}
+		return deps.ApplyActionsCfg(d)
 	})
 }

--- a/internal/panels/gitdiff/worddiff.go
+++ b/internal/panels/gitdiff/worddiff.go
@@ -1,0 +1,160 @@
+package gitdiff
+
+import (
+	"unicode"
+
+	"github.com/jongio/grut/internal/git"
+)
+
+// maxWordTokens caps the token count per line for the intra-line diff. Lines
+// longer than this fall back to plain line-level coloring so the O(n*m) LCS
+// stays bounded on pathological single-line files (e.g. minified assets).
+const maxWordTokens = 400
+
+// wordSeg is a run of characters within a diff line, flagged as changed or
+// unchanged relative to its paired line on the other side of the diff.
+type wordSeg struct {
+	Text    string
+	Changed bool
+}
+
+// isWordRune reports whether r is part of an identifier-like token. Runs of
+// these are grouped into a single token; every other rune is its own token so
+// punctuation and whitespace changes are highlighted precisely.
+func isWordRune(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// tokenizeWord splits s into tokens: maximal runs of word runes, plus one
+// token per non-word rune.
+func tokenizeWord(s string) []string {
+	if s == "" {
+		return nil
+	}
+	toks := make([]string, 0, len(s))
+	var buf []rune
+	flush := func() {
+		if len(buf) > 0 {
+			toks = append(toks, string(buf))
+			buf = buf[:0]
+		}
+	}
+	for _, r := range s {
+		if isWordRune(r) {
+			buf = append(buf, r)
+			continue
+		}
+		flush()
+		toks = append(toks, string(r))
+	}
+	flush()
+	return toks
+}
+
+// appendSeg appends text to segs, coalescing with the previous segment when it
+// carries the same Changed flag. This keeps the styled output compact.
+func appendSeg(segs []wordSeg, text string, changed bool) []wordSeg {
+	if n := len(segs); n > 0 && segs[n-1].Changed == changed {
+		segs[n-1].Text += text
+		return segs
+	}
+	return append(segs, wordSeg{Text: text, Changed: changed})
+}
+
+// diffWords computes intra-line change segments for a removed/added line pair
+// using a token-level longest common subsequence. It returns the segments for
+// the old line and the new line. When either line is empty, or a line exceeds
+// maxWordTokens, it returns (nil, nil) so the caller renders plain lines.
+func diffWords(oldLine, newLine string) (oldSegs, newSegs []wordSeg) {
+	a := tokenizeWord(oldLine)
+	b := tokenizeWord(newLine)
+	if len(a) == 0 || len(b) == 0 {
+		return nil, nil
+	}
+	if len(a) > maxWordTokens || len(b) > maxWordTokens {
+		return nil, nil
+	}
+
+	n, m := len(a), len(b)
+	// dp[i][j] = length of the LCS of a[i:] and b[j:].
+	dp := make([][]int, n+1)
+	for i := range dp {
+		dp[i] = make([]int, m+1)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				dp[i][j] = dp[i+1][j+1] + 1
+			} else if dp[i+1][j] >= dp[i][j+1] {
+				dp[i][j] = dp[i+1][j]
+			} else {
+				dp[i][j] = dp[i][j+1]
+			}
+		}
+	}
+
+	i, j := 0, 0
+	for i < n && j < m {
+		switch {
+		case a[i] == b[j]:
+			oldSegs = appendSeg(oldSegs, a[i], false)
+			newSegs = appendSeg(newSegs, b[j], false)
+			i++
+			j++
+		case dp[i+1][j] >= dp[i][j+1]:
+			oldSegs = appendSeg(oldSegs, a[i], true)
+			i++
+		default:
+			newSegs = appendSeg(newSegs, b[j], true)
+			j++
+		}
+	}
+	for ; i < n; i++ {
+		oldSegs = appendSeg(oldSegs, a[i], true)
+	}
+	for ; j < m; j++ {
+		newSegs = appendSeg(newSegs, b[j], true)
+	}
+	return oldSegs, newSegs
+}
+
+// computeHunkWordEmphasis pairs consecutive removed lines with consecutive
+// added lines inside a hunk and computes their intra-line change segments. The
+// result maps a line's index within lines to its segments. Only lines that are
+// part of a removed/added pair get an entry; pure additions and pure deletions
+// are left out so they render with plain line-level coloring.
+func computeHunkWordEmphasis(lines []git.DiffLine) map[int][]wordSeg {
+	out := make(map[int][]wordSeg)
+	var removed, added []int
+	flush := func() {
+		pairs := len(removed)
+		if len(added) < pairs {
+			pairs = len(added)
+		}
+		for k := 0; k < pairs; k++ {
+			oldSegs, newSegs := diffWords(lines[removed[k]].Content, lines[added[k]].Content)
+			if len(oldSegs) == 0 || len(newSegs) == 0 {
+				continue
+			}
+			out[removed[k]] = oldSegs
+			out[added[k]] = newSegs
+		}
+		removed = removed[:0]
+		added = added[:0]
+	}
+	for i := range lines {
+		switch lines[i].Type {
+		case git.DiffLineRemoved:
+			removed = append(removed, i)
+		case git.DiffLineAdded:
+			added = append(added, i)
+		default:
+			flush()
+		}
+	}
+	flush()
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/panels/gitdiff/worddiff_test.go
+++ b/internal/panels/gitdiff/worddiff_test.go
@@ -38,56 +38,56 @@ func TestTokenizeWord(t *testing.T) {
 }
 
 func TestDiffWordsIdentical(t *testing.T) {
-	old, new := diffWords("same line here", "same line here")
+	oldSegs, newSegs := diffWords("same line here", "same line here")
 	// No tokens changed; the reconstructed text is preserved on both sides.
-	assert.Equal(t, "same line here", segFull(old))
-	assert.Equal(t, "same line here", segFull(new))
-	assert.Empty(t, segText(old, true))
-	assert.Empty(t, segText(new, true))
+	assert.Equal(t, "same line here", segFull(oldSegs))
+	assert.Equal(t, "same line here", segFull(newSegs))
+	assert.Empty(t, segText(oldSegs, true))
+	assert.Empty(t, segText(newSegs, true))
 }
 
 func TestDiffWordsSingleWordChange(t *testing.T) {
-	old, new := diffWords("alpha beta gamma", "alpha delta gamma")
+	oldSegs, newSegs := diffWords("alpha beta gamma", "alpha delta gamma")
 	// Full text is preserved on each side.
-	assert.Equal(t, "alpha beta gamma", segFull(old))
-	assert.Equal(t, "alpha delta gamma", segFull(new))
+	assert.Equal(t, "alpha beta gamma", segFull(oldSegs))
+	assert.Equal(t, "alpha delta gamma", segFull(newSegs))
 	// Only the differing word is flagged; the shared words are not.
-	assert.Equal(t, "beta", segText(old, true))
-	assert.Equal(t, "delta", segText(new, true))
-	assert.Contains(t, segText(old, false), "alpha")
-	assert.Contains(t, segText(old, false), "gamma")
+	assert.Equal(t, "beta", segText(oldSegs, true))
+	assert.Equal(t, "delta", segText(newSegs, true))
+	assert.Contains(t, segText(oldSegs, false), "alpha")
+	assert.Contains(t, segText(oldSegs, false), "gamma")
 }
 
 func TestDiffWordsPrefixAndSuffix(t *testing.T) {
-	old, new := diffWords("func foo(a int)", "func foo(a, b int)")
-	assert.Equal(t, "func foo(a int)", segFull(old))
-	assert.Equal(t, "func foo(a, b int)", segFull(new))
+	oldSegs, newSegs := diffWords("func foo(a int)", "func foo(a, b int)")
+	assert.Equal(t, "func foo(a int)", segFull(oldSegs))
+	assert.Equal(t, "func foo(a, b int)", segFull(newSegs))
 	// The addition is only flagged on the new side.
-	assert.Empty(t, segText(old, true))
-	assert.NotEmpty(t, segText(new, true))
+	assert.Empty(t, segText(oldSegs, true))
+	assert.NotEmpty(t, segText(newSegs, true))
 }
 
 func TestDiffWordsFullReplacement(t *testing.T) {
-	old, new := diffWords("aaa", "bbb")
-	assert.Equal(t, "aaa", segText(old, true))
-	assert.Equal(t, "bbb", segText(new, true))
+	oldSegs, newSegs := diffWords("aaa", "bbb")
+	assert.Equal(t, "aaa", segText(oldSegs, true))
+	assert.Equal(t, "bbb", segText(newSegs, true))
 }
 
 func TestDiffWordsEmptyReturnsNil(t *testing.T) {
-	old, new := diffWords("", "added")
-	assert.Nil(t, old)
-	assert.Nil(t, new)
+	oldSegs, newSegs := diffWords("", "added")
+	assert.Nil(t, oldSegs)
+	assert.Nil(t, newSegs)
 
-	old, new = diffWords("removed", "")
-	assert.Nil(t, old)
-	assert.Nil(t, new)
+	oldSegs, newSegs = diffWords("removed", "")
+	assert.Nil(t, oldSegs)
+	assert.Nil(t, newSegs)
 }
 
 func TestDiffWordsOverCapFallsBack(t *testing.T) {
 	long := strings.Repeat("a ", maxWordTokens+10) // > maxWordTokens tokens
-	old, new := diffWords(long, long+"x")
-	assert.Nil(t, old, "over-cap lines should fall back to plain rendering")
-	assert.Nil(t, new)
+	oldSegs, newSegs := diffWords(long, long+"x")
+	assert.Nil(t, oldSegs, "over-cap lines should fall back to plain rendering")
+	assert.Nil(t, newSegs)
 }
 
 func TestComputeHunkWordEmphasisPairsChanges(t *testing.T) {

--- a/internal/panels/gitdiff/worddiff_test.go
+++ b/internal/panels/gitdiff/worddiff_test.go
@@ -1,0 +1,202 @@
+package gitdiff
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jongio/grut/internal/git"
+	"github.com/jongio/grut/internal/panels"
+	"github.com/stretchr/testify/assert"
+)
+
+// segText joins the text of the changed (or unchanged) segments so tests can
+// assert which parts of a line were flagged.
+func segText(segs []wordSeg, changed bool) string {
+	var b strings.Builder
+	for _, s := range segs {
+		if s.Changed == changed {
+			b.WriteString(s.Text)
+		}
+	}
+	return b.String()
+}
+
+func segFull(segs []wordSeg) string {
+	var b strings.Builder
+	for _, s := range segs {
+		b.WriteString(s.Text)
+	}
+	return b.String()
+}
+
+func TestTokenizeWord(t *testing.T) {
+	assert.Nil(t, tokenizeWord(""))
+	assert.Equal(t, []string{"foo"}, tokenizeWord("foo"))
+	assert.Equal(t, []string{"foo", " ", "bar"}, tokenizeWord("foo bar"))
+	assert.Equal(t, []string{"a", "(", "b", ")"}, tokenizeWord("a(b)"))
+	assert.Equal(t, []string{"x_1", ".", "y2"}, tokenizeWord("x_1.y2"))
+}
+
+func TestDiffWordsIdentical(t *testing.T) {
+	old, new := diffWords("same line here", "same line here")
+	// No tokens changed; the reconstructed text is preserved on both sides.
+	assert.Equal(t, "same line here", segFull(old))
+	assert.Equal(t, "same line here", segFull(new))
+	assert.Empty(t, segText(old, true))
+	assert.Empty(t, segText(new, true))
+}
+
+func TestDiffWordsSingleWordChange(t *testing.T) {
+	old, new := diffWords("alpha beta gamma", "alpha delta gamma")
+	// Full text is preserved on each side.
+	assert.Equal(t, "alpha beta gamma", segFull(old))
+	assert.Equal(t, "alpha delta gamma", segFull(new))
+	// Only the differing word is flagged; the shared words are not.
+	assert.Equal(t, "beta", segText(old, true))
+	assert.Equal(t, "delta", segText(new, true))
+	assert.Contains(t, segText(old, false), "alpha")
+	assert.Contains(t, segText(old, false), "gamma")
+}
+
+func TestDiffWordsPrefixAndSuffix(t *testing.T) {
+	old, new := diffWords("func foo(a int)", "func foo(a, b int)")
+	assert.Equal(t, "func foo(a int)", segFull(old))
+	assert.Equal(t, "func foo(a, b int)", segFull(new))
+	// The addition is only flagged on the new side.
+	assert.Empty(t, segText(old, true))
+	assert.NotEmpty(t, segText(new, true))
+}
+
+func TestDiffWordsFullReplacement(t *testing.T) {
+	old, new := diffWords("aaa", "bbb")
+	assert.Equal(t, "aaa", segText(old, true))
+	assert.Equal(t, "bbb", segText(new, true))
+}
+
+func TestDiffWordsEmptyReturnsNil(t *testing.T) {
+	old, new := diffWords("", "added")
+	assert.Nil(t, old)
+	assert.Nil(t, new)
+
+	old, new = diffWords("removed", "")
+	assert.Nil(t, old)
+	assert.Nil(t, new)
+}
+
+func TestDiffWordsOverCapFallsBack(t *testing.T) {
+	long := strings.Repeat("a ", maxWordTokens+10) // > maxWordTokens tokens
+	old, new := diffWords(long, long+"x")
+	assert.Nil(t, old, "over-cap lines should fall back to plain rendering")
+	assert.Nil(t, new)
+}
+
+func TestComputeHunkWordEmphasisPairsChanges(t *testing.T) {
+	lines := []git.DiffLine{
+		{Type: git.DiffLineContext, Content: "ctx"},
+		{Type: git.DiffLineRemoved, Content: "alpha beta gamma"},
+		{Type: git.DiffLineAdded, Content: "alpha delta gamma"},
+		{Type: git.DiffLineContext, Content: "ctx2"},
+	}
+	emph := computeHunkWordEmphasis(lines)
+	// Indices 1 (removed) and 2 (added) form a pair and get segments.
+	assert.Contains(t, emph, 1)
+	assert.Contains(t, emph, 2)
+	assert.Equal(t, "beta", segText(emph[1], true))
+	assert.Equal(t, "delta", segText(emph[2], true))
+}
+
+func TestComputeHunkWordEmphasisSkipsUnpaired(t *testing.T) {
+	// Pure additions with no preceding removed lines get no emphasis.
+	lines := []git.DiffLine{
+		{Type: git.DiffLineContext, Content: "ctx"},
+		{Type: git.DiffLineAdded, Content: "brand new line"},
+		{Type: git.DiffLineAdded, Content: "another new line"},
+	}
+	assert.Nil(t, computeHunkWordEmphasis(lines))
+}
+
+// wordDiffSampleDiff returns a diff whose change block swaps one word so the
+// intra-line highlighter has something to emphasize.
+func wordDiffSampleDiff() git.FileDiff {
+	return git.FileDiff{
+		Path: "file.go",
+		Hunks: []git.Hunk{
+			{
+				Header: "@@ -1,3 +1,3 @@",
+				Lines: []git.DiffLine{
+					{Type: git.DiffLineContext, Content: "ctx", OldLine: 1, NewLine: 1},
+					{Type: git.DiffLineRemoved, Content: "alpha beta gamma", OldLine: 2, NewLine: 0},
+					{Type: git.DiffLineAdded, Content: "alpha delta gamma", OldLine: 0, NewLine: 2},
+				},
+			},
+		},
+	}
+}
+
+// findLine returns the first rendered line whose ANSI-stripped text contains
+// the given substring.
+func findLine(lines []string, substr string) (string, bool) {
+	for _, l := range lines {
+		if strings.Contains(panels.StripANSI(l), substr) {
+			return l, true
+		}
+	}
+	return "", false
+}
+
+func TestWordHighlightOnPreservesTextAndAddsStyling(t *testing.T) {
+	th := loadTestTheme(t)
+
+	on := newTestPanel(th)
+	on.SetWordHighlight(true)
+	on.SetSize(80, 24)
+	on.SetDiffs([]git.FileDiff{wordDiffSampleDiff()})
+
+	off := newTestPanel(th)
+	off.SetSize(80, 24)
+	off.SetDiffs([]git.FileDiff{wordDiffSampleDiff()})
+
+	onAdded, ok := findLine(on.lines, "+ alpha delta gamma")
+	assert.True(t, ok, "added line should still render with its + prefix and full text")
+	offAdded, ok := findLine(off.lines, "+ alpha delta gamma")
+	assert.True(t, ok)
+
+	// Visible text is identical with and without highlighting.
+	assert.Equal(t, panels.StripANSI(offAdded), panels.StripANSI(onAdded))
+	// But the styled output differs because the changed word is emphasized.
+	assert.NotEqual(t, offAdded, onAdded, "word highlight should change the ANSI styling")
+}
+
+func TestWordHighlightDefaultOff(t *testing.T) {
+	// A freshly constructed panel keeps highlighting off so line-level tests
+	// and callers that never opt in are unaffected.
+	p := New(nil, nil)
+	assert.False(t, p.wordHighlight)
+}
+
+func TestSetWordHighlightRebuilds(t *testing.T) {
+	th := loadTestTheme(t)
+	p := newTestPanel(th)
+	p.SetSize(80, 24)
+	p.SetDiffs([]git.FileDiff{wordDiffSampleDiff()})
+	before, _ := findLine(p.lines, "+ alpha delta gamma")
+
+	p.SetWordHighlight(true)
+	after, ok := findLine(p.lines, "+ alpha delta gamma")
+	assert.True(t, ok)
+	assert.NotEqual(t, before, after, "enabling word highlight should rebuild rendered lines")
+}
+
+func TestToggleWordHighlightKey(t *testing.T) {
+	th := loadTestTheme(t)
+	p := newTestPanel(th)
+	p.SetSize(80, 24)
+	p.SetDiffs([]git.FileDiff{wordDiffSampleDiff()})
+	assert.False(t, p.wordHighlight)
+
+	_, _ = p.handleKey(keyMsg("w"))
+	assert.True(t, p.wordHighlight, "pressing w should enable word highlight")
+
+	_, _ = p.handleKey(keyMsg("w"))
+	assert.False(t, p.wordHighlight, "pressing w again should disable it")
+}


### PR DESCRIPTION
## What

Adds word-level (intra-line) highlighting to the inline diff view. When a line is modified, grut now emphasizes the specific words that changed instead of coloring the entire line. This makes small edits (a renamed variable, a flipped boolean, a tweaked string) obvious at a glance.

## How

- New `internal/panels/gitdiff/worddiff.go` tokenizes each side of a removed/added pair into word runs plus single punctuation/space tokens, then runs a token-level longest common subsequence to find which tokens changed.
- Changed tokens are rendered with reverse styling on top of the existing added/removed color. Reverse works on any theme without guessing colors.
- Consecutive removed lines are paired with consecutive added lines within a hunk (same block logic the side-by-side view already uses). Pure additions and pure deletions keep plain line-level coloring.
- Lines longer than 400 tokens fall back to plain rendering so the O(n*m) LCS stays bounded on minified or generated files.

## Config and keys

- `git.diff_word_highlight` (default `true`) sets the startup state.
- Press `w` in the diff panel to toggle it for the session.

## Testing

- `go build ./...`, `go test ./...` (full suite green).
- New tests cover the tokenizer, the LCS (identical, single-word change, prefix/suffix insert, full replacement, empty and over-cap fallback), hunk pairing, the `w` toggle, and that turning highlighting on preserves the visible text while changing the styling.

Closes #241