### PR TITLE
Open a pull request from the TUI

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -134,6 +134,7 @@ GitHub panel (panel 3).
 | `l` | Releases tab |
 | `o` | Open in browser |
 | `y` | Copy to clipboard |
+| `n` | Create pull request (PRs tab) |
 | `m` | Merge PR (PRs tab) |
 | `r` | Rerun (Actions tab) |
 | `x` | Cancel (Actions tab) |

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -114,6 +114,7 @@
         { "key": "l", "action": "Releases tab" },
         { "key": "o", "action": "Open in browser" },
         { "key": "y", "action": "Copy to clipboard" },
+        { "key": "n", "action": "Create pull request (PRs tab)" },
         { "key": "m", "action": "Merge PR (PRs tab)" },
         { "key": "r", "action": "Rerun (Actions tab)" },
         { "key": "x", "action": "Cancel (Actions tab)" },

--- a/internal/panels/gitinfo/gitinfo.go
+++ b/internal/panels/gitinfo/gitinfo.go
@@ -148,6 +148,10 @@ const (
 	opPRMergeStrategy                    // awaiting merge strategy selection
 	opPRMergeConfirm                     // awaiting merge confirmation
 	opPRDeleteBranchAfterMerge           // awaiting post-merge branch deletion confirmation
+	opPRCreateHead                       // awaiting create-PR head branch
+	opPRCreateBase                       // awaiting create-PR base branch
+	opPRCreateTitle                      // awaiting create-PR title
+	opPRCreateBody                       // awaiting create-PR body (optional, final step)
 )
 
 // ---------------------------------------------------------------------------
@@ -294,18 +298,28 @@ type gitState struct {
 // githubState holds all GitHub-related integration state: API client,
 // repository metadata, and cached issue / PR data.
 type githubState struct {
-	client      ghclient.Client
-	err         error
-	owner       string
-	repo        string
-	user        string
-	allIssues   []ghIssueItem
-	allPRs      []ghPRItem
-	cfg         config.GitHubConfig
-	issueFilter IssueFilterKind
-	prFilter    PRFilterKind
-	repoPrivate bool
-	pageSize    int
+	client          ghclient.Client
+	err             error
+	owner           string
+	repo            string
+	user            string
+	defaultBranch   string // repo default branch, used to prefill PR base
+	allIssues       []ghIssueItem
+	allPRs          []ghPRItem
+	cfg             config.GitHubConfig
+	issueFilter     IssueFilterKind
+	prFilter        PRFilterKind
+	pendingSelectPR int // PR number to reselect after the next data load (0 = none)
+	repoPrivate     bool
+	pageSize        int
+}
+
+// prCreateDraft holds the field values captured across the multi-step
+// create-PR modal flow (head then base then title then body).
+type prCreateDraft struct {
+	head  string
+	base  string
+	title string
 }
 
 // ---------------------------------------------------------------------------
@@ -333,6 +347,7 @@ type Panel struct {
 	activeTab         tabID         // currently active tab
 	remoteCount       int           // actual number of remotes (distinct from tabItems len which includes sub-rows)
 	pending           pendingOp     // operation awaiting modal result
+	prDraft           prCreateDraft // in-progress fields for the multi-step create-PR flow
 	actionsWatchFrame int           // current animation frame index into watchFrames
 	lastWidth         int           // last rendered width, used for click zone calculation
 	// CI watch animation state — animated indicator when in-progress runs exist.
@@ -745,6 +760,8 @@ func (p *Panel) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 		return p.handlePRMergeResult(msg)
 	case prBranchDeleteResultMsg:
 		return p.handlePRBranchDeleteResult(msg)
+	case prCreateResultMsg:
+		return p.handlePRCreateResult(msg)
 
 	// CRUD actions dispatched via keymap.
 	case panels.ItemCreateMsg:
@@ -1921,6 +1938,8 @@ func (p *Panel) doCreate() (panels.Panel, tea.Cmd) {
 				return notify.ShowToastMsg{Message: "Opened new issue page", Level: notify.Info}
 			}
 		}
+	case tabPRs:
+		return p.doCreatePR()
 	}
 	return p, nil
 }
@@ -2057,6 +2076,8 @@ func (p *Panel) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, tea.
 	pendingPath := p.pendingPath
 	p.clearPending()
 	if !msg.Accept {
+		// Abort any in-progress create-PR flow so a later run starts clean.
+		p.prDraft = prCreateDraft{}
 		return p, nil
 	}
 	a := modalArgs{
@@ -2113,6 +2134,14 @@ func (p *Panel) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, tea.
 		return p.handlePRMergeConfirm(a)
 	case opPRDeleteBranchAfterMerge:
 		return p.handlePRDeleteBranchAfterMerge(a)
+	case opPRCreateHead:
+		return p.handlePRCreateHead(a)
+	case opPRCreateBase:
+		return p.handlePRCreateBase(a)
+	case opPRCreateTitle:
+		return p.handlePRCreateTitle(a)
+	case opPRCreateBody:
+		return p.handlePRCreateBody(a)
 	}
 	return p, nil
 }

--- a/internal/panels/gitinfo/gitinfo_github.go
+++ b/internal/panels/gitinfo/gitinfo_github.go
@@ -139,6 +139,12 @@ type prBranchDeleteResultMsg struct {
 	localErr  error
 }
 
+// prCreateResultMsg carries the result of creating a pull request.
+type prCreateResultMsg struct {
+	pr  ghPRItem
+	err error
+}
+
 // workflowInputsFetchedMsg carries the result of fetching workflow_dispatch
 // input definitions from the workflow YAML file.
 type workflowInputsFetchedMsg struct {
@@ -244,20 +250,22 @@ func (f PRFilterKind) String() string {
 
 // ghDataLoadedMsg carries the result of an async GitHub data load.
 type ghDataLoadedMsg struct {
-	err         error
-	user        string
-	issues      []ghIssueItem
-	prs         []ghPRItem
-	actions     []ghActionItem
-	workflows   []ghWorkflowItem
-	releases    []ghReleaseItem
-	repoPrivate bool
+	err           error
+	user          string
+	defaultBranch string
+	issues        []ghIssueItem
+	prs           []ghPRItem
+	actions       []ghActionItem
+	workflows     []ghWorkflowItem
+	releases      []ghReleaseItem
+	repoPrivate   bool
 }
 
 // ghMetaLoadedMsg carries repo metadata and current user info.
 type ghMetaLoadedMsg struct {
-	user        string
-	repoPrivate bool
+	user          string
+	defaultBranch string
+	repoPrivate   bool
 }
 
 // ghIssuesPageMsg carries one page of issues from the GitHub API.
@@ -397,6 +405,7 @@ func (p *Panel) loadGitHubData() tea.Cmd {
 			slog.Warn("github: fetch repo info failed", "owner", owner, "repo", repo, "err", err)
 		} else if repoInfo != nil {
 			result.repoPrivate = repoInfo.GetPrivate()
+			result.defaultBranch = repoInfo.GetDefaultBranch()
 		}
 		// Get current user.
 		user, err := client.CurrentUser(ctx)
@@ -568,8 +577,17 @@ func (p *Panel) handleGHDataLoaded(msg ghDataLoadedMsg) (panels.Panel, tea.Cmd) 
 	if msg.user != "" {
 		p.gh.user = msg.user
 	}
+	if msg.defaultBranch != "" {
+		p.gh.defaultBranch = msg.defaultBranch
+	}
 	p.gh.repoPrivate = msg.repoPrivate
 	p.buildGitHubItems(msg.issues, msg.prs, msg.actions, msg.workflows, msg.releases)
+	// If a create/merge flow requested a specific PR be reselected after this
+	// refresh, honor it now that the list has been rebuilt.
+	if p.gh.pendingSelectPR != 0 {
+		p.selectPRByNumber(p.gh.pendingSelectPR)
+		p.gh.pendingSelectPR = 0
+	}
 	// Determine if any workflow run is still in progress or queued.
 	wasWatching := p.actionsWatching
 	p.actionsWatching = false
@@ -641,6 +659,7 @@ func (p *Panel) loadGitHubMeta() tea.Cmd {
 			slog.Warn("github: fetch repo info failed", "owner", owner, "repo", repo, "err", err)
 		} else if repoInfo != nil {
 			result.repoPrivate = repoInfo.GetPrivate()
+			result.defaultBranch = repoInfo.GetDefaultBranch()
 		}
 		user, err := client.CurrentUser(ctx)
 		if err != nil {
@@ -866,6 +885,9 @@ func (p *Panel) loadReleasesPage(page int, replace bool) tea.Cmd {
 func (p *Panel) handleMetaLoaded(msg ghMetaLoadedMsg) (panels.Panel, tea.Cmd) {
 	if msg.user != "" {
 		p.gh.user = msg.user
+	}
+	if msg.defaultBranch != "" {
+		p.gh.defaultBranch = msg.defaultBranch
 	}
 	p.gh.repoPrivate = msg.repoPrivate
 	return p, nil
@@ -1790,8 +1812,176 @@ func (p *Panel) handlePRBranchDeleteResult(msg prBranchDeleteResultMsg) (panels.
 }
 
 // ---------------------------------------------------------------------------
-// GitHub item rendering
+// GitHub PR creation
 // ---------------------------------------------------------------------------
+
+// doCreatePR starts the multi-step flow to open a pull request from the TUI.
+// Head is prefilled with the current local branch and base with the repo
+// default branch; both remain editable in the modal.
+func (p *Panel) doCreatePR() (panels.Panel, tea.Cmd) {
+	if p.gh.client == nil {
+		return p, nil
+	}
+	head := p.currentLocalBranch()
+	if head == "" {
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: "Cannot open PR: no current branch detected",
+				Level:   notify.Warn,
+			}
+		}
+	}
+	if !p.branchIsPushed(head) {
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: fmt.Sprintf("Push branch %q before opening a PR", head),
+				Level:   notify.Warn,
+			}
+		}
+	}
+	base := p.gh.defaultBranch
+	if base == "" {
+		base = branchMain
+	}
+	p.clearPending()
+	p.prDraft = prCreateDraft{head: head, base: base}
+	p.pending = opPRCreateHead
+	return p, notify.ShowInputWithValue("PR Head Branch", "head-branch", head)
+}
+
+// currentLocalBranch returns the name of the current local branch by scanning
+// the full branch list, which includes local branches even in GitHub mode.
+// It returns "" when no current local branch can be determined.
+func (p *Panel) currentLocalBranch() string {
+	for _, b := range p.gitData.lastBranches {
+		if !b.IsRemote && b.IsCurrent {
+			return b.Name
+		}
+	}
+	return ""
+}
+
+// remoteBranchName strips the leading remote name from a remote-tracking ref,
+// e.g. "origin/main" becomes "main".
+func remoteBranchName(name string) string {
+	if i := strings.IndexByte(name, '/'); i >= 0 {
+		return name[i+1:]
+	}
+	return name
+}
+
+// branchIsPushed reports whether the named local branch appears to exist on a
+// remote: either it tracks an upstream, or a remote branch with a matching
+// short name is present in the branch list.
+func (p *Panel) branchIsPushed(name string) bool {
+	for _, b := range p.gitData.lastBranches {
+		if !b.IsRemote && b.Name == name && b.Upstream != "" {
+			return true
+		}
+		if b.IsRemote && remoteBranchName(b.Name) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// createPRCmd returns a tea.Cmd that opens the pull request asynchronously.
+func (p *Panel) createPRCmd(head, base, title, body string) tea.Cmd {
+	client := p.gh.client
+	owner, repo := p.gh.owner, p.gh.repo
+	ctx := p.ctx
+	return func() tea.Msg {
+		req := &gh.NewPullRequest{
+			Title: gh.Ptr(title),
+			Head:  gh.Ptr(head),
+			Base:  gh.Ptr(base),
+		}
+		if body != "" {
+			req.Body = gh.Ptr(body)
+		}
+		created, err := client.CreatePR(ctx, owner, repo, req)
+		if err != nil {
+			return prCreateResultMsg{err: err}
+		}
+		if created == nil {
+			return prCreateResultMsg{err: fmt.Errorf("no pull request returned")}
+		}
+		author := ""
+		if created.User != nil {
+			author = created.User.GetLogin()
+		}
+		state := created.GetState()
+		if created.GetDraft() {
+			state = stateDraft
+		}
+		return prCreateResultMsg{pr: ghPRItem{
+			Number:     created.GetNumber(),
+			Title:      created.GetTitle(),
+			State:      state,
+			HeadBranch: created.GetHead().GetRef(),
+			Author:     author,
+			HTMLURL:    created.GetHTMLURL(),
+		}}
+	}
+}
+
+// handlePRCreateResult processes the async result of opening a pull request.
+func (p *Panel) handlePRCreateResult(msg prCreateResultMsg) (panels.Panel, tea.Cmd) {
+	if msg.err != nil {
+		errStr := msg.err.Error()
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: "Create PR failed: " + errStr,
+				Level:   notify.Error,
+			}
+		}
+	}
+	// Show all PRs so the new one is guaranteed visible, then insert it
+	// optimistically for immediate feedback ahead of the server refresh.
+	p.gh.prFilter = prFilterAll
+	exists := false
+	for i := range p.gh.allPRs {
+		if p.gh.allPRs[i].Number == msg.pr.Number {
+			p.gh.allPRs[i] = msg.pr
+			exists = true
+			break
+		}
+	}
+	if !exists {
+		p.gh.allPRs = append([]ghPRItem{msg.pr}, p.gh.allPRs...)
+	}
+	p.applyPRFilter()
+	p.selectPRByNumber(msg.pr.Number)
+	// Refresh from the server and reselect the new PR once it arrives.
+	p.gh.pendingSelectPR = msg.pr.Number
+	return p, tea.Batch(
+		func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: fmt.Sprintf("PR #%d created", msg.pr.Number),
+				Level:   notify.Success,
+			}
+		},
+		p.loadGitHubData(),
+	)
+}
+
+// selectPRByNumber moves the PRs-tab cursor to the PR with the given number,
+// if it is present in the currently visible list.
+func (p *Panel) selectPRByNumber(number int) {
+	if number == 0 {
+		return
+	}
+	for i, item := range p.tabItems[tabPRs] {
+		if item.kind == kindPR && item.pr.Number == number {
+			p.tabCursor[tabPRs] = i
+			if p.activeTab == tabPRs {
+				p.ensureCursorVisible()
+			}
+			return
+		}
+	}
+}
+
 // renderIssue renders a GitHub issue line: "  #42 Fix auth token...   bug"
 func (p *Panel) renderIssue(item listItem, width int, isCursor bool) string {
 	iss := item.issue

--- a/internal/panels/gitinfo/gitinfo_modal_handlers.go
+++ b/internal/panels/gitinfo/gitinfo_modal_handlers.go
@@ -402,3 +402,62 @@ func (p *Panel) handlePRDeleteBranchAfterMerge(a modalArgs) (panels.Panel, tea.C
 		}
 	}
 }
+
+// prCreateAbort resets the in-progress draft and shows a warning toast. It is
+// used by the create-PR steps when validation fails.
+func (p *Panel) prCreateAbort(message string) (panels.Panel, tea.Cmd) {
+	p.prDraft = prCreateDraft{}
+	return p, func() tea.Msg {
+		return notify.ShowToastMsg{Message: message, Level: notify.Warn}
+	}
+}
+
+// handlePRCreateHead captures the head branch, then prompts for the base.
+func (p *Panel) handlePRCreateHead(a modalArgs) (panels.Panel, tea.Cmd) {
+	head := strings.TrimSpace(a.msg.Value)
+	if head == "" {
+		return p.prCreateAbort("Cannot open PR: head branch is required")
+	}
+	p.prDraft.head = head
+	p.pending = opPRCreateBase
+	return p, notify.ShowInputWithValue("PR Base Branch", "base-branch", p.prDraft.base)
+}
+
+// handlePRCreateBase captures the base branch, guards head==base, then prompts
+// for the title.
+func (p *Panel) handlePRCreateBase(a modalArgs) (panels.Panel, tea.Cmd) {
+	base := strings.TrimSpace(a.msg.Value)
+	if base == "" {
+		return p.prCreateAbort("Cannot open PR: base branch is required")
+	}
+	if base == p.prDraft.head {
+		return p.prCreateAbort(fmt.Sprintf("Cannot open PR: head and base are both %q", base))
+	}
+	p.prDraft.base = base
+	p.pending = opPRCreateTitle
+	return p, notify.ShowInput("PR Title", "title")
+}
+
+// handlePRCreateTitle captures the required title, then prompts for the
+// optional body.
+func (p *Panel) handlePRCreateTitle(a modalArgs) (panels.Panel, tea.Cmd) {
+	title := strings.TrimSpace(a.msg.Value)
+	if title == "" {
+		return p.prCreateAbort("Cannot open PR: title is required")
+	}
+	p.prDraft.title = title
+	p.pending = opPRCreateBody
+	return p, notify.ShowInput("PR Body", "(optional)")
+}
+
+// handlePRCreateBody captures the optional body and fires the create request.
+func (p *Panel) handlePRCreateBody(a modalArgs) (panels.Panel, tea.Cmd) {
+	body := strings.TrimSpace(a.msg.Value)
+	head, base, title := p.prDraft.head, p.prDraft.base, p.prDraft.title
+	p.prDraft = prCreateDraft{}
+	if head == "" || base == "" || title == "" {
+		// Defensive: state was lost somehow; abort quietly with a warning.
+		return p.prCreateAbort("Cannot open PR: missing branch or title")
+	}
+	return p, p.createPRCmd(head, base, title, body)
+}

--- a/internal/panels/gitinfo/gitinfo_test.go
+++ b/internal/panels/gitinfo/gitinfo_test.go
@@ -2492,6 +2492,13 @@ type mockGHClientFull struct {
 	cancelErr  error
 	mergeErr   error
 	getPRCalls int
+
+	// Create-PR controls.
+	createdPR   *gh.PullRequest    // returned by CreatePR when createErr is nil
+	createErr   error              // returned by CreatePR
+	createReq   *gh.NewPullRequest // captured request passed to CreatePR
+	createCalls int                // number of times CreatePR was called
+	repoInfo    *gh.Repository     // returned by RepoInfo
 }
 
 func (m *mockGHClientFull) CurrentUser(_ context.Context) (*gh.User, error) {
@@ -2552,8 +2559,10 @@ func (m *mockGHClientFull) GetPRCommits(_ context.Context, _, _ string, _ int) (
 	return m.prCommits, m.prCommErr
 }
 
-func (m *mockGHClientFull) CreatePR(_ context.Context, _, _ string, _ *gh.NewPullRequest) (*gh.PullRequest, error) {
-	return nil, nil
+func (m *mockGHClientFull) CreatePR(_ context.Context, _, _ string, req *gh.NewPullRequest) (*gh.PullRequest, error) {
+	m.createCalls++
+	m.createReq = req
+	return m.createdPR, m.createErr
 }
 
 func (m *mockGHClientFull) MergePR(_ context.Context, _, _ string, _ int, _ string, _ *gh.PullRequestOptions) error {
@@ -2605,7 +2614,7 @@ func (m *mockGHClientFull) ListNotifications(_ context.Context, _ *gh.Notificati
 }
 func (m *mockGHClientFull) MarkRead(_ context.Context, _ string) error { return nil }
 func (m *mockGHClientFull) RepoInfo(_ context.Context, _, _ string) (*gh.Repository, error) {
-	return nil, nil
+	return m.repoInfo, nil
 }
 
 func (m *mockGHClientFull) ListWorkflows(_ context.Context, _, _ string, _ *gh.ListOptions) ([]*gh.Workflow, error) {
@@ -4835,4 +4844,273 @@ func TestRightClickLabel_ANSIInjection(t *testing.T) {
 			assert.Contains(t, label, tt.want)
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Create pull request from the PRs tab (issue #249)
+// ---------------------------------------------------------------------------
+
+// pushedFeatureBranches returns a branch set with "feature" as the current,
+// pushed local branch plus its remote counterpart and origin/main.
+func pushedFeatureBranches() []git.Branch {
+	return []git.Branch{
+		{Name: "feature", IsCurrent: true, Upstream: "origin/feature"},
+		{Name: "origin/feature", IsRemote: true},
+		{Name: "origin/main", IsRemote: true},
+	}
+}
+
+func TestDoCreatePR_PrefillsHeadAndBase(t *testing.T) {
+	p := newGHPanelWithClient(t, defaultMock(), &mockGHClientFull{})
+	p.activeTab = tabPRs
+	p.gh.defaultBranch = "main"
+	p.gitData.lastBranches = pushedFeatureBranches()
+
+	_, cmd := p.doCreatePR()
+	require.NotNil(t, cmd, "should open the head-branch input")
+	assert.Equal(t, opPRCreateHead, p.pending)
+	assert.Equal(t, "feature", p.prDraft.head, "head should prefill with current branch")
+	assert.Equal(t, "main", p.prDraft.base, "base should prefill with default branch")
+}
+
+func TestDoCreatePR_DefaultBranchFallback(t *testing.T) {
+	p := newGHPanelWithClient(t, defaultMock(), &mockGHClientFull{})
+	p.activeTab = tabPRs
+	p.gh.defaultBranch = "" // unknown default → fall back to main
+	p.gitData.lastBranches = pushedFeatureBranches()
+
+	_, cmd := p.doCreatePR()
+	require.NotNil(t, cmd)
+	assert.Equal(t, branchMain, p.prDraft.base)
+}
+
+func TestDoCreatePR_NoCurrentBranchWarns(t *testing.T) {
+	p := newGHPanelWithClient(t, defaultMock(), &mockGHClientFull{})
+	p.activeTab = tabPRs
+	p.gitData.lastBranches = []git.Branch{{Name: "origin/main", IsRemote: true}}
+
+	_, cmd := p.doCreatePR()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	toast, ok := msg.(notify.ShowToastMsg)
+	require.True(t, ok, "expected a toast, got %T", msg)
+	assert.Equal(t, notify.Warn, toast.Level)
+	assert.Equal(t, opNone, p.pending, "no modal flow should start")
+}
+
+func TestDoCreatePR_UnpushedBranchWarns(t *testing.T) {
+	p := newGHPanelWithClient(t, defaultMock(), &mockGHClientFull{})
+	p.activeTab = tabPRs
+	// Current branch has no upstream and no matching remote branch.
+	p.gitData.lastBranches = []git.Branch{{Name: "feature", IsCurrent: true}}
+
+	_, cmd := p.doCreatePR()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	toast, ok := msg.(notify.ShowToastMsg)
+	require.True(t, ok, "expected a toast, got %T", msg)
+	assert.Equal(t, notify.Warn, toast.Level)
+	assert.Contains(t, toast.Message, "Push branch")
+	assert.Equal(t, opNone, p.pending)
+}
+
+func TestDoCreatePR_NilClientNoop(t *testing.T) {
+	p := newTestGitHubPanel(t, defaultMock()) // no gh client wired
+	p.gh.client = nil
+	p.activeTab = tabPRs
+
+	_, cmd := p.doCreatePR()
+	assert.Nil(t, cmd, "no client should be a no-op")
+}
+
+func TestPRCreateFlow_EmptyTitleRejected(t *testing.T) {
+	ghMock := &mockGHClientFull{}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+	p.activeTab = tabPRs
+	p.gh.defaultBranch = "main"
+	p.gitData.lastBranches = pushedFeatureBranches()
+
+	p.doCreatePR()
+	p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "feature"}) // head
+	p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "main"})    // base
+	require.Equal(t, opPRCreateTitle, p.pending)
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "   "}) // blank title
+	require.NotNil(t, cmd)
+	msg := cmd()
+	toast, ok := msg.(notify.ShowToastMsg)
+	require.True(t, ok, "expected a toast, got %T", msg)
+	assert.Equal(t, notify.Warn, toast.Level)
+	assert.Equal(t, prCreateDraft{}, p.prDraft, "draft should reset on abort")
+	assert.Zero(t, ghMock.createCalls, "CreatePR must not be called with an empty title")
+}
+
+func TestPRCreateFlow_HeadEqualsBaseRejected(t *testing.T) {
+	ghMock := &mockGHClientFull{}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+	p.activeTab = tabPRs
+	p.gh.defaultBranch = "main"
+	p.gitData.lastBranches = pushedFeatureBranches()
+
+	p.doCreatePR()
+	p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "main"}) // head edited to main
+	require.Equal(t, opPRCreateBase, p.pending)
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "main"}) // base == head
+	require.NotNil(t, cmd)
+	msg := cmd()
+	toast, ok := msg.(notify.ShowToastMsg)
+	require.True(t, ok, "expected a toast, got %T", msg)
+	assert.Equal(t, notify.Warn, toast.Level)
+	assert.Contains(t, toast.Message, "head and base")
+	assert.Equal(t, prCreateDraft{}, p.prDraft)
+	assert.Zero(t, ghMock.createCalls)
+}
+
+func TestPRCreateFlow_Success(t *testing.T) {
+	num := 42
+	createdPR := &gh.PullRequest{
+		Number: &num,
+		Title:  gh.Ptr("My new PR"),
+		State:  gh.Ptr(prStateOpen),
+		Head:   &gh.PullRequestBranch{Ref: gh.Ptr("feature")},
+		User:   ghUser("me"),
+	}
+	ghMock := &mockGHClientFull{createdPR: createdPR, prs: []*gh.PullRequest{createdPR}}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+	p.activeTab = tabPRs
+	p.gh.defaultBranch = "main"
+	p.gh.prFilter = prFilterMine // start on a filtered view to prove it resets
+	p.gitData.lastBranches = pushedFeatureBranches()
+
+	_, cmd := p.doCreatePR()
+	require.NotNil(t, cmd)
+	require.Equal(t, opPRCreateHead, p.pending)
+
+	p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "feature"})
+	require.Equal(t, opPRCreateBase, p.pending)
+	p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "main"})
+	require.Equal(t, opPRCreateTitle, p.pending)
+	p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "My new PR"})
+	require.Equal(t, opPRCreateBody, p.pending)
+
+	_, createCmd := p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "Closes #249"})
+	require.NotNil(t, createCmd)
+	assert.Equal(t, prCreateDraft{}, p.prDraft, "draft should reset once the request fires")
+
+	msg := createCmd()
+	res, ok := msg.(prCreateResultMsg)
+	require.True(t, ok, "expected prCreateResultMsg, got %T", msg)
+	require.NoError(t, res.err)
+	assert.Equal(t, 42, res.pr.Number)
+
+	// The request should carry the exact head, base, title, and body entered.
+	require.NotNil(t, ghMock.createReq)
+	assert.Equal(t, 1, ghMock.createCalls)
+	assert.Equal(t, "My new PR", ghMock.createReq.GetTitle())
+	assert.Equal(t, "feature", ghMock.createReq.GetHead())
+	assert.Equal(t, "main", ghMock.createReq.GetBase())
+	assert.Equal(t, "Closes #249", ghMock.createReq.GetBody())
+
+	// Handling the result inserts the PR, resets the filter, and queues reselect.
+	_, afterCmd := p.handlePRCreateResult(res)
+	require.NotNil(t, afterCmd)
+	assert.Equal(t, prFilterAll, p.gh.prFilter, "filter should reset so the new PR is visible")
+	require.NotEmpty(t, p.gh.allPRs)
+	assert.Equal(t, 42, p.gh.allPRs[0].Number, "new PR inserted at the front")
+	assert.Equal(t, 42, p.gh.pendingSelectPR, "reselect queued for the post-refresh load")
+	// The visible cursor should land on the new PR.
+	require.NotEmpty(t, p.tabItems[tabPRs])
+	assert.Equal(t, 42, p.tabItems[tabPRs][p.tabCursor[tabPRs]].pr.Number)
+}
+
+func TestCreatePRCmd_OmitsEmptyBody(t *testing.T) {
+	ghMock := &mockGHClientFull{createdPR: &gh.PullRequest{Number: gh.Ptr(1), Title: gh.Ptr("t"), State: gh.Ptr(prStateOpen), Head: &gh.PullRequestBranch{Ref: gh.Ptr("feature")}}}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+
+	msg := p.createPRCmd("feature", "main", "t", "")()
+	res, ok := msg.(prCreateResultMsg)
+	require.True(t, ok)
+	require.NoError(t, res.err)
+	require.NotNil(t, ghMock.createReq)
+	assert.Nil(t, ghMock.createReq.Body, "empty body should be omitted from the request")
+}
+
+func TestCreatePRCmd_ErrorPropagates(t *testing.T) {
+	ghMock := &mockGHClientFull{createErr: fmt.Errorf("api down")}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+
+	msg := p.createPRCmd("feature", "main", "t", "")()
+	res, ok := msg.(prCreateResultMsg)
+	require.True(t, ok)
+	require.Error(t, res.err)
+}
+
+func TestCreatePRCmd_NilResultIsError(t *testing.T) {
+	ghMock := &mockGHClientFull{} // createdPR nil, createErr nil
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+
+	msg := p.createPRCmd("feature", "main", "t", "")()
+	res, ok := msg.(prCreateResultMsg)
+	require.True(t, ok)
+	require.Error(t, res.err, "a nil PR with no error should surface as an error")
+}
+
+func TestHandlePRCreateResult_ErrorShowsToast(t *testing.T) {
+	p := newGHPanelWithClient(t, defaultMock(), &mockGHClientFull{})
+	p.activeTab = tabPRs
+
+	_, cmd := p.handlePRCreateResult(prCreateResultMsg{err: fmt.Errorf("boom")})
+	require.NotNil(t, cmd)
+	msg := cmd()
+	toast, ok := msg.(notify.ShowToastMsg)
+	require.True(t, ok, "expected a toast, got %T", msg)
+	assert.Equal(t, notify.Error, toast.Level)
+	assert.Contains(t, toast.Message, "boom")
+	assert.Empty(t, p.gh.allPRs, "no PR should be inserted on failure")
+}
+
+func TestHandleModalResultCancel_ResetsPRDraft(t *testing.T) {
+	p := newGHPanelWithClient(t, defaultMock(), &mockGHClientFull{})
+	p.pending = opPRCreateTitle
+	p.prDraft = prCreateDraft{head: "feature", base: "main"}
+
+	p.handleModalResult(notify.ModalResultMsg{Accept: false})
+	assert.Equal(t, prCreateDraft{}, p.prDraft, "cancel should clear the in-progress draft")
+	assert.Equal(t, opNone, p.pending)
+}
+
+func TestHandleGHDataLoaded_ConsumesPendingSelectPR(t *testing.T) {
+	p := newTestGitHubPanel(t, defaultMock())
+	p.activeTab = tabPRs
+	p.gh.prFilter = prFilterAll
+	p.gh.pendingSelectPR = 7
+
+	p.Update(ghDataLoadedMsg{prs: []ghPRItem{
+		{Number: 9, State: prStateOpen},
+		{Number: 7, State: prStateOpen},
+	}})
+
+	require.Len(t, p.tabItems[tabPRs], 2)
+	assert.Equal(t, 7, p.tabItems[tabPRs][p.tabCursor[tabPRs]].pr.Number, "cursor should land on the queued PR")
+	assert.Zero(t, p.gh.pendingSelectPR, "pendingSelectPR should be consumed")
+}
+
+func TestHandleMetaLoaded_StoresDefaultBranch(t *testing.T) {
+	p := newTestGitHubPanel(t, defaultMock())
+	p.Update(ghMetaLoadedMsg{user: "me", defaultBranch: "develop", repoPrivate: true})
+	assert.Equal(t, "develop", p.gh.defaultBranch)
+}
+
+func TestNKey_OnPRsTabStartsCreateFlow(t *testing.T) {
+	p := newGHPanelWithClient(t, defaultMock(), &mockGHClientFull{})
+	p.Focused = true
+	p.activeTab = tabPRs
+	p.gh.defaultBranch = "main"
+	p.gitData.lastBranches = pushedFeatureBranches()
+
+	_, cmd := p.Update(tea.KeyPressMsg{Code: 'n'})
+	require.NotNil(t, cmd, "'n' on the PRs tab should open the create-PR flow")
+	assert.Equal(t, opPRCreateHead, p.pending)
+	assert.Equal(t, "feature", p.prDraft.head)
 }


### PR DESCRIPTION
Closes #249

## What changed

Wires the existing `github.Client.CreatePR` into the GitHub panel so you can open a pull request without leaving grut.

Pressing `n` on the Pull Requests tab starts a multi-step form:

1. Head branch, prefilled with the current local branch (editable)
2. Base branch, prefilled with the repository default branch (editable)
3. Title, required
4. Body, optional

On submit the PR is created through `CreatePR`, the list refreshes, and the new PR is selected. The filter resets to All so the new PR is guaranteed visible, and it is inserted optimistically for instant feedback ahead of the server refresh.

## Guards

- No GitHub client: no-op.
- No current branch detected: warning notification, flow does not start.
- Current branch not pushed (no upstream and no matching remote branch): warning notification telling you to push first.
- Head equals base: rejected with a message.
- Empty title: rejected with a message.
- Escape cancels at any step and clears the in-progress draft.
- API failure: clear error notification, nothing inserted.

The current branch is read from the existing git client branch list, which carries local branches even while the panel is in GitHub mode. Base falls back to `main` when the default branch is unknown.

## Keybindings and docs

- Added the `n` binding to the github section of `internal/keybindings/keybindings.json`.
- Regenerated `docs/keybindings.md`. The help overlay reads the JSON directly.

## How tested

- `go build ./...` after every change, all clean.
- `go test ./...`: full suite passes, including 16 new tests in `internal/panels/gitinfo/gitinfo_test.go` covering prefill, default-branch fallback, the no-branch/unpushed/nil-client guards, empty-title and head-equals-base rejection, the full create-then-refresh flow with request-content assertions, empty-body omission, error propagation, cancel reset, pending-reselect consumption, and the `n` key entry point. Tests use the existing `mockGHClientFull`.
- `go vet ./...`: clean.
- `gofmt`: clean.

No new dependencies. Single panel touched (`internal/panels/gitinfo/`) plus the keybinding registry and generated docs.