### PR TITLE
Add GitHub notifications tab to the gitinfo panel

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -132,10 +132,12 @@ GitHub panel (panel 3).
 | `a` | Actions tab |
 | `w` | Workflows tab |
 | `l` | Releases tab |
+| `N` | Notifications tab |
+| `Enter` | Open notification in browser (Notifications tab) |
 | `o` | Open in browser |
 | `y` | Copy to clipboard |
-| `m` | Merge PR (PRs tab) |
-| `r` | Rerun (Actions tab) |
+| `m` | Merge PR (PRs tab) / Mark read (Notifications tab) |
+| `r` | Rerun (Actions tab) / Refresh (Notifications tab) |
 | `x` | Cancel (Actions tab) |
 | `D` | Dispatch workflow |
 

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -112,10 +112,12 @@
         { "key": "a", "action": "Actions tab" },
         { "key": "w", "action": "Workflows tab" },
         { "key": "l", "action": "Releases tab" },
+        { "key": "N", "action": "Notifications tab" },
+        { "key": "Enter", "action": "Open notification in browser (Notifications tab)" },
         { "key": "o", "action": "Open in browser" },
         { "key": "y", "action": "Copy to clipboard" },
-        { "key": "m", "action": "Merge PR (PRs tab)" },
-        { "key": "r", "action": "Rerun (Actions tab)" },
+        { "key": "m", "action": "Merge PR (PRs tab) / Mark read (Notifications tab)" },
+        { "key": "r", "action": "Rerun (Actions tab) / Refresh (Notifications tab)" },
         { "key": "x", "action": "Cancel (Actions tab)" },
         { "key": "D", "action": "Dispatch workflow" }
       ]

--- a/internal/panels/gitinfo/constants.go
+++ b/internal/panels/gitinfo/constants.go
@@ -27,6 +27,8 @@ const (
 	labelReflog    = "Reflog"
 	labelActions   = "Actions"
 	labelAll       = "All"
+
+	labelNotifications = "Notifications"
 )
 
 // Section names (lowercase, used in SetActiveTab and filter messages).
@@ -40,6 +42,8 @@ const (
 	sectionIssues    = "issues"
 	sectionPRs       = "prs"
 	sectionActions   = "actions"
+
+	sectionNotifications = "notifications"
 )
 
 // Git operation result keys used in opResultMsg.op.

--- a/internal/panels/gitinfo/gitinfo.go
+++ b/internal/panels/gitinfo/gitinfo.go
@@ -73,6 +73,7 @@ const (
 	kindTag                          // local tag
 	kindRemoteTag                    // remote-only tag
 	kindReflogEntry                  // reflog entry
+	kindNotification                 // GitHub notification thread
 )
 
 // PanelMode controls which subset of tabs a gitinfo panel displays.
@@ -99,24 +100,26 @@ const (
 	tabActions
 	tabWorkflows
 	tabReleases
+	tabNotifications
 	tabCount // sentinel for array sizing
 )
 
 // listItem represents a single row in a tab's item list.
 type listItem struct {
-	tag       git.Tag         // tag data (valid when kind == kindTag/kindRemoteTag)
-	reflog    git.ReflogEntry // reflog data (valid when kind == kindReflogEntry)
-	issue     ghIssueItem     // issue data (valid when kind == kindIssue)
-	release   ghReleaseItem   // release data (valid when kind == kindRelease)
-	actionRun ghActionItem    // action run data (valid when kind == kindActionRun)
-	pr        ghPRItem        // PR data (valid when kind == kindPR)
-	stash     git.StashEntry  // stash data (valid when kind == kindStashEntry)
-	branch    git.Branch      // branch data (valid when kind == kindLocalBranch/kindRemoteBranch)
-	workflow  ghWorkflowItem  // workflow definition (valid when kind == kindWorkflow)
-	remote    git.Remote      // remote data (valid when kind == kindRemote)
-	text      string          // display text for sub-items (kind == kindRemoteSub)
-	hash      string          // hash for clipboard copy (extracted for click targeting)
-	worktree  git.Worktree    // worktree data (valid when kind == kindWorktree)
+	tag       git.Tag            // tag data (valid when kind == kindTag/kindRemoteTag)
+	reflog    git.ReflogEntry    // reflog data (valid when kind == kindReflogEntry)
+	issue     ghIssueItem        // issue data (valid when kind == kindIssue)
+	release   ghReleaseItem      // release data (valid when kind == kindRelease)
+	actionRun ghActionItem       // action run data (valid when kind == kindActionRun)
+	pr        ghPRItem           // PR data (valid when kind == kindPR)
+	stash     git.StashEntry     // stash data (valid when kind == kindStashEntry)
+	branch    git.Branch         // branch data (valid when kind == kindLocalBranch/kindRemoteBranch)
+	workflow  ghWorkflowItem     // workflow definition (valid when kind == kindWorkflow)
+	remote    git.Remote         // remote data (valid when kind == kindRemote)
+	text      string             // display text for sub-items (kind == kindRemoteSub)
+	hash      string             // hash for clipboard copy (extracted for click targeting)
+	worktree  git.Worktree       // worktree data (valid when kind == kindWorktree)
+	notif     ghNotificationItem // notification data (valid when kind == kindNotification)
 	kind      itemKind
 }
 
@@ -294,18 +297,20 @@ type gitState struct {
 // githubState holds all GitHub-related integration state: API client,
 // repository metadata, and cached issue / PR data.
 type githubState struct {
-	client      ghclient.Client
-	err         error
-	owner       string
-	repo        string
-	user        string
-	allIssues   []ghIssueItem
-	allPRs      []ghPRItem
-	cfg         config.GitHubConfig
-	issueFilter IssueFilterKind
-	prFilter    PRFilterKind
-	repoPrivate bool
-	pageSize    int
+	client       ghclient.Client
+	err          error
+	owner        string
+	repo         string
+	user         string
+	allIssues    []ghIssueItem
+	allPRs       []ghPRItem
+	cfg          config.GitHubConfig
+	issueFilter  IssueFilterKind
+	prFilter     PRFilterKind
+	repoPrivate  bool
+	pageSize     int
+	notifLoading bool  // true while notifications are being fetched
+	notifErr     error // last notification load error, if any
 }
 
 // ---------------------------------------------------------------------------
@@ -362,12 +367,12 @@ func (p *Panel) visibleTabs() []tabID {
 	case ModeGit:
 		return []tabID{tabBranches, tabWorktrees, tabRemotes, tabStash, tabTags, tabReflog}
 	case ModeGitHub:
-		return []tabID{tabBranches, tabTags, tabIssues, tabPRs, tabActions, tabWorkflows, tabReleases}
+		return []tabID{tabBranches, tabTags, tabIssues, tabPRs, tabActions, tabWorkflows, tabReleases, tabNotifications}
 	default: // ModeAll
 		if isGitTab(p.activeTab) {
 			return []tabID{tabBranches, tabWorktrees, tabRemotes, tabStash, tabTags, tabReflog}
 		}
-		return []tabID{tabBranches, tabTags, tabIssues, tabPRs, tabActions, tabWorkflows, tabReleases}
+		return []tabID{tabBranches, tabTags, tabIssues, tabPRs, tabActions, tabWorkflows, tabReleases, tabNotifications}
 	}
 }
 
@@ -413,6 +418,8 @@ func (p *Panel) SetActiveTab(name string) {
 		p.activeTab = tabWorkflows
 	case "releases":
 		p.activeTab = tabReleases
+	case sectionNotifications:
+		p.activeTab = tabNotifications
 	}
 }
 
@@ -512,6 +519,8 @@ func (p *Panel) startGitHubLoad() tea.Cmd {
 		for _, tab := range []tabID{tabIssues, tabPRs, tabActions, tabWorkflows, tabReleases} {
 			p.tabPaging[tab] = tabPagination{loading: true, nextPage: 1}
 		}
+		p.gh.notifLoading = true
+		p.gh.notifErr = nil
 		cmds = append(
 			cmds,
 			p.loadGitHubMeta(),
@@ -520,6 +529,7 @@ func (p *Panel) startGitHubLoad() tea.Cmd {
 			p.loadActionsPage(1, true),
 			p.loadWorkflowsPage(1, true),
 			p.loadReleasesPage(1, true),
+			p.loadNotifications(),
 			p.githubPollTickCmd(),
 		)
 	}
@@ -556,6 +566,8 @@ func (p *Panel) handleRepoChanged(msg panels.RepoChangedMsg) (panels.Panel, tea.
 	p.gh.err = nil
 	p.gh.allIssues = nil
 	p.gh.allPRs = nil
+	p.gh.notifErr = nil
+	p.gh.notifLoading = false
 	p.actionsWatching = false
 	p.actionsWatchFrame = 0
 	p.gh.repoPrivate = false
@@ -676,6 +688,10 @@ func (p *Panel) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 		return p.handleWorkflowsPage(msg)
 	case ghReleasesPageMsg:
 		return p.handleReleasesPage(msg)
+	case ghNotificationsLoadedMsg:
+		return p.handleNotificationsLoaded(msg)
+	case notificationReadResultMsg:
+		return p.handleNotificationReadResult(msg)
 	case githubPollTickMsg:
 		// Reset pagination state for fresh page-1 loads.
 		for _, tab := range []tabID{tabIssues, tabPRs, tabActions, tabWorkflows, tabReleases} {
@@ -688,6 +704,7 @@ func (p *Panel) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 			p.loadActionsPage(1, true),
 			p.loadWorkflowsPage(1, true),
 			p.loadReleasesPage(1, true),
+			p.loadNotifications(),
 			p.githubPollTickCmd(),
 		)
 	case actionsWatchTickMsg:
@@ -791,7 +808,14 @@ func (p *Panel) View(width, height int) string {
 	items := p.tabItems[p.activeTab]
 	if len(items) == 0 {
 		label := "No items"
-		if p.activeTab >= tabIssues && p.gh.err != nil {
+		switch {
+		case p.activeTab == tabNotifications && p.gh.notifErr != nil:
+			label = "Notifications unavailable"
+		case p.activeTab == tabNotifications && p.gh.notifLoading:
+			label = "Loading..."
+		case p.activeTab == tabNotifications:
+			label = "No unread notifications"
+		case p.activeTab >= tabIssues && p.gh.err != nil:
 			label = "GitHub unavailable"
 		}
 		empty := lipgloss.NewStyle().
@@ -874,6 +898,8 @@ func (p *Panel) KeyBindings() []panels.KeyBinding {
 			panels.KeyBinding{Key: "a", Description: "Actions tab", Action: "tab_actions"},
 			panels.KeyBinding{Key: "W", Description: "Workflows tab", Action: "tab_workflows"},
 			panels.KeyBinding{Key: "L", Description: "Releases tab", Action: "tab_releases"},
+			panels.KeyBinding{Key: "N", Description: "Notifications tab", Action: "tab_notifications"},
+			panels.KeyBinding{Key: "m", Description: "Merge PR / Mark notification read", Action: "notification_mark_read"},
 		)
 	}
 	return bindings
@@ -1078,6 +1104,9 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		if p.activeTab == tabActions && p.gh.client != nil {
 			return p.doActionsRerun()
 		}
+		if p.activeTab == tabNotifications && p.gh.client != nil {
+			return p.doRefreshNotifications()
+		}
 		if p.mode != ModeGitHub {
 			p.activeTab = tabRemotes
 			return p, p.activeTabSelectionCmd()
@@ -1117,6 +1146,11 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 			p.activeTab = tabActions
 			return p, p.activeTabSelectionCmd()
 		}
+	case "N":
+		if p.mode != ModeGit && p.gh.client != nil {
+			p.activeTab = tabNotifications
+			return p, p.activeTabSelectionCmd()
+		}
 	case "D":
 		if p.activeTab == tabWorkflows && p.gh.client != nil {
 			return p.doWorkflowDispatch()
@@ -1124,6 +1158,9 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 	case "m":
 		if p.activeTab == tabPRs && p.gh.client != nil {
 			return p.doMergePR()
+		}
+		if p.activeTab == tabNotifications && p.gh.client != nil {
+			return p.doMarkNotificationRead()
 		}
 	case "pgdown":
 		p.pageDown()
@@ -1148,6 +1185,9 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 	case "enter":
 		if p.activeTab == tabReflog {
 			return p.doReflogCheckout()
+		}
+		if p.activeTab == tabNotifications {
+			return p.doOpenInBrowser()
 		}
 		return p.doAction()
 	case "f":
@@ -1202,7 +1242,7 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 				func() tea.Msg { return panels.ActionRunDeselectedMsg{} },
 				p.activeTabSelectionCmd(),
 			)
-		case tabWorkflows, tabReleases:
+		case tabWorkflows, tabReleases, tabNotifications:
 			p.activeTab = defaultTab
 			return p, p.activeTabSelectionCmd()
 		case tabBranches, tabTags:
@@ -1334,6 +1374,8 @@ func (p *Panel) rightClickLabel(item listItem) string {
 		return panels.StripANSI(item.release.TagName) + " " + panels.StripANSI(item.release.Name)
 	case kindTag, kindRemoteTag:
 		return panels.StripANSI(item.tag.Name)
+	case kindNotification:
+		return panels.StripANSI(item.notif.Title)
 	default:
 		return panels.StripANSI(item.text)
 	}
@@ -2025,6 +2067,12 @@ func (p *Panel) doOpenInBrowser() (panels.Panel, tea.Cmd) {
 			url = raw + "/releases/tag/" + item.tag.Name
 			label = "tag " + item.tag.Name
 		}
+	case kindNotification:
+		url = item.notif.HTMLURL
+		label = "notification"
+		if item.notif.Title != "" {
+			label = panels.StripANSI(item.notif.Title)
+		}
 	}
 	if url == "" {
 		return p, func() tea.Msg {
@@ -2288,6 +2336,8 @@ func (p *Panel) renderLine(item listItem, width int, isCursor bool) string {
 		return p.renderTag(item, width, isCursor)
 	case kindReflogEntry:
 		return p.renderReflogEntry(item, width, isCursor)
+	case kindNotification:
+		return p.renderNotification(item, width, isCursor)
 	}
 	return ""
 }
@@ -2371,6 +2421,7 @@ func (p *Panel) renderTabBar(width int) string {
 		{id: tabActions, name: labelActions, short: shortAct, count: actionsCount},
 		{id: tabWorkflows, name: "Workflows", short: "Wf", count: p.ghTabCountStr(tabWorkflows)},
 		{id: tabReleases, name: "Releases", short: "Rel", count: p.ghTabCountStr(tabReleases)},
+		{id: tabNotifications, name: labelNotifications, short: "Ntf", count: p.ghNotifCountStr()},
 	}
 	// In ModeGitHub, prepend Branches and Tags to the GitHub tab row.
 	if p.mode == ModeGitHub {

--- a/internal/panels/gitinfo/gitinfo_github.go
+++ b/internal/panels/gitinfo/gitinfo_github.go
@@ -333,6 +333,7 @@ func (p *Panel) handleGitHubTabBarClick(col int) {
 		tabEntry{id: tabActions, name: labelActions, short: shortAct, count: p.actionsStatusIcon()},
 		tabEntry{id: tabWorkflows, name: "Workflows", short: "Wf", count: fmt.Sprintf("%d", len(p.tabItems[tabWorkflows]))},
 		tabEntry{id: tabReleases, name: "Releases", short: "Rel", count: fmt.Sprintf("%d", len(p.tabItems[tabReleases]))},
+		tabEntry{id: tabNotifications, name: labelNotifications, short: "Ntf", count: p.ghNotifCountStr()},
 	)
 	// Determine whether abbreviations are active (same logic as renderRow).
 	plain := make([]struct{ name, short, count string }, len(tabs))

--- a/internal/panels/gitinfo/gitinfo_notifications.go
+++ b/internal/panels/gitinfo/gitinfo_notifications.go
@@ -1,0 +1,285 @@
+// GitHub notifications: browse your notification threads, open them in the
+// browser, and mark them read. Reuses the github client's ListNotifications
+// and MarkRead. Notifications are account-wide, so unlike issues/PRs/etc they
+// load all pages at once and do not use the cursor-based pagination machinery.
+package gitinfo
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	gh "github.com/google/go-github/v88/github"
+	"github.com/jongio/grut/internal/notify"
+	"github.com/jongio/grut/internal/panels"
+)
+
+// ghNotificationItem holds display data for a single GitHub notification thread.
+type ghNotificationItem struct {
+	ThreadID     string // notification thread ID (used by MarkRead)
+	RepoFullName string // "owner/repo"
+	Title        string // subject title
+	Type         string // subject type: "Issue", "PullRequest", "Release", ...
+	Reason       string // notification reason: "mention", "review_requested", ...
+	UpdatedAt    string // formatted update time
+	HTMLURL      string // browsable GitHub web URL
+	Unread       bool   // true when the thread is still unread
+}
+
+// ghNotificationsLoadedMsg carries the result of an async notifications load.
+type ghNotificationsLoadedMsg struct {
+	err           error
+	notifications []ghNotificationItem
+}
+
+// notificationReadResultMsg carries the result of a mark-read operation.
+type notificationReadResultMsg struct {
+	threadID string
+	err      error
+}
+
+// loadNotifications fetches unread notifications asynchronously.
+func (p *Panel) loadNotifications() tea.Cmd {
+	client := p.gh.client
+	if client == nil {
+		return nil
+	}
+	ctx := p.ctx
+	return func() tea.Msg {
+		var result ghNotificationsLoadedMsg
+		notifs, err := client.ListNotifications(ctx, &gh.NotificationListOptions{All: false})
+		if err != nil {
+			slog.Warn("github: fetch notifications failed", "err", err)
+			result.err = err
+			return result
+		}
+		for _, n := range notifs {
+			subj := n.GetSubject()
+			repo := n.GetRepository().GetFullName()
+			result.notifications = append(result.notifications, ghNotificationItem{
+				ThreadID:     n.GetID(),
+				RepoFullName: repo,
+				Title:        subj.GetTitle(),
+				Type:         subj.GetType(),
+				Reason:       n.GetReason(),
+				UpdatedAt:    n.GetUpdatedAt().Format("Jan 2 15:04"),
+				HTMLURL:      notificationHTMLURL(subj.GetURL(), repo),
+				Unread:       n.GetUnread(),
+			})
+		}
+		return result
+	}
+}
+
+// handleNotificationsLoaded stores loaded notifications into the tab.
+func (p *Panel) handleNotificationsLoaded(msg ghNotificationsLoadedMsg) (panels.Panel, tea.Cmd) {
+	p.gh.notifLoading = false
+	if msg.err != nil {
+		p.gh.notifErr = msg.err
+		p.tabItems[tabNotifications] = nil
+		p.tabCursor[tabNotifications] = 0
+		p.tabOffset[tabNotifications] = 0
+		return p, nil
+	}
+	p.gh.notifErr = nil
+	p.buildNotificationItems(msg.notifications)
+	return p, nil
+}
+
+// buildNotificationItems constructs the listItem slice for the notifications tab.
+func (p *Panel) buildNotificationItems(notifs []ghNotificationItem) {
+	p.tabItems[tabNotifications] = nil
+	for _, n := range notifs {
+		p.tabItems[tabNotifications] = append(p.tabItems[tabNotifications], listItem{
+			kind:  kindNotification,
+			notif: n,
+		})
+	}
+	p.clampNotificationCursor()
+}
+
+// clampNotificationCursor keeps the notifications cursor and viewport offset
+// within the bounds of the current item list.
+func (p *Panel) clampNotificationCursor() {
+	items := p.tabItems[tabNotifications]
+	if p.tabCursor[tabNotifications] >= len(items) {
+		p.tabCursor[tabNotifications] = len(items) - 1
+	}
+	if p.tabCursor[tabNotifications] < 0 {
+		p.tabCursor[tabNotifications] = 0
+	}
+	if p.tabOffset[tabNotifications] > p.tabCursor[tabNotifications] {
+		p.tabOffset[tabNotifications] = p.tabCursor[tabNotifications]
+	}
+	if p.tabOffset[tabNotifications] < 0 {
+		p.tabOffset[tabNotifications] = 0
+	}
+}
+
+// doRefreshNotifications reloads the notifications list from the API.
+func (p *Panel) doRefreshNotifications() (panels.Panel, tea.Cmd) {
+	if p.gh.client == nil {
+		return p, nil
+	}
+	p.gh.notifLoading = true
+	p.gh.notifErr = nil
+	return p, p.loadNotifications()
+}
+
+// doMarkNotificationRead marks the selected notification thread as read.
+func (p *Panel) doMarkNotificationRead() (panels.Panel, tea.Cmd) {
+	items := p.tabItems[tabNotifications]
+	cursor := p.tabCursor[tabNotifications]
+	if cursor < 0 || cursor >= len(items) {
+		return p, nil
+	}
+	item := items[cursor]
+	if item.kind != kindNotification || item.notif.ThreadID == "" {
+		return p, nil
+	}
+	return p, p.markNotificationReadCmd(item.notif.ThreadID)
+}
+
+// markNotificationReadCmd returns a command that marks the given thread read.
+func (p *Panel) markNotificationReadCmd(threadID string) tea.Cmd {
+	client := p.gh.client
+	if client == nil {
+		return nil
+	}
+	ctx := p.ctx
+	return func() tea.Msg {
+		err := client.MarkRead(ctx, threadID)
+		return notificationReadResultMsg{threadID: threadID, err: err}
+	}
+}
+
+// handleNotificationReadResult updates the row after a mark-read operation.
+func (p *Panel) handleNotificationReadResult(msg notificationReadResultMsg) (panels.Panel, tea.Cmd) {
+	if msg.err != nil {
+		errText := msg.err.Error()
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{Message: "Mark read failed: " + errText, Level: notify.Error}
+		}
+	}
+	p.markNotificationReadLocally(msg.threadID)
+	return p, func() tea.Msg {
+		return notify.ShowToastMsg{Message: "Marked notification read", Level: notify.Success}
+	}
+}
+
+// markNotificationReadLocally greys the matching row by clearing its unread
+// flag. Returns true when a matching thread was found.
+func (p *Panel) markNotificationReadLocally(threadID string) bool {
+	items := p.tabItems[tabNotifications]
+	for i := range items {
+		if items[i].kind == kindNotification && items[i].notif.ThreadID == threadID {
+			items[i].notif.Unread = false
+			return true
+		}
+	}
+	return false
+}
+
+// ghNotifCountStr returns the unread notification count for the tab bar.
+func (p *Panel) ghNotifCountStr() string {
+	unread := 0
+	for _, it := range p.tabItems[tabNotifications] {
+		if it.kind == kindNotification && it.notif.Unread {
+			unread++
+		}
+	}
+	return fmt.Sprintf("%d", unread)
+}
+
+// notificationHTMLURL converts a notification subject API URL into a browsable
+// GitHub web URL. The subject URL is an api.github.com REST URL (e.g.
+// ".../repos/o/r/issues/1" or ".../repos/o/r/pulls/1"); the paths for pulls and
+// commits differ on the web. Types without a clean web mapping (releases,
+// discussions, check suites) fall back to the repository page.
+func notificationHTMLURL(apiURL, repoFullName string) string {
+	repoURL := ""
+	if repoFullName != "" {
+		repoURL = "https://github.com/" + repoFullName
+	}
+	const apiPrefix = "https://api.github.com/repos/"
+	if !strings.HasPrefix(apiURL, apiPrefix) {
+		return repoURL
+	}
+	rest := strings.TrimPrefix(apiURL, apiPrefix) // "o/r/issues/1"
+	switch {
+	case strings.Contains(rest, "/issues/"):
+		return "https://github.com/" + rest
+	case strings.Contains(rest, "/pulls/"):
+		return "https://github.com/" + strings.Replace(rest, "/pulls/", "/pull/", 1)
+	case strings.Contains(rest, "/commits/"):
+		return "https://github.com/" + strings.Replace(rest, "/commits/", "/commit/", 1)
+	default:
+		return repoURL
+	}
+}
+
+// renderNotification renders a notification row:
+// "  ● owner/repo  Subject title       PullRequest · review_requested  Jan 2 15:04"
+// Read threads are greyed with a hollow marker.
+func (p *Panel) renderNotification(item listItem, width int, isCursor bool) string {
+	n := item.notif
+	prefix := "  "
+	var icon, fg string
+	if n.Unread {
+		icon = runDot
+		fg = p.colors.Issue
+	} else {
+		icon = "○"
+		fg = p.colors.Dim
+	}
+	left := icon
+	if n.RepoFullName != "" {
+		left += " " + panels.StripANSI(n.RepoFullName)
+	}
+	if n.Title != "" {
+		left += "  " + panels.StripANSI(n.Title)
+	}
+	// Right side: "Type · reason" plus the update time.
+	meta := n.Type
+	if n.Reason != "" {
+		if meta != "" {
+			meta += " · " + n.Reason
+		} else {
+			meta = n.Reason
+		}
+	}
+	rightSide := ""
+	if meta != "" {
+		rightSide += " " + meta
+	}
+	if n.UpdatedAt != "" {
+		rightSide += "  " + n.UpdatedAt
+	}
+	maxLeft := width - lipgloss.Width(prefix) - lipgloss.Width(rightSide) - 1
+	leftRunes := []rune(left)
+	if maxLeft > 0 && len(leftRunes) > maxLeft {
+		if maxLeft > 1 {
+			left = string(leftRunes[:maxLeft-1]) + "…"
+		} else {
+			left = string(leftRunes[:maxLeft])
+		}
+	} else if maxLeft <= 0 {
+		left = ""
+	}
+	leftSide := prefix + left
+	usedWidth := lipgloss.Width(leftSide) + lipgloss.Width(rightSide)
+	gap := ""
+	if usedWidth < width {
+		gap = strings.Repeat(" ", width-usedWidth)
+	}
+	line := leftSide + gap + rightSide
+	style := lipgloss.NewStyle().Width(width).MaxWidth(width).
+		Foreground(lipgloss.Color(fg))
+	if isCursor {
+		style = style.Background(lipgloss.Color(p.colors.CursorBg))
+	}
+	return style.Render(line)
+}

--- a/internal/panels/gitinfo/gitinfo_test.go
+++ b/internal/panels/gitinfo/gitinfo_test.go
@@ -2615,6 +2615,7 @@ func (m *mockGHClientFull) MarkRead(_ context.Context, threadID string) error {
 	m.markReadID = threadID
 	return m.markReadErr
 }
+
 func (m *mockGHClientFull) RepoInfo(_ context.Context, _, _ string) (*gh.Repository, error) {
 	return nil, nil
 }

--- a/internal/panels/gitinfo/gitinfo_test.go
+++ b/internal/panels/gitinfo/gitinfo_test.go
@@ -2492,6 +2492,12 @@ type mockGHClientFull struct {
 	cancelErr  error
 	mergeErr   error
 	getPRCalls int
+
+	notifications []*gh.Notification
+	notifErr      error
+	markReadErr   error
+	markReadCalls int
+	markReadID    string
 }
 
 func (m *mockGHClientFull) CurrentUser(_ context.Context) (*gh.User, error) {
@@ -2601,9 +2607,14 @@ func (m *mockGHClientFull) CancelWorkflowRun(_ context.Context, _, _ string, _ i
 }
 
 func (m *mockGHClientFull) ListNotifications(_ context.Context, _ *gh.NotificationListOptions) ([]*gh.Notification, error) {
-	return nil, nil
+	return m.notifications, m.notifErr
 }
-func (m *mockGHClientFull) MarkRead(_ context.Context, _ string) error { return nil }
+
+func (m *mockGHClientFull) MarkRead(_ context.Context, threadID string) error {
+	m.markReadCalls++
+	m.markReadID = threadID
+	return m.markReadErr
+}
 func (m *mockGHClientFull) RepoInfo(_ context.Context, _, _ string) (*gh.Repository, error) {
 	return nil, nil
 }
@@ -3244,7 +3255,7 @@ func TestRenderTabBar_WithGHClient(t *testing.T) {
 	p := newGHPanelWithClient(t, defaultMock(), ghMock)
 	populateGH(p, sampleIssues(), samplePRs(), sampleActions())
 
-	bar := panels.StripANSI(p.renderTabBar(80))
+	bar := panels.StripANSI(p.renderTabBar(120))
 	assert.Contains(t, bar, "Issues")
 	assert.Contains(t, bar, "PRs")
 	assert.Contains(t, bar, "Actions")
@@ -3369,7 +3380,7 @@ func TestView_WithGHClient(t *testing.T) {
 	p := newGHPanelWithClient(t, defaultMock(), ghMock)
 	populateGH(p, sampleIssues(), samplePRs(), sampleActions())
 
-	view := panels.StripANSI(p.View(80, 20))
+	view := panels.StripANSI(p.View(120, 20))
 	assert.Contains(t, view, "Issues")
 	assert.Contains(t, view, "Bug report")
 }
@@ -3809,7 +3820,7 @@ func TestTabCyclesGitHubTabs(t *testing.T) {
 	// ModeGitHub starts on tabIssues (set by NewGitHub).
 	assert.Equal(t, tabIssues, p.activeTab)
 
-	expected := []tabID{tabPRs, tabActions, tabWorkflows, tabReleases, tabBranches, tabTags, tabIssues}
+	expected := []tabID{tabPRs, tabActions, tabWorkflows, tabReleases, tabNotifications, tabBranches, tabTags, tabIssues}
 	for _, want := range expected {
 		p.Update(tea.KeyPressMsg{Code: '\t'})
 		assert.Equal(t, want, p.activeTab, "expected tab %d after pressing Tab", want)
@@ -3821,7 +3832,7 @@ func TestShiftTabCyclesGitHubTabsBackward(t *testing.T) {
 	p.Focused = true
 	assert.Equal(t, tabIssues, p.activeTab)
 
-	expected := []tabID{tabTags, tabBranches, tabReleases, tabWorkflows, tabActions, tabPRs, tabIssues}
+	expected := []tabID{tabTags, tabBranches, tabNotifications, tabReleases, tabWorkflows, tabActions, tabPRs, tabIssues}
 	for _, want := range expected {
 		p.Update(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
 		assert.Equal(t, want, p.activeTab, "expected tab %d after pressing Shift+Tab", want)
@@ -3845,7 +3856,7 @@ func TestVisibleTabsGitMode(t *testing.T) {
 func TestVisibleTabsGitHubMode(t *testing.T) {
 	p := newTestGitHubPanel(t, defaultMock())
 	tabs := p.visibleTabs()
-	assert.Equal(t, []tabID{tabBranches, tabTags, tabIssues, tabPRs, tabActions, tabWorkflows, tabReleases}, tabs)
+	assert.Equal(t, []tabID{tabBranches, tabTags, tabIssues, tabPRs, tabActions, tabWorkflows, tabReleases, tabNotifications}, tabs)
 }
 
 // ---------------------------------------------------------------------------
@@ -4835,4 +4846,229 @@ func TestRightClickLabel_ANSIInjection(t *testing.T) {
 			assert.Contains(t, label, tt.want)
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// GitHub notifications
+// ---------------------------------------------------------------------------
+
+func ghNotif(id, repo, title, typ, reason, apiURL string, unread bool) *gh.Notification {
+	return &gh.Notification{
+		ID:         &id,
+		Reason:     &reason,
+		Unread:     &unread,
+		UpdatedAt:  &gh.Timestamp{Time: time.Date(2024, time.January, 2, 15, 4, 0, 0, time.UTC)},
+		Repository: &gh.Repository{FullName: &repo},
+		Subject:    &gh.NotificationSubject{Title: &title, Type: &typ, URL: &apiURL},
+	}
+}
+
+func TestNotificationHTMLURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		apiURL string
+		repo   string
+		want   string
+	}{
+		{"issue", "https://api.github.com/repos/o/r/issues/1", "o/r", "https://github.com/o/r/issues/1"},
+		{"pull maps to pull", "https://api.github.com/repos/o/r/pulls/9", "o/r", "https://github.com/o/r/pull/9"},
+		{"commit maps to commit", "https://api.github.com/repos/o/r/commits/abc123", "o/r", "https://github.com/o/r/commit/abc123"},
+		{"release falls back to repo", "https://api.github.com/repos/o/r/releases/5", "o/r", "https://github.com/o/r"},
+		{"empty falls back to repo", "", "o/r", "https://github.com/o/r"},
+		{"non-api falls back to repo", "https://example.com/x", "o/r", "https://github.com/o/r"},
+		{"no repo no url", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, notificationHTMLURL(tt.apiURL, tt.repo))
+		})
+	}
+}
+
+func TestLoadNotifications_BuildsItems(t *testing.T) {
+	ghMock := &mockGHClientFull{
+		notifications: []*gh.Notification{
+			ghNotif("1", "octo/repo", "Fix the bug", "Issue", "mention", "https://api.github.com/repos/octo/repo/issues/7", true),
+			ghNotif("2", "octo/repo", "Add feature", "PullRequest", "review_requested", "https://api.github.com/repos/octo/repo/pulls/8", true),
+		},
+	}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+
+	msg := p.loadNotifications()()
+	loaded, ok := msg.(ghNotificationsLoadedMsg)
+	require.True(t, ok, "expected ghNotificationsLoadedMsg, got %T", msg)
+	require.NoError(t, loaded.err)
+	p.handleNotificationsLoaded(loaded)
+
+	items := p.tabItems[tabNotifications]
+	require.Len(t, items, 2)
+	assert.Equal(t, kindNotification, items[0].kind)
+	assert.Equal(t, "octo/repo", items[0].notif.RepoFullName)
+	assert.Equal(t, "Fix the bug", items[0].notif.Title)
+	assert.Equal(t, "Issue", items[0].notif.Type)
+	assert.Equal(t, "mention", items[0].notif.Reason)
+	assert.Equal(t, "https://github.com/octo/repo/issues/7", items[0].notif.HTMLURL)
+	assert.True(t, items[0].notif.Unread)
+	assert.Equal(t, "https://github.com/octo/repo/pull/8", items[1].notif.HTMLURL)
+	assert.False(t, p.gh.notifLoading)
+	assert.NoError(t, p.gh.notifErr)
+}
+
+func TestHandleNotificationsLoaded_Error(t *testing.T) {
+	p := newGHPanelWithClient(t, defaultMock(), &mockGHClientFull{})
+	p.buildNotificationItems([]ghNotificationItem{{ThreadID: "x", Unread: true}})
+	require.Len(t, p.tabItems[tabNotifications], 1)
+
+	p.handleNotificationsLoaded(ghNotificationsLoadedMsg{err: fmt.Errorf("boom")})
+	assert.Error(t, p.gh.notifErr)
+	assert.Empty(t, p.tabItems[tabNotifications])
+	assert.False(t, p.gh.notifLoading)
+}
+
+func TestMarkNotificationRead_StateChange(t *testing.T) {
+	ghMock := &mockGHClientFull{
+		notifications: []*gh.Notification{
+			ghNotif("thread-1", "octo/repo", "Fix the bug", "Issue", "mention", "https://api.github.com/repos/octo/repo/issues/7", true),
+		},
+	}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+	loaded := p.loadNotifications()().(ghNotificationsLoadedMsg)
+	p.handleNotificationsLoaded(loaded)
+	p.activeTab = tabNotifications
+	p.tabCursor[tabNotifications] = 0
+
+	_, cmd := p.doMarkNotificationRead()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	result, ok := msg.(notificationReadResultMsg)
+	require.True(t, ok, "expected notificationReadResultMsg, got %T", msg)
+	require.NoError(t, result.err)
+	assert.Equal(t, 1, ghMock.markReadCalls)
+	assert.Equal(t, "thread-1", ghMock.markReadID)
+
+	// Handling the result greys the row (Unread=false).
+	assert.True(t, p.tabItems[tabNotifications][0].notif.Unread)
+	p.handleNotificationReadResult(result)
+	assert.False(t, p.tabItems[tabNotifications][0].notif.Unread, "row should be marked read")
+}
+
+func TestMarkNotificationRead_Error(t *testing.T) {
+	ghMock := &mockGHClientFull{
+		notifications: []*gh.Notification{
+			ghNotif("t1", "octo/repo", "Bug", "Issue", "mention", "", true),
+		},
+		markReadErr: fmt.Errorf("network down"),
+	}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+	p.handleNotificationsLoaded(p.loadNotifications()().(ghNotificationsLoadedMsg))
+	p.activeTab = tabNotifications
+
+	_, cmd := p.doMarkNotificationRead()
+	require.NotNil(t, cmd)
+	result := cmd().(notificationReadResultMsg)
+	require.Error(t, result.err)
+
+	// On error the row stays unread.
+	p.handleNotificationReadResult(result)
+	assert.True(t, p.tabItems[tabNotifications][0].notif.Unread, "row should stay unread on error")
+}
+
+func TestClampNotificationCursor(t *testing.T) {
+	p := newGHPanelWithClient(t, defaultMock(), &mockGHClientFull{})
+
+	// Cursor beyond the list is clamped to the last item.
+	p.tabCursor[tabNotifications] = 99
+	p.buildNotificationItems([]ghNotificationItem{
+		{ThreadID: "a", Unread: true},
+		{ThreadID: "b", Unread: true},
+	})
+	assert.Equal(t, 1, p.tabCursor[tabNotifications])
+
+	// Empty list clamps to 0 rather than a negative index.
+	p.tabCursor[tabNotifications] = 5
+	p.buildNotificationItems(nil)
+	assert.Equal(t, 0, p.tabCursor[tabNotifications])
+}
+
+func TestRenderNotification_Content(t *testing.T) {
+	p := newTestGitHubPanel(t, defaultMock())
+	item := listItem{kind: kindNotification, notif: ghNotificationItem{
+		RepoFullName: "octo/repo", Title: "Fix the bug", Type: "Issue",
+		Reason: "mention", UpdatedAt: "Jan 2 15:04", Unread: true,
+	}}
+	line := p.renderNotification(item, 120, false)
+	assert.Contains(t, line, "octo/repo")
+	assert.Contains(t, line, "Fix the bug")
+	assert.Contains(t, line, "Issue")
+	assert.Contains(t, line, "mention")
+	assert.Contains(t, line, "Jan 2 15:04")
+	assert.Contains(t, line, "●", "unread notifications use a filled marker")
+}
+
+func TestRenderNotification_ReadMarker(t *testing.T) {
+	p := newTestGitHubPanel(t, defaultMock())
+	item := listItem{kind: kindNotification, notif: ghNotificationItem{
+		RepoFullName: "octo/repo", Title: "Done", Unread: false,
+	}}
+	line := p.renderNotification(item, 120, false)
+	assert.Contains(t, line, "○", "read notifications use a hollow marker")
+}
+
+func TestRenderLine_Notification(t *testing.T) {
+	p := newTestGitHubPanel(t, defaultMock())
+	item := listItem{kind: kindNotification, notif: ghNotificationItem{
+		RepoFullName: "o/r", Title: "Hi", Unread: true,
+	}}
+	line := p.renderLine(item, 120, false)
+	assert.Contains(t, line, "o/r")
+	assert.Contains(t, line, "Hi")
+}
+
+func TestNotificationsView_EmptyLoadingAndError(t *testing.T) {
+	p := newTestGitHubPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabNotifications
+	p.tabItems[tabNotifications] = nil
+
+	// Empty state.
+	p.gh.notifLoading = false
+	p.gh.notifErr = nil
+	assert.Contains(t, p.View(80, 10), "No unread notifications")
+
+	// Error state.
+	p.gh.notifErr = fmt.Errorf("nope")
+	assert.Contains(t, p.View(80, 10), "Notifications unavailable")
+
+	// Loading state.
+	p.gh.notifErr = nil
+	p.gh.notifLoading = true
+	assert.Contains(t, p.View(80, 10), "Loading...")
+}
+
+func TestKeyBindings_IncludesNotifications(t *testing.T) {
+	p := newGHPanelWithClient(t, defaultMock(), &mockGHClientFull{})
+	found := false
+	for _, b := range p.KeyBindings() {
+		if b.Action == "tab_notifications" {
+			found = true
+		}
+	}
+	assert.True(t, found, "KeyBindings should include tab_notifications when a GitHub client is present")
+}
+
+func TestKeyTabSwitch_N(t *testing.T) {
+	p := newGHPanelWithClient(t, defaultMock(), &mockGHClientFull{})
+	p.Focused = true
+	p.Update(tea.KeyPressMsg{Code: -1, Text: "N"})
+	assert.Equal(t, tabNotifications, p.activeTab)
+}
+
+func TestGhNotifCountStr_CountsUnread(t *testing.T) {
+	p := newGHPanelWithClient(t, defaultMock(), &mockGHClientFull{})
+	p.buildNotificationItems([]ghNotificationItem{
+		{ThreadID: "a", Unread: true},
+		{ThreadID: "b", Unread: false},
+		{ThreadID: "c", Unread: true},
+	})
+	assert.Equal(t, "2", p.ghNotifCountStr())
 }


### PR DESCRIPTION
Closes #250

## What changed

Adds a **Notifications** tab to the GitHub panel (`internal/panels/gitinfo/`). It wires the existing `ListNotifications` and `MarkRead` github client methods into the UI (the API side was already implemented, this is the UI wiring).

The tab lists unread notification threads showing repo, subject title, type, reason, and updated time.

Keys (GitHub panel):
- `N` switches to the Notifications tab
- `Enter` / `o` opens the selected thread in the browser
- `m` marks the thread read and greys the row
- `r` refreshes the list
- `esc` returns to the default tab

Empty, loading, and error states are handled ("No unread notifications", "Loading...", "Notifications unavailable").

Notifications are account-wide, so they load all pages at once and skip the cursor pagination used by issues and PRs. This keeps the feature self-contained and follows the same special-casing the reflog tab uses.

Row markers use clean Unicode colored through lipgloss: a filled dot for unread, a hollow ring for read. No emoji.

The subject API URL is converted to a browsable github.com URL (issues, pulls, and commits map correctly; other types fall back to the repo page).

## Files

- `internal/panels/gitinfo/gitinfo_notifications.go` (new): struct, messages, load / mark-read commands and handlers, URL helper, render function, count helper.
- `internal/panels/gitinfo/gitinfo.go`: tab and item kind, render dispatch, key handling, load wiring, poll tick, empty/loading/error view, tab bar entry, KeyBindings.
- `internal/panels/gitinfo/gitinfo_github.go`: tab bar click zone entry.
- `internal/panels/gitinfo/constants.go`: section and label constants.
- `internal/keybindings/keybindings.json` and `docs/keybindings.md`: new key documentation (regenerated).
- `internal/panels/gitinfo/gitinfo_test.go`: extended the github client mock and added tests.

## How tested

- `go build ./...` passes.
- `go test ./...` passes (all previously passing packages still pass).
- `go vet ./...` clean.
- `gofmt` clean.

New unit tests cover row rendering (unread and read markers), mark-read state change (success greys the row, error leaves it unread), cursor clamping, the URL helper, and the empty/loading/error views.