### PR TITLE
feat(gitinfo): create GitHub issues from the Issues tab

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -132,6 +132,7 @@ GitHub panel (panel 3).
 | `a` | Actions tab |
 | `w` | Workflows tab |
 | `l` | Releases tab |
+| `n` | Create issue (Issues tab) |
 | `o` | Open in browser |
 | `y` | Copy to clipboard |
 | `m` | Merge PR (PRs tab) |

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -112,6 +112,7 @@
         { "key": "a", "action": "Actions tab" },
         { "key": "w", "action": "Workflows tab" },
         { "key": "l", "action": "Releases tab" },
+        { "key": "n", "action": "Create issue (Issues tab)" },
         { "key": "o", "action": "Open in browser" },
         { "key": "y", "action": "Copy to clipboard" },
         { "key": "m", "action": "Merge PR (PRs tab)" },

--- a/internal/panels/gitinfo/gitinfo.go
+++ b/internal/panels/gitinfo/gitinfo.go
@@ -148,6 +148,9 @@ const (
 	opPRMergeStrategy                    // awaiting merge strategy selection
 	opPRMergeConfirm                     // awaiting merge confirmation
 	opPRDeleteBranchAfterMerge           // awaiting post-merge branch deletion confirmation
+	opIssueCreateTitle                   // awaiting new issue title (step 1)
+	opIssueCreateBody                    // awaiting new issue body (step 2)
+	opIssueCreateLabels                  // awaiting new issue labels (step 3)
 )
 
 // ---------------------------------------------------------------------------
@@ -306,6 +309,10 @@ type githubState struct {
 	prFilter    PRFilterKind
 	repoPrivate bool
 	pageSize    int
+	// New-issue create flow (multi-step input overlay driven by opIssueCreate*).
+	issueDraftTitle    string // in-progress new-issue title
+	issueDraftBody     string // in-progress new-issue body
+	pendingSelectIssue int    // issue number to select after the next Issues refresh (0 = none)
 }
 
 // ---------------------------------------------------------------------------
@@ -745,6 +752,8 @@ func (p *Panel) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 		return p.handlePRMergeResult(msg)
 	case prBranchDeleteResultMsg:
 		return p.handlePRBranchDeleteResult(msg)
+	case issueCreateResultMsg:
+		return p.handleIssueCreateResult(msg)
 
 	// CRUD actions dispatched via keymap.
 	case panels.ItemCreateMsg:
@@ -1912,6 +1921,12 @@ func (p *Panel) doCreate() (panels.Panel, tea.Cmd) {
 		p.pending = opTagCreate
 		return p, notify.ShowInput("Tag Name", "tag-name")
 	case tabIssues:
+		if p.gh.client != nil {
+			p.clearPending()
+			p.pending = opIssueCreateTitle
+			return p, notify.ShowInput("New Issue — Title", "Issue title (required)")
+		}
+		// Fallback: open the browser new-issue page when no API client is available.
 		if p.gh.owner != "" && p.gh.repo != "" {
 			url := fmt.Sprintf("https://github.com/%s/%s/issues/new", p.gh.owner, p.gh.repo)
 			return p, func() tea.Msg {
@@ -2049,12 +2064,16 @@ func (p *Panel) clearPending() {
 	p.pending = opNone
 	p.pendingName = ""
 	p.pendingPath = ""
+	p.gh.issueDraftTitle = ""
+	p.gh.issueDraftBody = ""
 }
 
 func (p *Panel) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, tea.Cmd) {
 	op := p.pending
 	name := p.pendingName
 	pendingPath := p.pendingPath
+	issueTitle := p.gh.issueDraftTitle
+	issueBody := p.gh.issueDraftBody
 	p.clearPending()
 	if !msg.Accept {
 		return p, nil
@@ -2063,6 +2082,8 @@ func (p *Panel) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, tea.
 		msg:         msg,
 		name:        name,
 		pendingPath: pendingPath,
+		issueTitle:  issueTitle,
+		issueBody:   issueBody,
 		git:         p.git,
 		ctx:         p.ctx,
 	}
@@ -2113,6 +2134,12 @@ func (p *Panel) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, tea.
 		return p.handlePRMergeConfirm(a)
 	case opPRDeleteBranchAfterMerge:
 		return p.handlePRDeleteBranchAfterMerge(a)
+	case opIssueCreateTitle:
+		return p.handleIssueCreateTitle(a)
+	case opIssueCreateBody:
+		return p.handleIssueCreateBody(a)
+	case opIssueCreateLabels:
+		return p.handleIssueCreateLabels(a)
 	}
 	return p, nil
 }

--- a/internal/panels/gitinfo/gitinfo_github.go
+++ b/internal/panels/gitinfo/gitinfo_github.go
@@ -139,6 +139,13 @@ type prBranchDeleteResultMsg struct {
 	localErr  error
 }
 
+// issueCreateResultMsg carries the result of a create-issue operation.
+type issueCreateResultMsg struct {
+	err    error
+	title  string
+	number int
+}
+
 // workflowInputsFetchedMsg carries the result of fetching workflow_dispatch
 // input definitions from the workflow YAML file.
 type workflowInputsFetchedMsg struct {
@@ -894,6 +901,14 @@ func (p *Panel) handleIssuesPage(msg ghIssuesPageMsg) (panels.Panel, tea.Cmd) {
 		p.tabCursor[tabIssues] = savedCursor
 		p.tabOffset[tabIssues] = savedOffset
 	}
+	// After a full refresh, select the just-created issue if one is pending.
+	if msg.replace && p.gh.pendingSelectIssue != 0 {
+		found := p.selectIssueByNumber(p.gh.pendingSelectIssue)
+		p.gh.pendingSelectIssue = 0
+		if found {
+			return p, p.issueSelectedCmd()
+		}
+	}
 	return p, nil
 }
 
@@ -1148,6 +1163,91 @@ func (p *Panel) matchesIssueFilter(iss ghIssueItem) bool {
 	default:
 		return true
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue creation
+// ---------------------------------------------------------------------------
+
+// parseIssueLabels splits a comma-separated labels string into a trimmed,
+// de-duplicated slice, dropping empty entries.
+func parseIssueLabels(raw string) []string {
+	seen := make(map[string]bool)
+	var labels []string
+	for _, part := range strings.Split(raw, ",") {
+		label := strings.TrimSpace(part)
+		if label == "" || seen[label] {
+			continue
+		}
+		seen[label] = true
+		labels = append(labels, label)
+	}
+	return labels
+}
+
+// createIssueCmd returns a tea.Cmd that creates a new issue asynchronously
+// and reports the outcome via issueCreateResultMsg.
+func (p *Panel) createIssueCmd(title, body string, labels []string) tea.Cmd {
+	client := p.gh.client
+	if client == nil {
+		return nil
+	}
+	owner, repo := p.gh.owner, p.gh.repo
+	ctx := p.ctx
+	return func() tea.Msg {
+		req := &gh.IssueRequest{Title: gh.Ptr(title)}
+		if body != "" {
+			req.Body = gh.Ptr(body)
+		}
+		if len(labels) > 0 {
+			req.Labels = &labels
+		}
+		issue, err := client.CreateIssue(ctx, owner, repo, req)
+		if err != nil {
+			return issueCreateResultMsg{err: err, title: title}
+		}
+		return issueCreateResultMsg{number: issue.GetNumber(), title: issue.GetTitle()}
+	}
+}
+
+// handleIssueCreateResult processes the async result of creating an issue.
+// On success it refreshes the Issues list and queues selection of the new item.
+func (p *Panel) handleIssueCreateResult(msg issueCreateResultMsg) (panels.Panel, tea.Cmd) {
+	if msg.err != nil {
+		errStr := msg.err.Error()
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: "Create issue failed: " + errStr,
+				Level:   notify.Error,
+			}
+		}
+	}
+	// Make sure the refreshed list is visible and reset pagination for a page-1 reload.
+	p.activeTab = tabIssues
+	p.gh.pendingSelectIssue = msg.number
+	p.tabPaging[tabIssues] = tabPagination{loading: true, nextPage: 1}
+	return p, tea.Batch(
+		func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: fmt.Sprintf("Created issue #%d", msg.number),
+				Level:   notify.Success,
+			}
+		},
+		p.loadIssuesPage(1, true),
+	)
+}
+
+// selectIssueByNumber moves the Issues-tab cursor to the issue with the given
+// number, if present in the current filtered view. Returns true when found.
+func (p *Panel) selectIssueByNumber(number int) bool {
+	for i, item := range p.tabItems[tabIssues] {
+		if item.kind == kindIssue && item.issue.Number == number {
+			p.tabCursor[tabIssues] = i
+			p.ensureCursorVisible()
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Panel) applyPRFilter() {

--- a/internal/panels/gitinfo/gitinfo_issue_create_test.go
+++ b/internal/panels/gitinfo/gitinfo_issue_create_test.go
@@ -1,0 +1,220 @@
+package gitinfo
+
+import (
+	"errors"
+	"testing"
+
+	gh "github.com/google/go-github/v88/github"
+	"github.com/jongio/grut/internal/notify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// parseIssueLabels
+// ---------------------------------------------------------------------------
+
+func TestParseIssueLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"whitespace only", "   ", nil},
+		{"single", "bug", []string{"bug"}},
+		{"trims spaces", " bug , ui ", []string{"bug", "ui"}},
+		{"drops empties", "bug,,ui,", []string{"bug", "ui"}},
+		{"dedupes", "bug, ui, bug", []string{"bug", "ui"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseIssueLabels(tt.in))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// doCreate on the Issues tab
+// ---------------------------------------------------------------------------
+
+func TestDoCreate_IssuesTab_StartsFlowWithClient(t *testing.T) {
+	p := newGHPanelWithClient(t, defaultMock(), &mockGHClientFull{})
+	p.activeTab = tabIssues
+
+	_, cmd := p.doCreate()
+
+	assert.Equal(t, opIssueCreateTitle, p.pending)
+	require.NotNil(t, cmd, "should show the title input overlay")
+}
+
+func TestDoCreate_IssuesTab_NoClientDoesNotStartFlow(t *testing.T) {
+	p := newTestGitHubPanel(t, defaultMock())
+	p.gh.client = nil
+	p.gh.owner = "owner"
+	p.gh.repo = "repo"
+	p.activeTab = tabIssues
+
+	_, cmd := p.doCreate()
+
+	assert.Equal(t, opNone, p.pending, "no in-TUI create flow without an API client")
+	require.NotNil(t, cmd, "falls back to the browser new-issue page")
+}
+
+// ---------------------------------------------------------------------------
+// Validation: empty title is rejected and the flow stays recoverable
+// ---------------------------------------------------------------------------
+
+func TestIssueCreate_EmptyTitleReprompts(t *testing.T) {
+	ghMock := &mockGHClientFull{}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+	p.activeTab = tabIssues
+	p.pending = opIssueCreateTitle
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "   "})
+
+	assert.Equal(t, opIssueCreateTitle, p.pending, "should re-prompt for the title")
+	require.NotNil(t, cmd, "re-prompt + inline warning command expected")
+	assert.Zero(t, ghMock.createIssueCalls, "no issue created on empty title")
+}
+
+func TestIssueCreate_EscapeCancelsAndClearsDraft(t *testing.T) {
+	ghMock := &mockGHClientFull{}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+	p.activeTab = tabIssues
+	p.pending = opIssueCreateBody
+	p.gh.issueDraftTitle = "Half-typed"
+	p.gh.issueDraftBody = "partial"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: false})
+
+	assert.Equal(t, opNone, p.pending)
+	assert.Empty(t, p.gh.issueDraftTitle)
+	assert.Empty(t, p.gh.issueDraftBody)
+	assert.Nil(t, cmd)
+	assert.Zero(t, ghMock.createIssueCalls)
+}
+
+// ---------------------------------------------------------------------------
+// createIssueCmd builds the correct request
+// ---------------------------------------------------------------------------
+
+func TestCreateIssueCmd_BuildsRequestWithAllFields(t *testing.T) {
+	ghMock := &mockGHClientFull{
+		createIssueResp: &gh.Issue{Number: gh.Ptr(42), Title: gh.Ptr("My title")},
+	}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+
+	msg := p.createIssueCmd("My title", "My body", []string{"bug", "ui"})()
+
+	res, ok := msg.(issueCreateResultMsg)
+	require.True(t, ok)
+	require.NoError(t, res.err)
+	assert.Equal(t, 42, res.number)
+
+	require.NotNil(t, ghMock.createIssueReq)
+	assert.Equal(t, "My title", ghMock.createIssueReq.GetTitle())
+	assert.Equal(t, "My body", ghMock.createIssueReq.GetBody())
+	require.NotNil(t, ghMock.createIssueReq.Labels)
+	assert.Equal(t, []string{"bug", "ui"}, *ghMock.createIssueReq.Labels)
+}
+
+func TestCreateIssueCmd_OmitsEmptyBodyAndLabels(t *testing.T) {
+	ghMock := &mockGHClientFull{
+		createIssueResp: &gh.Issue{Number: gh.Ptr(7), Title: gh.Ptr("T")},
+	}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+
+	p.createIssueCmd("T", "", nil)()
+
+	require.NotNil(t, ghMock.createIssueReq)
+	assert.Equal(t, "T", ghMock.createIssueReq.GetTitle())
+	assert.Nil(t, ghMock.createIssueReq.Body, "empty body should be omitted")
+	assert.Nil(t, ghMock.createIssueReq.Labels, "empty labels should be omitted")
+}
+
+func TestCreateIssueCmd_SurfacesError(t *testing.T) {
+	ghMock := &mockGHClientFull{createIssueErr: errors.New("boom")}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+
+	msg := p.createIssueCmd("T", "", nil)()
+
+	res, ok := msg.(issueCreateResultMsg)
+	require.True(t, ok)
+	require.Error(t, res.err)
+
+	// The result handler surfaces a clear error notification.
+	_, cmd := p.handleIssueCreateResult(res)
+	require.NotNil(t, cmd)
+	toast, ok := cmd().(notify.ShowToastMsg)
+	require.True(t, ok)
+	assert.Equal(t, notify.Error, toast.Level)
+	assert.Contains(t, toast.Message, "Create issue failed")
+	assert.Zero(t, p.gh.pendingSelectIssue, "no selection queued on failure")
+}
+
+// ---------------------------------------------------------------------------
+// Full create-then-refresh-then-select flow
+// ---------------------------------------------------------------------------
+
+func TestIssueCreate_FullFlowRefreshesAndSelects(t *testing.T) {
+	newNum := 99
+	newTitle := "New issue"
+	ghMock := &mockGHClientFull{
+		createIssueResp: &gh.Issue{Number: &newNum, Title: &newTitle, State: gh.Ptr("open")},
+	}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+	p.gh.pageSize = 25
+	p.activeTab = tabIssues
+
+	// Press n -> title prompt.
+	if _, cmd := p.doCreate(); assert.NotNil(t, cmd) {
+		assert.Equal(t, opIssueCreateTitle, p.pending)
+	}
+
+	// Step 1: title.
+	p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "New issue"})
+	assert.Equal(t, opIssueCreateBody, p.pending)
+	assert.Equal(t, "New issue", p.gh.issueDraftTitle)
+
+	// Step 2: body.
+	p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "Body text"})
+	assert.Equal(t, opIssueCreateLabels, p.pending)
+	assert.Equal(t, "Body text", p.gh.issueDraftBody)
+
+	// Step 3: labels -> creates the issue.
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "bug, ui"})
+	require.NotNil(t, cmd)
+	res, ok := cmd().(issueCreateResultMsg)
+	require.True(t, ok)
+	require.NoError(t, res.err)
+	assert.Equal(t, 99, res.number)
+	assert.Equal(t, opNone, p.pending, "pending cleared after submit")
+
+	// Request carried title, body, and labels.
+	require.NotNil(t, ghMock.createIssueReq)
+	assert.Equal(t, "New issue", ghMock.createIssueReq.GetTitle())
+	assert.Equal(t, "Body text", ghMock.createIssueReq.GetBody())
+	require.NotNil(t, ghMock.createIssueReq.Labels)
+	assert.Equal(t, []string{"bug", "ui"}, *ghMock.createIssueReq.Labels)
+
+	// Result queues a refresh + selection of the new issue.
+	_, cmd = p.handleIssueCreateResult(res)
+	require.NotNil(t, cmd)
+	assert.Equal(t, 99, p.gh.pendingSelectIssue)
+	assert.Equal(t, tabIssues, p.activeTab)
+
+	// The refreshed list contains the new issue; selection lands on it.
+	ghMock.issues = []*gh.Issue{
+		{Number: gh.Ptr(1), Title: gh.Ptr("Existing"), State: gh.Ptr("open")},
+		{Number: &newNum, Title: &newTitle, State: gh.Ptr("open")},
+	}
+	pageMsg, ok := p.loadIssuesPage(1, true)().(ghIssuesPageMsg)
+	require.True(t, ok)
+	_, selCmd := p.handleIssuesPage(pageMsg)
+
+	assert.Zero(t, p.gh.pendingSelectIssue, "selection consumed after refresh")
+	require.Len(t, p.tabItems[tabIssues], 2)
+	assert.Equal(t, 1, p.tabCursor[tabIssues], "cursor on the newly created issue")
+	require.NotNil(t, selCmd, "emits an issue-selected command")
+}

--- a/internal/panels/gitinfo/gitinfo_modal_handlers.go
+++ b/internal/panels/gitinfo/gitinfo_modal_handlers.go
@@ -26,6 +26,8 @@ type modalArgs struct {
 	msg         notify.ModalResultMsg
 	name        string
 	pendingPath string
+	issueTitle  string // captured new-issue draft title (opIssueCreate* flow)
+	issueBody   string // captured new-issue draft body (opIssueCreate* flow)
 	git         gitOps
 	ctx         context.Context
 }
@@ -401,4 +403,42 @@ func (p *Panel) handlePRDeleteBranchAfterMerge(a modalArgs) (panels.Panel, tea.C
 			localErr:  localErr,
 		}
 	}
+}
+
+// handleIssueCreateTitle is step 1 of the new-issue flow. It validates the
+// title and advances to the body step. An empty title is rejected with an
+// inline message and the title prompt is re-shown so the flow stays recoverable.
+func (p *Panel) handleIssueCreateTitle(a modalArgs) (panels.Panel, tea.Cmd) {
+	title := strings.TrimSpace(a.msg.Value)
+	if title == "" {
+		p.pending = opIssueCreateTitle
+		return p, tea.Batch(
+			func() tea.Msg {
+				return notify.ShowToastMsg{Message: "Issue title is required", Level: notify.Warn}
+			},
+			notify.ShowInput("New Issue — Title (required)", "Title cannot be empty"),
+		)
+	}
+	p.gh.issueDraftTitle = title
+	p.pending = opIssueCreateBody
+	return p, notify.ShowInput("New Issue — Body", "Optional description (leave empty to skip)")
+}
+
+// handleIssueCreateBody is step 2 of the new-issue flow. It records the body
+// and advances to the optional labels step.
+func (p *Panel) handleIssueCreateBody(a modalArgs) (panels.Panel, tea.Cmd) {
+	p.gh.issueDraftTitle = a.issueTitle
+	p.gh.issueDraftBody = strings.TrimSpace(a.msg.Value)
+	p.pending = opIssueCreateLabels
+	return p, notify.ShowInput("New Issue — Labels", "comma,separated (optional)")
+}
+
+// handleIssueCreateLabels is step 3 of the new-issue flow. It parses the
+// optional labels and creates the issue.
+func (p *Panel) handleIssueCreateLabels(a modalArgs) (panels.Panel, tea.Cmd) {
+	title := a.issueTitle
+	if title == "" {
+		return p, nil
+	}
+	return p, p.createIssueCmd(title, a.issueBody, parseIssueLabels(a.msg.Value))
 }

--- a/internal/panels/gitinfo/gitinfo_test.go
+++ b/internal/panels/gitinfo/gitinfo_test.go
@@ -2492,6 +2492,11 @@ type mockGHClientFull struct {
 	cancelErr  error
 	mergeErr   error
 	getPRCalls int
+	// New-issue create recording.
+	createIssueReq   *gh.IssueRequest
+	createIssueResp  *gh.Issue
+	createIssueErr   error
+	createIssueCalls int
 }
 
 func (m *mockGHClientFull) CurrentUser(_ context.Context) (*gh.User, error) {
@@ -2510,8 +2515,10 @@ func (m *mockGHClientFull) GetIssueComments(_ context.Context, _, _ string, _ in
 	return nil, nil
 }
 
-func (m *mockGHClientFull) CreateIssue(_ context.Context, _, _ string, _ *gh.IssueRequest) (*gh.Issue, error) {
-	return nil, nil
+func (m *mockGHClientFull) CreateIssue(_ context.Context, _, _ string, req *gh.IssueRequest) (*gh.Issue, error) {
+	m.createIssueCalls++
+	m.createIssueReq = req
+	return m.createIssueResp, m.createIssueErr
 }
 
 func (m *mockGHClientFull) EditIssue(_ context.Context, _, _ string, _ int, _ *gh.IssueRequest) error {


### PR DESCRIPTION
Closes #248

## What changed

Press `n` on the Issues tab of the GitHub panel to create a real GitHub issue without leaving the TUI. Previously `n` on that tab only opened the browser new-issue page.

The flow reuses the existing multi-step modal input pattern (the same one used for remote add, tag create, and workflow dispatch):

1. **Title** (required)
2. **Body** (optional)
3. **Labels** (optional, comma-separated)

On submit it calls the existing `CreateIssue` client method in `internal/github/client.go`, so no API code was added. On success the Issues list refreshes and the new issue is selected. When no API client is configured (for example unauthenticated), the previous browser new-issue fallback is kept.

Behavior details:
- Empty title is rejected with an inline notification and the title prompt is re-shown, so the flow stays recoverable.
- Escape cancels at any step and clears the in-progress draft.
- API failures show an error notification instead of silently failing.

Also registered the `n` binding in `internal/keybindings/keybindings.json` (single source of truth) and regenerated `docs/keybindings.md`. The help overlay already lists `n` as "Create new item" from the panel's `KeyBindings()`.

## Files

- `internal/panels/gitinfo/gitinfo.go` — new pending-op steps, draft state on `githubState`, `doCreate` Issues branch, modal dispatch, Update case.
- `internal/panels/gitinfo/gitinfo_modal_handlers.go` — three step handlers (title, body, labels) plus draft fields on `modalArgs`.
- `internal/panels/gitinfo/gitinfo_github.go` — `issueCreateResultMsg`, `parseIssueLabels`, `createIssueCmd`, `handleIssueCreateResult`, `selectIssueByNumber`, and post-refresh selection in `handleIssuesPage`.
- `internal/keybindings/keybindings.json` + `docs/keybindings.md` — `n` binding.
- `internal/panels/gitinfo/gitinfo_test.go` — mock records `CreateIssue` calls.
- `internal/panels/gitinfo/gitinfo_issue_create_test.go` — new unit tests.

## How I tested

- `go build ./...` — clean.
- `go test ./...` — all 53 packages pass, including the new `gitinfo_issue_create_test.go` (label parsing, flow start with and without a client, empty-title reprompt, escape cancel, request building with and without body/labels, error surfacing, and the full create then refresh then select path).
- `go vet ./...` — clean.
- `gofmt` and `gofumpt` — clean.

No new dependencies. No changes to the GitHub API client.