### PR TITLE
feat(gitinfo): comment on selected issue or PR

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -135,6 +135,7 @@ GitHub panel (panel 3).
 | `o` | Open in browser |
 | `y` | Copy to clipboard |
 | `m` | Merge PR (PRs tab) |
+| `c` | Comment on issue/PR (Issues/PRs tab) |
 | `r` | Rerun (Actions tab) |
 | `x` | Cancel (Actions tab) |
 | `D` | Dispatch workflow |

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -115,6 +115,7 @@
         { "key": "o", "action": "Open in browser" },
         { "key": "y", "action": "Copy to clipboard" },
         { "key": "m", "action": "Merge PR (PRs tab)" },
+        { "key": "c", "action": "Comment on issue/PR (Issues/PRs tab)" },
         { "key": "r", "action": "Rerun (Actions tab)" },
         { "key": "x", "action": "Cancel (Actions tab)" },
         { "key": "D", "action": "Dispatch workflow" }

--- a/internal/notify/messages.go
+++ b/internal/notify/messages.go
@@ -73,4 +73,7 @@ const (
 	// ModalActionPickerWithCheckbox displays a selectable list of actions
 	// with a "remember this choice" checkbox.
 	ModalActionPickerWithCheckbox
+	// ModalMultilineInput displays a multi-line text composer. Enter inserts
+	// a newline, Ctrl+D submits, and Esc cancels.
+	ModalMultilineInput
 )

--- a/internal/notify/modal.go
+++ b/internal/notify/modal.go
@@ -102,6 +102,8 @@ func (ms *modalState) handleKey(mgr *Manager, msg tea.KeyPressMsg) tea.Cmd {
 		return ms.handleActionPickerKey(mgr, key)
 	case ModalActionPickerWithCheckbox:
 		return ms.handleActionPickerWithCheckboxKey(mgr, key)
+	case ModalMultilineInput:
+		return ms.handleMultilineInputKey(mgr, key, msg)
 	}
 	return nil
 }
@@ -255,6 +257,64 @@ func (ms *modalState) handleInputKey(mgr *Manager, key string, msg tea.KeyPressM
 	}
 }
 
+// handleMultilineInputKey handles key input for a multi-line text composer.
+// Enter inserts a newline, Ctrl+D submits the composed value, and Esc
+// cancels. Backspace, arrow keys, and printable characters edit the text.
+func (ms *modalState) handleMultilineInputKey(mgr *Manager, key string, msg tea.KeyPressMsg) tea.Cmd {
+	switch key {
+	case "esc":
+		mgr.dismissModal()
+		return func() tea.Msg {
+			return ModalResultMsg{Accept: false}
+		}
+	case "ctrl+d":
+		value := ms.input
+		mgr.dismissModal()
+		return func() tea.Msg {
+			return ModalResultMsg{Accept: true, Value: value}
+		}
+	case "enter":
+		ms.insertText("\n")
+		return nil
+	case "backspace":
+		if ms.cursor > 0 {
+			runes := []rune(ms.input)
+			ms.input = string(runes[:ms.cursor-1]) + string(runes[ms.cursor:])
+			ms.cursor--
+		}
+		return nil
+	case "left":
+		if ms.cursor > 0 {
+			ms.cursor--
+		}
+		return nil
+	case "right":
+		if ms.cursor < len([]rune(ms.input)) {
+			ms.cursor++
+		}
+		return nil
+	default:
+		ms.insertText(msg.Text)
+		return nil
+	}
+}
+
+// insertText inserts text at the current cursor position and advances the
+// cursor. Empty text is a no-op.
+func (ms *modalState) insertText(text string) {
+	if text == "" {
+		return
+	}
+	runes := []rune(ms.input)
+	inserted := []rune(text)
+	newRunes := make([]rune, 0, len(runes)+len(inserted))
+	newRunes = append(newRunes, runes[:ms.cursor]...)
+	newRunes = append(newRunes, inserted...)
+	newRunes = append(newRunes, runes[ms.cursor:]...)
+	ms.input = string(newRunes)
+	ms.cursor += len(inserted)
+}
+
 // handleActionPickerKey handles key input for an action picker modal.
 func (ms *modalState) handleActionPickerKey(mgr *Manager, key string) tea.Cmd {
 	switch key {
@@ -356,7 +416,7 @@ func (ms *modalState) handleActionPickerWithCheckboxKey(mgr *Manager, key string
 // ModalResultMsg when a clickable element is activated.
 func (ms *modalState) handleMouseClick(mgr *Manager, mouseX, mouseY, screenWidth, screenHeight int) tea.Cmd {
 	// Input modals only support keyboard interaction.
-	if ms.kind == ModalInput {
+	if ms.kind == ModalInput || ms.kind == ModalMultilineInput {
 		return nil
 	}
 	// Compute the box width identically to view().
@@ -561,6 +621,11 @@ func (ms *modalState) view(width, height int) string {
 		content.WriteString(ms.renderConfirmButtons(cw))
 	case ModalInput:
 		content.WriteString(ms.renderInputField(cw))
+	case ModalMultilineInput:
+		content.WriteString(ms.renderMultilineInputField(cw))
+		content.WriteString("\n")
+		hintStyle := modalHintBase.Width(cw)
+		content.WriteString(hintStyle.Render("enter newline • ctrl+d submit • esc cancel"))
 	case ModalConfirmWithCheckbox:
 		content.WriteString(ms.renderCheckbox(cw))
 		content.WriteString("\n")
@@ -618,6 +683,23 @@ func (ms *modalState) renderInputField(width int) string {
 	return inputStyle.Render(display)
 }
 
+// renderMultilineInputField renders the text composer for a multi-line
+// input modal. The field keeps a minimum height so it reads as a composer
+// even when empty, and shows the placeholder until the user types.
+func (ms *modalState) renderMultilineInputField(width int) string {
+	const minLines = 4
+	display := ms.input
+	if display == "" && ms.placeholder != "" {
+		display = ms.placeholder
+	}
+	lines := strings.Split(display, "\n")
+	for len(lines) < minLines {
+		lines = append(lines, "")
+	}
+	inputStyle := modalInputBorder.Width(width - 4)
+	return inputStyle.Render(strings.Join(lines, "\n"))
+}
+
 // ShowConfirm returns a tea.Cmd that produces a ShowModalMsg for a
 // yes/no confirmation dialog.
 func ShowConfirm(title, message string) tea.Cmd {
@@ -651,6 +733,19 @@ func ShowInputWithValue(title, placeholder, value string) tea.Cmd {
 			Placeholder: placeholder,
 			Value:       value,
 			Kind:        ModalInput,
+		}
+	}
+}
+
+// ShowMultilineInput returns a tea.Cmd that produces a ShowModalMsg for a
+// multi-line text composer. Enter inserts a newline, Ctrl+D submits, and
+// Esc cancels.
+func ShowMultilineInput(title, placeholder string) tea.Cmd {
+	return func() tea.Msg {
+		return ShowModalMsg{
+			Title:       title,
+			Placeholder: placeholder,
+			Kind:        ModalMultilineInput,
 		}
 	}
 }

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -522,6 +522,64 @@ func TestModalInputBackspace(t *testing.T) {
 	assert.Equal(t, "ab", result.Value)
 }
 
+func TestShowMultilineInput(t *testing.T) {
+	cmd := ShowMultilineInput("Comment on issue #1", "Fix the bug")
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	smm, ok := msg.(ShowModalMsg)
+	require.True(t, ok)
+	assert.Equal(t, "Comment on issue #1", smm.Title)
+	assert.Equal(t, "Fix the bug", smm.Placeholder)
+	assert.Equal(t, ModalMultilineInput, smm.Kind)
+}
+
+func TestModalMultilineInputSubmit(t *testing.T) {
+	m := NewManager()
+	m.Update(ShowModalMsg{
+		Title: "Comment",
+		Kind:  ModalMultilineInput,
+	})
+	require.True(t, m.HasModal())
+
+	m.Update(tea.KeyPressMsg{Code: -1, Text: "h"})
+	m.Update(tea.KeyPressMsg{Code: -1, Text: "i"})
+	// Enter inserts a newline instead of submitting.
+	enterCmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assert.Nil(t, enterCmd, "enter should insert a newline, not submit")
+	assert.True(t, m.HasModal(), "modal should stay open after enter")
+	m.Update(tea.KeyPressMsg{Code: -1, Text: "y"})
+
+	// Ctrl+D submits.
+	cmd := m.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	result, ok := msg.(ModalResultMsg)
+	require.True(t, ok)
+	assert.True(t, result.Accept)
+	assert.Equal(t, "hi\ny", result.Value)
+	assert.False(t, m.HasModal())
+}
+
+func TestModalMultilineInputEscape(t *testing.T) {
+	m := NewManager()
+	m.Update(ShowModalMsg{
+		Title: "Comment",
+		Kind:  ModalMultilineInput,
+	})
+
+	m.Update(tea.KeyPressMsg{Code: -1, Text: "a"})
+	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	result, ok := msg.(ModalResultMsg)
+	require.True(t, ok)
+	assert.False(t, result.Accept)
+	assert.False(t, m.HasModal())
+}
+
 func TestModalViewRendering(t *testing.T) {
 	m := NewManager()
 	m.Update(ShowModalMsg{

--- a/internal/panels/gitinfo/gitinfo.go
+++ b/internal/panels/gitinfo/gitinfo.go
@@ -148,6 +148,7 @@ const (
 	opPRMergeStrategy                    // awaiting merge strategy selection
 	opPRMergeConfirm                     // awaiting merge confirmation
 	opPRDeleteBranchAfterMerge           // awaiting post-merge branch deletion confirmation
+	opIssuePRComment                     // awaiting comment body for an issue or PR
 )
 
 // ---------------------------------------------------------------------------
@@ -743,6 +744,8 @@ func (p *Panel) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 
 	case prMergeResultMsg:
 		return p.handlePRMergeResult(msg)
+	case commentResultMsg:
+		return p.handleCommentResult(msg)
 	case prBranchDeleteResultMsg:
 		return p.handlePRBranchDeleteResult(msg)
 
@@ -874,6 +877,7 @@ func (p *Panel) KeyBindings() []panels.KeyBinding {
 			panels.KeyBinding{Key: "a", Description: "Actions tab", Action: "tab_actions"},
 			panels.KeyBinding{Key: "W", Description: "Workflows tab", Action: "tab_workflows"},
 			panels.KeyBinding{Key: "L", Description: "Releases tab", Action: "tab_releases"},
+			panels.KeyBinding{Key: "c", Description: "Comment on issue/PR", Action: "item_comment"},
 		)
 	}
 	return bindings
@@ -1124,6 +1128,10 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 	case "m":
 		if p.activeTab == tabPRs && p.gh.client != nil {
 			return p.doMergePR()
+		}
+	case "c":
+		if (p.activeTab == tabIssues || p.activeTab == tabPRs) && p.gh.client != nil {
+			return p.doCommentOnItem()
 		}
 	case "pgdown":
 		p.pageDown()
@@ -2113,6 +2121,8 @@ func (p *Panel) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, tea.
 		return p.handlePRMergeConfirm(a)
 	case opPRDeleteBranchAfterMerge:
 		return p.handlePRDeleteBranchAfterMerge(a)
+	case opIssuePRComment:
+		return p.handleIssuePRComment(a)
 	}
 	return p, nil
 }

--- a/internal/panels/gitinfo/gitinfo_extra_test.go
+++ b/internal/panels/gitinfo/gitinfo_extra_test.go
@@ -1516,6 +1516,236 @@ func TestHandleModalResult_PRDeleteBranchAfterMerge_EmptyBranch(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Comment on issue/PR (issue #252) — distinct from inline review comments (#212)
+// ---------------------------------------------------------------------------
+
+// collectCmdMsgs runs a cmd and recursively expands tea.BatchMsg so tests can
+// inspect every message a batched command would emit.
+func collectCmdMsgs(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var out []tea.Msg
+		for _, c := range batch {
+			out = append(out, collectCmdMsgs(c)...)
+		}
+		return out
+	}
+	return []tea.Msg{msg}
+}
+
+func TestDoCommentOnItem_Issue(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	populateGH(p, sampleIssues(), nil, nil)
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabIssues
+	p.tabCursor[tabIssues] = 0
+
+	_, cmd := p.doCommentOnItem()
+	assert.NotNil(t, cmd, "should open the composer")
+	assert.Equal(t, opIssuePRComment, p.pending)
+	assert.Equal(t, "issue:1", p.pendingName)
+}
+
+func TestDoCommentOnItem_PR(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	populateGH(p, nil, samplePRs(), nil)
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabPRs
+	p.tabCursor[tabPRs] = 0
+
+	_, cmd := p.doCommentOnItem()
+	assert.NotNil(t, cmd, "should open the composer")
+	assert.Equal(t, opIssuePRComment, p.pending)
+	assert.Equal(t, "PR:10", p.pendingName)
+}
+
+func TestDoCommentOnItem_NoClient(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	populateGH(p, sampleIssues(), nil, nil)
+	p.gh.client = nil
+	p.activeTab = tabIssues
+	p.tabCursor[tabIssues] = 0
+
+	_, cmd := p.doCommentOnItem()
+	assert.Nil(t, cmd, "no client should be a no-op")
+	assert.Equal(t, opNone, p.pending)
+}
+
+func TestDoCommentOnItem_EmptyCursor(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabIssues
+	p.tabItems[tabIssues] = []listItem{}
+
+	_, cmd := p.doCommentOnItem()
+	assert.Nil(t, cmd, "empty list should be a no-op")
+	assert.Equal(t, opNone, p.pending)
+}
+
+// TestHandleModalResult_IssuePRComment_EmptyBody verifies that submitting a
+// blank comment is rejected client-side and never calls the API.
+func TestHandleModalResult_IssuePRComment_EmptyBody(t *testing.T) {
+	t.Parallel()
+	mock := &mockGHClientFull{}
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = mock
+	p.gh.owner = "owner"
+	p.gh.repo = "repo"
+	p.ctx = t.Context()
+	p.pending = opIssuePRComment
+	p.pendingName = "issue:42"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "   \n  "})
+	assert.NotNil(t, cmd, "empty body should still surface a warning toast")
+	assert.Equal(t, opNone, p.pending, "pending state must be cleared")
+
+	// Draining the toast cmd must not hit the API.
+	for _, msg := range collectCmdMsgs(cmd) {
+		if toast, ok := msg.(notify.ShowToastMsg); ok {
+			assert.Equal(t, notify.Warn, toast.Level)
+		}
+	}
+	assert.Equal(t, 0, mock.commentCalls, "empty body must not call CommentOnIssue")
+}
+
+// TestHandleModalResult_IssuePRComment_Cancel verifies Escape cancels without
+// calling the API.
+func TestHandleModalResult_IssuePRComment_Cancel(t *testing.T) {
+	t.Parallel()
+	mock := &mockGHClientFull{}
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = mock
+	p.pending = opIssuePRComment
+	p.pendingName = "issue:42"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: false})
+	assert.Nil(t, cmd, "cancel should be a no-op")
+	assert.Equal(t, opNone, p.pending)
+	assert.Equal(t, 0, mock.commentCalls)
+}
+
+func TestHandleModalResult_IssuePRComment_BadPendingName(t *testing.T) {
+	t.Parallel()
+	mock := &mockGHClientFull{}
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = mock
+	p.pending = opIssuePRComment
+	p.pendingName = "bad" // missing ":number"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "hi"})
+	assert.Nil(t, cmd)
+	assert.Equal(t, 0, mock.commentCalls)
+}
+
+// TestHandleModalResult_IssuePRComment_PostsAndRefreshes exercises the full
+// comment-then-refresh flow: submit a body, confirm CommentOnIssue is called
+// with the right args, then confirm the conversation preview is refreshed.
+func TestHandleModalResult_IssuePRComment_PostsAndRefreshes(t *testing.T) {
+	t.Parallel()
+	mock := &mockGHClientFull{}
+	p := newTestPanel(t, defaultMock())
+	populateGH(p, sampleIssues(), nil, nil)
+	p.gh.client = mock
+	p.ctx = t.Context()
+	p.activeTab = tabIssues
+	p.tabCursor[tabIssues] = 0
+	p.pending = opIssuePRComment
+	p.pendingName = "issue:1"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "  LGTM, shipping it  "})
+	assert.NotNil(t, cmd, "accepting a non-empty body should post the comment")
+	assert.Equal(t, opNone, p.pending)
+
+	// Run the post command; it should call the API with the trimmed body.
+	postMsg := cmd()
+	result, ok := postMsg.(commentResultMsg)
+	assert.True(t, ok, "post cmd should yield a commentResultMsg")
+	assert.NoError(t, result.err)
+	assert.Equal(t, 1, mock.commentCalls)
+	assert.Equal(t, 1, mock.commentNumber)
+	assert.Equal(t, "LGTM, shipping it", mock.commentBody, "body should be trimmed")
+
+	// Handling the result should show a success toast and refresh the preview.
+	_, resultCmd := p.handleCommentResult(result)
+	assert.NotNil(t, resultCmd)
+	var sawSuccess, sawRefresh bool
+	for _, msg := range collectCmdMsgs(resultCmd) {
+		switch m := msg.(type) {
+		case notify.ShowToastMsg:
+			if m.Level == notify.Success {
+				sawSuccess = true
+			}
+		case panels.IssueSelectedMsg:
+			sawRefresh = true
+		}
+	}
+	assert.True(t, sawSuccess, "should show a success toast")
+	assert.True(t, sawRefresh, "should refresh the conversation preview")
+}
+
+func TestHandleCommentResult_Error(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+
+	_, cmd := p.handleCommentResult(commentResultMsg{
+		number: 42,
+		kind:   commentKindIssue,
+		err:    errors.New("network down"),
+	})
+	assert.NotNil(t, cmd, "should produce an error toast")
+	var sawError bool
+	for _, msg := range collectCmdMsgs(cmd) {
+		if toast, ok := msg.(notify.ShowToastMsg); ok && toast.Level == notify.Error {
+			sawError = true
+		}
+	}
+	assert.True(t, sawError, "failed comment should surface an error toast")
+}
+
+func TestCommentCmd_PostsBody(t *testing.T) {
+	t.Parallel()
+	mock := &mockGHClientFull{}
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = mock
+	p.gh.owner = "owner"
+	p.gh.repo = "repo"
+	p.ctx = t.Context()
+
+	cmd := p.commentCmd(7, "hello world", commentKindPR)
+	msg := cmd()
+	result, ok := msg.(commentResultMsg)
+	assert.True(t, ok)
+	assert.NoError(t, result.err)
+	assert.Equal(t, 7, result.number)
+	assert.Equal(t, commentKindPR, result.kind)
+	assert.Equal(t, 1, mock.commentCalls)
+	assert.Equal(t, "hello world", mock.commentBody)
+}
+
+func TestCommentCmd_PropagatesError(t *testing.T) {
+	t.Parallel()
+	mock := &mockGHClientFull{commentErr: errors.New("403 forbidden")}
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = mock
+	p.gh.owner = "owner"
+	p.gh.repo = "repo"
+	p.ctx = t.Context()
+
+	cmd := p.commentCmd(7, "hello", commentKindIssue)
+	msg := cmd()
+	result, ok := msg.(commentResultMsg)
+	assert.True(t, ok)
+	assert.Error(t, result.err)
+}
+
+// ---------------------------------------------------------------------------
 // handlePRBranchDeleteResult
 // ---------------------------------------------------------------------------
 

--- a/internal/panels/gitinfo/gitinfo_github.go
+++ b/internal/panels/gitinfo/gitinfo_github.go
@@ -132,6 +132,14 @@ type prMergeResultMsg struct {
 	err        error
 }
 
+// commentResultMsg carries the result of posting a conversation-level comment
+// on an issue or PR.
+type commentResultMsg struct {
+	number int
+	kind   string
+	err    error
+}
+
 // prBranchDeleteResultMsg carries the result of deleting a branch after PR merge.
 type prBranchDeleteResultMsg struct {
 	branch    string
@@ -1746,6 +1754,88 @@ func (p *Panel) handlePRMergeResult(msg prMergeResultMsg) (panels.Panel, tea.Cmd
 		))
 	}
 
+	return p, tea.Batch(cmds...)
+}
+
+// commentKindIssue and commentKindPR label the target of a comment for the
+// pending-op name and result toast.
+const (
+	commentKindIssue = "issue"
+	commentKindPR    = "PR"
+)
+
+// doCommentOnItem opens a multi-line composer to post a conversation-level
+// comment on the selected issue or PR. This is distinct from inline diff
+// review comments; it uses the shared issue-comment endpoint.
+func (p *Panel) doCommentOnItem() (panels.Panel, tea.Cmd) {
+	items := p.tabItems[p.activeTab]
+	cursor := p.tabCursor[p.activeTab]
+	if cursor < 0 || cursor >= len(items) {
+		return p, nil
+	}
+	if p.gh.client == nil {
+		return p, nil
+	}
+
+	var number int
+	var title, kind string
+	switch items[cursor].kind {
+	case kindIssue:
+		number = items[cursor].issue.Number
+		title = items[cursor].issue.Title
+		kind = commentKindIssue
+	case kindPR:
+		number = items[cursor].pr.Number
+		title = items[cursor].pr.Title
+		kind = commentKindPR
+	default:
+		return p, nil
+	}
+
+	p.clearPending()
+	p.pending = opIssuePRComment
+	p.pendingName = fmt.Sprintf("%s:%d", kind, number)
+
+	modalTitle := fmt.Sprintf("Comment on %s #%d: %s", kind, number, title)
+	return p, notify.ShowMultilineInput(modalTitle, "Write a comment...")
+}
+
+// commentCmd returns a tea.Cmd that posts the comment asynchronously.
+func (p *Panel) commentCmd(number int, body, kind string) tea.Cmd {
+	client := p.gh.client
+	owner, repo := p.gh.owner, p.gh.repo
+	ctx := p.ctx
+	return func() tea.Msg {
+		err := client.CommentOnIssue(ctx, owner, repo, number, body)
+		return commentResultMsg{number: number, kind: kind, err: err}
+	}
+}
+
+// handleCommentResult processes the async result of posting a comment. On
+// success it refreshes the conversation shown in the preview.
+func (p *Panel) handleCommentResult(msg commentResultMsg) (panels.Panel, tea.Cmd) {
+	if msg.err != nil {
+		errStr := msg.err.Error()
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: fmt.Sprintf("Comment on %s #%d failed: %s", msg.kind, msg.number, errStr),
+				Level:   notify.Error,
+			}
+		}
+	}
+
+	toastMsg := fmt.Sprintf("Comment posted on %s #%d", msg.kind, msg.number)
+	cmds := []tea.Cmd{
+		func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: toastMsg,
+				Level:   notify.Success,
+			}
+		},
+	}
+	if refresh := p.activeTabSelectionCmd(); refresh != nil {
+		cmds = append(cmds, refresh)
+	}
 	return p, tea.Batch(cmds...)
 }
 

--- a/internal/panels/gitinfo/gitinfo_modal_handlers.go
+++ b/internal/panels/gitinfo/gitinfo_modal_handlers.go
@@ -402,3 +402,30 @@ func (p *Panel) handlePRDeleteBranchAfterMerge(a modalArgs) (panels.Panel, tea.C
 		}
 	}
 }
+
+// handleIssuePRComment posts the composed comment body to the selected issue
+// or PR. Empty bodies are rejected without hitting the API.
+// pendingName format: "kind:number" (e.g. "issue:252" or "PR:100").
+func (p *Panel) handleIssuePRComment(a modalArgs) (panels.Panel, tea.Cmd) {
+	parts := strings.SplitN(a.name, ":", 2)
+	if len(parts) < 2 {
+		return p, nil
+	}
+	kind := parts[0]
+	number, _ := strconv.Atoi(parts[1])
+	if number == 0 {
+		return p, nil
+	}
+
+	body := strings.TrimSpace(a.msg.Value)
+	if body == "" {
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: "Comment cannot be empty",
+				Level:   notify.Warn,
+			}
+		}
+	}
+
+	return p, p.commentCmd(number, body, kind)
+}

--- a/internal/panels/gitinfo/gitinfo_test.go
+++ b/internal/panels/gitinfo/gitinfo_test.go
@@ -2492,6 +2492,11 @@ type mockGHClientFull struct {
 	cancelErr  error
 	mergeErr   error
 	getPRCalls int
+
+	commentCalls  int
+	commentNumber int
+	commentBody   string
+	commentErr    error
 }
 
 func (m *mockGHClientFull) CurrentUser(_ context.Context) (*gh.User, error) {
@@ -2518,8 +2523,11 @@ func (m *mockGHClientFull) EditIssue(_ context.Context, _, _ string, _ int, _ *g
 	return nil
 }
 
-func (m *mockGHClientFull) CommentOnIssue(_ context.Context, _, _ string, _ int, _ string) error {
-	return nil
+func (m *mockGHClientFull) CommentOnIssue(_ context.Context, _, _ string, number int, body string) error {
+	m.commentCalls++
+	m.commentNumber = number
+	m.commentBody = body
+	return m.commentErr
 }
 func (m *mockGHClientFull) CloseIssue(_ context.Context, _, _ string, _ int) error  { return nil }
 func (m *mockGHClientFull) ReopenIssue(_ context.Context, _, _ string, _ int) error { return nil }

--- a/web/src/pages/docs/keybindings.astro
+++ b/web/src/pages/docs/keybindings.astro
@@ -115,6 +115,8 @@ import Screenshot from '../../components/Screenshot.astro';
     { key: 'Enter', action: 'Select (show in preview)' },
     { key: 'o', action: 'Open in browser' },
     { key: 'y', action: 'Copy to clipboard' },
+    { key: 'm', action: 'Merge PR (PRs tab only)' },
+    { key: 'c', action: 'Comment on issue/PR (Issues/PRs tab only)' },
     { key: 'r', action: 'Rerun (Actions tab only)' },
     { key: 'x', action: 'Cancel (Actions tab only)' },
     { key: 'D', action: 'Dispatch workflow (Workflows tab only)' },


### PR DESCRIPTION
Closes #252

## What changed

Adds a keybinding to post a conversation-level comment on the selected issue or pull request from the GitHub panel. The `github.Client.CommentOnIssue` method already existed but was not wired to any UI, so this is UI wiring only.

- Press `c` on the Issues or PRs tab to open a multi-line composer.
- Enter inserts a newline, `Ctrl+D` submits, `Esc` cancels.
- An empty body is rejected client-side with a warning toast and never calls the API.
- On success the comment is posted via `CommentOnIssue` and the conversation preview refreshes.
- API failures surface an error toast.

Comments work for both issues and PRs through the shared issue-comment endpoint.

### Implementation notes

- `internal/notify`: new `ModalMultilineInput` modal kind plus `ShowMultilineInput`, key handling, and a composer render that keeps a minimum height and shows a placeholder when empty.
- `internal/panels/gitinfo`: `c` key handler, `doCommentOnItem`, `commentCmd`, `handleCommentResult`, and the `handleIssuePRComment` modal-result handler. Registered in the panel `KeyBindings()`.
- Docs: added the `c` binding to `internal/keybindings/keybindings.json`, regenerated `docs/keybindings.md`, and updated `web/src/pages/docs/keybindings.astro`.

## How tested

- `go build ./...`, `go vet ./...`, and `gofmt` all clean.
- `go test ./...` passes across every package.
- New unit tests in `internal/panels/gitinfo` cover empty-body validation (no API call), cancel, bad pending-name, the full comment-then-refresh flow (asserts the trimmed body reaches the mock and the preview refresh is emitted), error handling, and the command itself. New tests in `internal/notify` cover the multiline modal submit, escape, and newline-on-enter behavior.

## Distinct from #212

This is a conversation-level comment on an issue or PR. It is separate from the inline diff review comments tracked in #212 and does not add or touch line-level review comments.