### PR TITLE
Add request-reviewers action to the GitHub PRs panel

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -135,6 +135,7 @@ GitHub panel (panel 3).
 | `o` | Open in browser |
 | `y` | Copy to clipboard |
 | `m` | Merge PR (PRs tab) |
+| `R` | Request reviewers (PRs tab) |
 | `r` | Rerun (Actions tab) |
 | `x` | Cancel (Actions tab) |
 | `D` | Dispatch workflow |

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -115,6 +115,7 @@
         { "key": "o", "action": "Open in browser" },
         { "key": "y", "action": "Copy to clipboard" },
         { "key": "m", "action": "Merge PR (PRs tab)" },
+        { "key": "R", "action": "Request reviewers (PRs tab)" },
         { "key": "r", "action": "Rerun (Actions tab)" },
         { "key": "x", "action": "Cancel (Actions tab)" },
         { "key": "D", "action": "Dispatch workflow" }

--- a/internal/panels/gitinfo/gitinfo.go
+++ b/internal/panels/gitinfo/gitinfo.go
@@ -148,6 +148,7 @@ const (
 	opPRMergeStrategy                    // awaiting merge strategy selection
 	opPRMergeConfirm                     // awaiting merge confirmation
 	opPRDeleteBranchAfterMerge           // awaiting post-merge branch deletion confirmation
+	opPRRequestReviewers                 // awaiting reviewer logins input
 )
 
 // ---------------------------------------------------------------------------
@@ -745,6 +746,8 @@ func (p *Panel) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 		return p.handlePRMergeResult(msg)
 	case prBranchDeleteResultMsg:
 		return p.handlePRBranchDeleteResult(msg)
+	case prRequestReviewersResultMsg:
+		return p.handlePRRequestReviewersResult(msg)
 
 	// CRUD actions dispatched via keymap.
 	case panels.ItemCreateMsg:
@@ -874,6 +877,7 @@ func (p *Panel) KeyBindings() []panels.KeyBinding {
 			panels.KeyBinding{Key: "a", Description: "Actions tab", Action: "tab_actions"},
 			panels.KeyBinding{Key: "W", Description: "Workflows tab", Action: "tab_workflows"},
 			panels.KeyBinding{Key: "L", Description: "Releases tab", Action: "tab_releases"},
+			panels.KeyBinding{Key: "R", Description: "Request reviewers (PRs tab)", Action: "pr_request_reviewers"},
 		)
 	}
 	return bindings
@@ -1124,6 +1128,10 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 	case "m":
 		if p.activeTab == tabPRs && p.gh.client != nil {
 			return p.doMergePR()
+		}
+	case "R":
+		if p.activeTab == tabPRs && p.gh.client != nil {
+			return p.doRequestReviewers()
 		}
 	case "pgdown":
 		p.pageDown()
@@ -2113,6 +2121,8 @@ func (p *Panel) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, tea.
 		return p.handlePRMergeConfirm(a)
 	case opPRDeleteBranchAfterMerge:
 		return p.handlePRDeleteBranchAfterMerge(a)
+	case opPRRequestReviewers:
+		return p.handlePRRequestReviewers(a)
 	}
 	return p, nil
 }

--- a/internal/panels/gitinfo/gitinfo_github.go
+++ b/internal/panels/gitinfo/gitinfo_github.go
@@ -132,6 +132,13 @@ type prMergeResultMsg struct {
 	err        error
 }
 
+// prRequestReviewersResultMsg carries the result of a request-reviewers operation.
+type prRequestReviewersResultMsg struct {
+	err       error
+	reviewers []string
+	number    int
+}
+
 // prBranchDeleteResultMsg carries the result of deleting a branch after PR merge.
 type prBranchDeleteResultMsg struct {
 	branch    string
@@ -1787,6 +1794,103 @@ func (p *Panel) handlePRBranchDeleteResult(msg prBranchDeleteResultMsg) (panels.
 		},
 		p.loadData(),
 	)
+}
+
+// doRequestReviewers initiates the request-reviewers flow for the selected PR.
+// It opens a single-line input for one or more comma-separated reviewer logins.
+func (p *Panel) doRequestReviewers() (panels.Panel, tea.Cmd) {
+	items := p.tabItems[p.activeTab]
+	cursor := p.tabCursor[p.activeTab]
+	if cursor < 0 || cursor >= len(items) || items[cursor].kind != kindPR {
+		return p, nil
+	}
+	pr := items[cursor].pr
+
+	// Guard: only request reviewers on open PRs.
+	if pr.State != prStateOpen {
+		stateLabel := pr.State
+		if stateLabel == "" {
+			stateLabel = stateUnknown
+		}
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: fmt.Sprintf("Cannot request reviewers on PR #%d: state is %s", pr.Number, stateLabel),
+				Level:   notify.Warn,
+			}
+		}
+	}
+
+	if p.gh.client == nil {
+		return p, nil
+	}
+
+	p.clearPending()
+	p.pending = opPRRequestReviewers
+	p.pendingName = fmt.Sprintf("%d", pr.Number)
+
+	title := fmt.Sprintf("Request reviewers for PR #%d", pr.Number)
+	return p, notify.ShowInput(title, "logins, comma separated (e.g. octocat, hubot)")
+}
+
+// parseReviewerLogins splits a comma-separated string of GitHub logins into a
+// trimmed, de-duplicated slice, preserving first-seen order. A leading "@" on
+// any login is stripped and empty entries are dropped. De-duplication is
+// case-insensitive since GitHub logins are case-insensitive.
+func parseReviewerLogins(input string) []string {
+	var out []string
+	seen := make(map[string]struct{})
+	for _, part := range strings.Split(input, ",") {
+		login := strings.TrimSpace(part)
+		login = strings.TrimPrefix(login, "@")
+		login = strings.TrimSpace(login)
+		if login == "" {
+			continue
+		}
+		key := strings.ToLower(login)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, login)
+	}
+	return out
+}
+
+// requestReviewersCmd returns a tea.Cmd that requests reviewers asynchronously.
+func (p *Panel) requestReviewersCmd(number int, reviewers []string) tea.Cmd {
+	client := p.gh.client
+	owner, repo := p.gh.owner, p.gh.repo
+	ctx := p.ctx
+	return func() tea.Msg {
+		err := client.RequestReviewers(ctx, owner, repo, number, reviewers)
+		return prRequestReviewersResultMsg{number: number, reviewers: reviewers, err: err}
+	}
+}
+
+// handlePRRequestReviewersResult processes the async result of a
+// request-reviewers operation, showing a notification and refreshing PR detail.
+func (p *Panel) handlePRRequestReviewersResult(msg prRequestReviewersResultMsg) (panels.Panel, tea.Cmd) {
+	if msg.err != nil {
+		errStr := msg.err.Error()
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: fmt.Sprintf("Request reviewers on PR #%d failed: %s", msg.number, errStr),
+				Level:   notify.Error,
+			}
+		}
+	}
+
+	toastMsg := fmt.Sprintf("Requested %s on PR #%d", strings.Join(msg.reviewers, ", "), msg.number)
+	cmds := []tea.Cmd{
+		func() tea.Msg {
+			return notify.ShowToastMsg{Message: toastMsg, Level: notify.Success}
+		},
+	}
+	// Refresh PR detail so requested reviewers show in the preview.
+	if p.gh.client != nil {
+		cmds = append(cmds, p.loadPRDetails(msg.number))
+	}
+	return p, tea.Batch(cmds...)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/panels/gitinfo/gitinfo_modal_handlers.go
+++ b/internal/panels/gitinfo/gitinfo_modal_handlers.go
@@ -402,3 +402,16 @@ func (p *Panel) handlePRDeleteBranchAfterMerge(a modalArgs) (panels.Panel, tea.C
 		}
 	}
 }
+
+func (p *Panel) handlePRRequestReviewers(a modalArgs) (panels.Panel, tea.Cmd) {
+	// User submitted reviewer logins. Empty input cancels.
+	reviewers := parseReviewerLogins(a.msg.Value)
+	if len(reviewers) == 0 {
+		return p, nil
+	}
+	prNumber, err := strconv.Atoi(a.name)
+	if err != nil || prNumber == 0 {
+		return p, nil
+	}
+	return p, p.requestReviewersCmd(prNumber, reviewers)
+}

--- a/internal/panels/gitinfo/gitinfo_reviewers_test.go
+++ b/internal/panels/gitinfo/gitinfo_reviewers_test.go
@@ -1,0 +1,265 @@
+package gitinfo
+
+import (
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/jongio/grut/internal/git"
+	"github.com/jongio/grut/internal/notify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// parseReviewerLogins — pure input parsing
+// ---------------------------------------------------------------------------
+
+func TestParseReviewerLogins(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"simple", "octocat, hubot", []string{"octocat", "hubot"}},
+		{"trims whitespace", "  octocat ,  hubot  ", []string{"octocat", "hubot"}},
+		{"strips at prefix", "@octocat, @hubot", []string{"octocat", "hubot"}},
+		{"dedupes case-insensitively", "octocat, OCTOCAT, octocat", []string{"octocat"}},
+		{"drops empty entries", "octocat,,hubot,", []string{"octocat", "hubot"}},
+		{"single login", "octocat", []string{"octocat"}},
+		{"empty", "", nil},
+		{"only separators and spaces", " , , ", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, parseReviewerLogins(tt.input))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// doRequestReviewers — guard rails
+// ---------------------------------------------------------------------------
+
+func TestDoRequestReviewers_OpenPR(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabPRs
+	p.tabItems[tabPRs] = []listItem{
+		{kind: kindPR, pr: ghPRItem{Number: 42, Title: "Add auth", State: prStateOpen}},
+	}
+	p.tabCursor[tabPRs] = 0
+
+	_, cmd := p.doRequestReviewers()
+	assert.NotNil(t, cmd, "open PR should open the reviewer input")
+	assert.Equal(t, opPRRequestReviewers, p.pending)
+	assert.Equal(t, "42", p.pendingName)
+}
+
+func TestDoRequestReviewers_NonOpenPR(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabPRs
+	p.tabItems[tabPRs] = []listItem{
+		{kind: kindPR, pr: ghPRItem{Number: 7, Title: "Old", State: prStateMerged}},
+	}
+	p.tabCursor[tabPRs] = 0
+
+	_, cmd := p.doRequestReviewers()
+	assert.NotNil(t, cmd, "should return a warning toast for a non-open PR")
+	assert.Equal(t, opNone, p.pending, "pending should not be set for a non-open PR")
+}
+
+func TestDoRequestReviewers_WrongTab(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabBranches
+	p.tabItems[tabBranches] = []listItem{
+		{kind: kindLocalBranch, branch: git.Branch{Name: "main"}},
+	}
+	p.tabCursor[tabBranches] = 0
+
+	_, cmd := p.doRequestReviewers()
+	assert.Nil(t, cmd)
+}
+
+func TestDoRequestReviewers_EmptyCursor(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabPRs
+	p.tabItems[tabPRs] = []listItem{}
+
+	_, cmd := p.doRequestReviewers()
+	assert.Nil(t, cmd)
+}
+
+func TestDoRequestReviewers_NoClient(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.activeTab = tabPRs
+	p.tabItems[tabPRs] = []listItem{
+		{kind: kindPR, pr: ghPRItem{Number: 42, Title: "Add auth", State: prStateOpen}},
+	}
+	p.tabCursor[tabPRs] = 0
+	// ghClient is nil.
+
+	_, cmd := p.doRequestReviewers()
+	assert.Nil(t, cmd)
+	assert.Equal(t, opNone, p.pending)
+}
+
+// ---------------------------------------------------------------------------
+// handleModalResult — opPRRequestReviewers
+// ---------------------------------------------------------------------------
+
+func TestHandleModalResult_PRRequestReviewers_RequestThenRefresh(t *testing.T) {
+	t.Parallel()
+	ghMock := &mockGHClientFull{}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+	p.activeTab = tabPRs
+	p.tabItems[tabPRs] = []listItem{
+		{kind: kindPR, pr: ghPRItem{Number: 42, Title: "Add auth", State: prStateOpen}},
+	}
+	p.tabCursor[tabPRs] = 0
+	p.pending = opPRRequestReviewers
+	p.pendingName = "42"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "octocat, @hubot, OCTOCAT"})
+	require.NotNil(t, cmd, "submitting logins should trigger the request")
+
+	// Executing the async command calls the client with parsed logins.
+	msg := cmd()
+	res, ok := msg.(prRequestReviewersResultMsg)
+	require.True(t, ok)
+	require.NoError(t, res.err)
+	assert.Equal(t, 42, res.number)
+	assert.Equal(t, []string{"octocat", "hubot"}, res.reviewers)
+	assert.Equal(t, 1, ghMock.requestReviewersCalls)
+	assert.Equal(t, []string{"octocat", "hubot"}, ghMock.requestedReviewers)
+
+	// Feeding the result back emits a toast plus a PR-detail refresh.
+	_, refreshCmd := p.handlePRRequestReviewersResult(res)
+	assert.NotNil(t, refreshCmd, "success should emit toast + PR detail refresh")
+}
+
+func TestHandleModalResult_PRRequestReviewers_EmptyCancels(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.pending = opPRRequestReviewers
+	p.pendingName = "42"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "   ,  , "})
+	assert.Nil(t, cmd, "empty/whitespace-only logins should cancel")
+}
+
+func TestHandleModalResult_PRRequestReviewers_BadNumber(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.pending = opPRRequestReviewers
+	p.pendingName = "not-a-number"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "octocat"})
+	assert.Nil(t, cmd)
+}
+
+func TestHandleModalResult_PRRequestReviewers_Cancel(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.pending = opPRRequestReviewers
+	p.pendingName = "42"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: false})
+	assert.Nil(t, cmd, "cancel should produce a nil cmd")
+	assert.Equal(t, opNone, p.pending)
+}
+
+// ---------------------------------------------------------------------------
+// requestReviewersCmd / handlePRRequestReviewersResult
+// ---------------------------------------------------------------------------
+
+func TestRequestReviewersCmd_Error(t *testing.T) {
+	t.Parallel()
+	ghMock := &mockGHClientFull{reviewersErr: errors.New("unknown login: nope")}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+
+	cmd := p.requestReviewersCmd(42, []string{"nope"})
+	require.NotNil(t, cmd)
+	msg := cmd()
+	res, ok := msg.(prRequestReviewersResultMsg)
+	require.True(t, ok)
+	require.Error(t, res.err)
+	assert.Equal(t, []string{"nope"}, ghMock.requestedReviewers)
+}
+
+func TestHandlePRRequestReviewersResult_Success(t *testing.T) {
+	t.Parallel()
+	ghMock := &mockGHClientFull{}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+
+	_, cmd := p.handlePRRequestReviewersResult(prRequestReviewersResultMsg{
+		number:    42,
+		reviewers: []string{"octocat", "hubot"},
+	})
+	assert.NotNil(t, cmd, "success should produce a toast + refresh")
+}
+
+func TestHandlePRRequestReviewersResult_Error(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+
+	_, cmd := p.handlePRRequestReviewersResult(prRequestReviewersResultMsg{
+		number:    42,
+		reviewers: []string{"nope"},
+		err:       errors.New("unknown login"),
+	})
+	assert.NotNil(t, cmd, "error should produce an error toast")
+}
+
+// ---------------------------------------------------------------------------
+// Key binding — 'R' triggers request-reviewers on the PRs tab
+// ---------------------------------------------------------------------------
+
+func TestHandleKey_R_PRsTab(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabPRs
+	p.tabItems[tabPRs] = []listItem{
+		{kind: kindPR, pr: ghPRItem{Number: 42, Title: "Test", State: prStateOpen}},
+	}
+	p.tabCursor[tabPRs] = 0
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: -1, Text: "R"})
+	assert.NotNil(t, cmd, "pressing 'R' on PRs tab should open the reviewer input")
+	assert.Equal(t, opPRRequestReviewers, p.pending)
+}
+
+func TestHandleKey_R_NotPRsTab(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabBranches
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: -1, Text: "R"})
+	assert.Nil(t, cmd, "pressing 'R' outside the PRs tab should be a no-op")
+}
+
+func TestHandleKey_R_NoGHClient(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.activeTab = tabPRs
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: -1, Text: "R"})
+	assert.Nil(t, cmd, "pressing 'R' without a ghClient should be a no-op")
+}

--- a/internal/panels/gitinfo/gitinfo_test.go
+++ b/internal/panels/gitinfo/gitinfo_test.go
@@ -2492,6 +2492,10 @@ type mockGHClientFull struct {
 	cancelErr  error
 	mergeErr   error
 	getPRCalls int
+
+	reviewersErr          error
+	requestedReviewers    []string
+	requestReviewersCalls int
 }
 
 func (m *mockGHClientFull) CurrentUser(_ context.Context) (*gh.User, error) {
@@ -2572,8 +2576,10 @@ func (m *mockGHClientFull) SubmitReview(_ context.Context, _, _ string, _ int, _
 	return nil
 }
 
-func (m *mockGHClientFull) RequestReviewers(_ context.Context, _, _ string, _ int, _ []string) error {
-	return nil
+func (m *mockGHClientFull) RequestReviewers(_ context.Context, _, _ string, _ int, reviewers []string) error {
+	m.requestReviewersCalls++
+	m.requestedReviewers = reviewers
+	return m.reviewersErr
 }
 
 func (m *mockGHClientFull) ListWorkflowRuns(_ context.Context, _, _ string, _ *gh.ListWorkflowRunsOptions) ([]*gh.WorkflowRun, error) {


### PR DESCRIPTION
Closes #251

## What changed

Wires the existing `github.Client.RequestReviewers` method into the GitHub panel. It was fully implemented in `internal/github/client.go` but had no UI entry point.

With a PR selected on the PRs tab, pressing `R` opens a single-line input for comma-separated reviewer logins. Submitting:

- Parses the logins: trims whitespace, strips a leading `@`, drops empty entries, and de-dupes case-insensitively while preserving first-seen order.
- Calls `RequestReviewers` asynchronously.
- Shows a success or error notification.
- Refreshes the PR detail so the requested reviewers appear in the preview.

Empty or whitespace-only input cancels the action. Requesting reviewers on a non-open PR is guarded with a warning notification.

Files:
- `internal/panels/gitinfo/gitinfo.go`: new `opPRRequestReviewers` pending op, `R` key case, `Update` dispatch, modal-result dispatch, and `KeyBindings()` entry.
- `internal/panels/gitinfo/gitinfo_github.go`: `doRequestReviewers`, `parseReviewerLogins`, `requestReviewersCmd`, `handlePRRequestReviewersResult`, and the result message struct.
- `internal/panels/gitinfo/gitinfo_modal_handlers.go`: `handlePRRequestReviewers` modal handler.
- `internal/keybindings/keybindings.json` and `docs/keybindings.md`: the `R` binding, so it shows in the help overlay and generated docs.
- `internal/panels/gitinfo/gitinfo_test.go` and `internal/panels/gitinfo/gitinfo_reviewers_test.go`: mock updates and new unit tests.

## Visual style

No emoji. Status comes from existing lipgloss-styled notification levels (Success, Warn, Error) only.

## How tested

- `go build ./...`
- `go test ./...` (all previously-passing packages pass)
- `go vet ./...`
- `gofmt` clean

New unit tests cover:
- `parseReviewerLogins` across trim, `@`-strip, de-dupe, empty, and separator-only cases.
- `doRequestReviewers` guard rails: open PR, non-open PR, wrong tab, empty cursor, and missing client.
- The modal result flow: request-then-refresh, empty-cancels, bad PR number, and cancel.
- `requestReviewersCmd` error path and `handlePRRequestReviewersResult` success and error branches.
- The `R` key on the PRs tab, off the PRs tab, and without a GitHub client.