### PR TITLE
feat(gitdiff): copy the current diff hunk to the clipboard

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -157,6 +157,23 @@ Commits panel (panel 4).
 
 ---
 
+## Diff Viewer
+
+Diff viewer panel (shows the diff for the selected file or commit).
+
+| Key | Action |
+|-----|--------|
+| `j/k` | Scroll up/down |
+| `d/u` | Page down/up |
+| `g/G` | Top/bottom |
+| `t` | Toggle inline/side-by-side |
+| `n/N` | Next/previous hunk |
+| `[/]` | Previous/next file |
+| `y` | Copy the current hunk to the clipboard |
+| `R` | Toggle review annotations |
+
+---
+
 ## Preview
 
 Preview panel (panel 5).

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -135,6 +135,21 @@
       ]
     },
     {
+      "id": "gitdiff",
+      "title": "Diff Viewer",
+      "description": "Diff viewer panel (shows the diff for the selected file or commit).",
+      "bindings": [
+        { "key": "j/k", "action": "Scroll up/down" },
+        { "key": "d/u", "action": "Page down/up" },
+        { "key": "g/G", "action": "Top/bottom" },
+        { "key": "t", "action": "Toggle inline/side-by-side" },
+        { "key": "n/N", "action": "Next/previous hunk" },
+        { "key": "[/]", "action": "Previous/next file" },
+        { "key": "y", "action": "Copy the current hunk to the clipboard" },
+        { "key": "R", "action": "Toggle review annotations" }
+      ]
+    },
+    {
       "id": "preview",
       "title": "Preview",
       "description": "Preview panel (panel 5).",

--- a/internal/keybindings/keybindings_test.go
+++ b/internal/keybindings/keybindings_test.go
@@ -34,7 +34,7 @@ func TestSections_ExpectedSections(t *testing.T) {
 	for i, s := range secs {
 		ids[i] = s.ID
 	}
-	expected := []string{"global", "navigation", "filetree", "gitstatus", "gitinfo", "github", "commits", "preview", "edit_mode"}
+	expected := []string{"global", "navigation", "filetree", "gitstatus", "gitinfo", "github", "commits", "gitdiff", "preview", "edit_mode"}
 	assert.Equal(t, expected, ids)
 }
 

--- a/internal/panels/gitdiff/gitdiff.go
+++ b/internal/panels/gitdiff/gitdiff.go
@@ -15,6 +15,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/jongio/grut/internal/config"
 	"github.com/jongio/grut/internal/git"
+	"github.com/jongio/grut/internal/notify"
 	"github.com/jongio/grut/internal/panels"
 	"github.com/jongio/grut/internal/theme"
 )
@@ -282,8 +283,84 @@ func (d *GitDiff) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		d.prevFile()
 	case "R":
 		d.toggleReviewAnnotations()
+	case "y":
+		return d.copyCurrentHunk()
 	}
 	return d, nil
+}
+
+// copyCurrentHunk copies the raw unified-diff text of the hunk under the
+// current scroll position to the clipboard. It is a safe no-op (with a
+// warning toast) when no diff is loaded.
+func (d *GitDiff) copyCurrentHunk() (panels.Panel, tea.Cmd) {
+	hunk, ok := d.currentHunk()
+	if !ok {
+		return d, func() tea.Msg {
+			return notify.ShowToastMsg{Message: "No hunk to copy", Level: notify.Warn}
+		}
+	}
+	patch := hunkToPatch(hunk)
+	ctx := d.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return d, func() tea.Msg {
+		if err := panels.CopyToClipboard(ctx, patch); err != nil {
+			return notify.ShowToastMsg{Message: "Copy failed: " + err.Error(), Level: notify.Error}
+		}
+		return notify.ShowToastMsg{Message: "Copied hunk to clipboard", Level: notify.Success}
+	}
+}
+
+// currentHunk returns the diff hunk under the current scroll position and
+// true, or a zero hunk and false when no diff is loaded. The hunk is located
+// by mapping d.scrollY through d.hunkStarts, which is built in the same
+// file-then-hunk order as the flattened hunk list below.
+func (d *GitDiff) currentHunk() (git.Hunk, bool) {
+	var flat []git.Hunk
+	for _, fd := range d.diffs {
+		flat = append(flat, fd.Hunks...)
+	}
+	if len(flat) == 0 {
+		return git.Hunk{}, false
+	}
+	idx := 0
+	for i, start := range d.hunkStarts {
+		if start <= d.scrollY {
+			idx = i
+		} else {
+			break
+		}
+	}
+	if idx >= len(flat) {
+		idx = len(flat) - 1
+	}
+	return flat[idx], true
+}
+
+// hunkToPatch renders a hunk as raw unified-diff text: the "@@" header
+// followed by each line prefixed with ' ', '+', or '-'.
+func hunkToPatch(h git.Hunk) string {
+	var b strings.Builder
+	b.WriteString(h.Header)
+	for _, ln := range h.Lines {
+		b.WriteByte('\n')
+		b.WriteString(diffLinePrefix(ln.Type))
+		b.WriteString(ln.Content)
+	}
+	return b.String()
+}
+
+// diffLinePrefix returns the single-character unified-diff prefix for a line.
+func diffLinePrefix(t git.DiffLineType) string {
+	switch t {
+	case git.DiffLineAdded:
+		return "+"
+	case git.DiffLineRemoved:
+		return "-"
+	default:
+		return " "
+	}
 }
 
 // handleMouseWheel scrolls the diff viewport.
@@ -354,6 +431,7 @@ func (d *GitDiff) KeyBindings() []panels.KeyBinding {
 		{Key: "t", Description: "Toggle inline/side-by-side", Action: "toggle_view"},
 		{Key: "n/N", Description: "Next/previous hunk", Action: "hunk_nav"},
 		{Key: "[/]", Description: "Previous/next file", Action: "file_nav"},
+		{Key: "y", Description: "Copy hunk to clipboard", Action: "copy_hunk"},
 		{Key: "R", Description: "Toggle review annotations", Action: "toggle_review"},
 	}
 }

--- a/internal/panels/gitdiff/gitdiff_test.go
+++ b/internal/panels/gitdiff/gitdiff_test.go
@@ -9,6 +9,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/jongio/grut/internal/git"
 	"github.com/jongio/grut/internal/git/gittest"
+	"github.com/jongio/grut/internal/notify"
 	"github.com/jongio/grut/internal/panels"
 	"github.com/jongio/grut/internal/theme"
 	"github.com/stretchr/testify/assert"
@@ -1113,4 +1114,65 @@ func TestRepoChangedMsg_ClearsState(t *testing.T) {
 	assert.False(t, d.loading, "loading should be false")
 	assert.Nil(t, d.err, "err should be nil")
 	assert.Nil(t, cmd, "no command should be returned")
+}
+
+// --- Copy hunk ---
+
+func TestHunkToPatch(t *testing.T) {
+	h := git.Hunk{
+		Header: "@@ -1,3 +1,3 @@",
+		Lines: []git.DiffLine{
+			{Type: git.DiffLineContext, Content: "ctx"},
+			{Type: git.DiffLineRemoved, Content: "old"},
+			{Type: git.DiffLineAdded, Content: "new"},
+		},
+	}
+	want := "@@ -1,3 +1,3 @@\n ctx\n-old\n+new"
+	assert.Equal(t, want, hunkToPatch(h))
+}
+
+func TestCurrentHunk_MapsScrollToEnclosingHunk(t *testing.T) {
+	p := newTestPanel(nil)
+	p.SetDiffs([]git.FileDiff{sampleMultiHunkDiff()})
+	require.Len(t, p.hunkStarts, 2, "sample has two hunks")
+
+	// At or before the first hunk start → first hunk.
+	p.scrollY = 0
+	h, ok := p.currentHunk()
+	require.True(t, ok)
+	assert.Equal(t, "@@ -1,3 +1,3 @@", h.Header)
+
+	// At the second hunk's start line → second hunk.
+	p.scrollY = p.hunkStarts[1]
+	h, ok = p.currentHunk()
+	require.True(t, ok)
+	assert.Equal(t, "@@ -20,2 +20,3 @@", h.Header)
+
+	// Scrolled past the end → clamps to the last hunk.
+	p.scrollY = 10000
+	h, ok = p.currentHunk()
+	require.True(t, ok)
+	assert.Equal(t, "@@ -20,2 +20,3 @@", h.Header)
+}
+
+func TestCurrentHunk_NoDiff(t *testing.T) {
+	p := newTestPanel(nil)
+	_, ok := p.currentHunk()
+	assert.False(t, ok, "no diff loaded → no current hunk")
+}
+
+func TestCopyCurrentHunk_NoDiff_Warns(t *testing.T) {
+	p := newTestPanel(nil)
+	_, cmd := p.copyCurrentHunk()
+	require.NotNil(t, cmd)
+	toast, ok := cmd().(notify.ShowToastMsg)
+	require.True(t, ok, "expected ShowToastMsg")
+	assert.Equal(t, notify.Warn, toast.Level)
+}
+
+func TestCopyCurrentHunk_WithDiff_ReturnsCommand(t *testing.T) {
+	p := newTestPanel(nil)
+	p.SetDiffs([]git.FileDiff{sampleMultiHunkDiff()})
+	_, cmd := p.copyCurrentHunk()
+	require.NotNil(t, cmd, "a copy command should be returned when a diff is loaded")
 }


### PR DESCRIPTION
## Summary

Adds a `y` keybinding to the diff viewer that copies the current hunk to the clipboard as raw unified-diff text.

The copied text is the hunk's `@@` header followed by each line prefixed with a space, `+`, or `-` - a valid patch fragment you can paste into a review, chat, or commit message.

## How it works

- `y` maps `d.scrollY` through the panel's existing `hunkStarts` index to find the hunk under the current scroll position, then reconstructs its patch text from the parsed `git.Hunk` data (not the ANSI-styled render).
- Works in both inline and side-by-side modes, since `hunkStarts` is built in the same file-then-hunk order in both.
- Reuses `panels.CopyToClipboard` (which strips ANSI) and reports success/failure via a toast.
- Safe no-op with a warning toast when no diff is loaded.

## Docs

The diff viewer panel's keybindings were not previously represented in `internal/keybindings/keybindings.json`. This adds a `Diff Viewer` section documenting the full key set (scroll, page, hunk/file nav, view toggle, review toggle) plus the new `y`, and regenerates `docs/keybindings.md` via `go run ./internal/keybindings/cmd/genmd` so the help overlay and docs stay in sync.

## Testing

- `go build ./...`
- `go test ./internal/panels/gitdiff/... ./internal/keybindings/...` (added `hunkToPatch` / `currentHunk` / `copyCurrentHunk` tests)

Closes #261