### PR TITLE
feat(gitinfo): close or reopen the selected issue

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -135,6 +135,7 @@ GitHub panel (panel 3).
 | `o` | Open in browser |
 | `y` | Copy to clipboard |
 | `m` | Merge PR (PRs tab) |
+| `c` | Close/reopen issue (Issues tab) |
 | `r` | Rerun (Actions tab) |
 | `x` | Cancel (Actions tab) |
 | `D` | Dispatch workflow |

--- a/internal/actions/registry.go
+++ b/internal/actions/registry.go
@@ -72,6 +72,7 @@ const (
 	ActionDownloadAssets   ActionID = "download_assets"
 	ActionCheckoutBranch   ActionID = "checkout_branch"
 	ActionMergePR          ActionID = "merge_pr"
+	ActionCloseReopenIssue ActionID = "close_reopen_issue"
 	ActionOpenInDefaultApp ActionID = "open_in_default_app"
 	ActionShowContextMenu  ActionID = "context_menu"
 	ActionPush             ActionID = "push"
@@ -93,7 +94,7 @@ var Registry = map[ItemType]ItemActions{
 	ItemWorktree:     {Default: ActionChangeDirectory, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionOpenTerminal, ActionCopyPath}, Description: "change to this worktree's directory"},
 	ItemRemote:       {Default: ActionOpenInBrowser, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionCopyURL}, Description: "open this remote in your browser"},
 	ItemStashEntry:   {Default: ActionPromptAction, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionApply, ActionPop, ActionDrop}, Description: "choose a stash action (apply/pop/drop)"},
-	ItemIssue:        {Default: ActionOpenInBrowser, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionCopyURL, ActionCopyNumber}, Description: "open this issue in your browser"},
+	ItemIssue:        {Default: ActionOpenInBrowser, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionCloseReopenIssue, ActionCopyURL, ActionCopyNumber}, Description: "open this issue in your browser"},
 	ItemPR:           {Default: ActionOpenInBrowser, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionMergePR, ActionCopyURL, ActionCopyNumber, ActionCheckoutBranch}, Description: "open this pull request in your browser"},
 	ItemActionRun:    {Default: ActionOpenInBrowser, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionRerun, ActionCopyURL}, Description: "open this workflow run in your browser"},
 	ItemWorkflow:     {Default: ActionDispatch, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionOpenInBrowser, ActionCopyURL}, Description: "dispatch this workflow"},
@@ -161,6 +162,7 @@ var actionLabels = map[ActionID]string{
 	ActionDownloadAssets:   "download assets",
 	ActionCheckoutBranch:   "checkout branch",
 	ActionMergePR:          "merge PR",
+	ActionCloseReopenIssue: "close/reopen issue",
 	ActionShowContextMenu:  "context menu",
 	ActionPush:             "push",
 	ActionChangeDirectory:  "change directory",

--- a/internal/actions/registry_test.go
+++ b/internal/actions/registry_test.go
@@ -107,6 +107,13 @@ func TestAllActionsUnknownType(t *testing.T) {
 	assert.Nil(t, AllActions("nonexistent"))
 }
 
+func TestAllActions_IssueIncludesCloseReopen(t *testing.T) {
+	got := AllActions(ItemIssue)
+	assert.Contains(t, got, ActionCloseReopenIssue,
+		"issue actions should include close/reopen")
+	assert.Equal(t, "close/reopen issue", ActionLabel(ActionCloseReopenIssue))
+}
+
 // ---------------------------------------------------------------------------
 // Description
 // ---------------------------------------------------------------------------

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -115,6 +115,7 @@
         { "key": "o", "action": "Open in browser" },
         { "key": "y", "action": "Copy to clipboard" },
         { "key": "m", "action": "Merge PR (PRs tab)" },
+        { "key": "c", "action": "Close/reopen issue (Issues tab)" },
         { "key": "r", "action": "Rerun (Actions tab)" },
         { "key": "x", "action": "Cancel (Actions tab)" },
         { "key": "D", "action": "Dispatch workflow" }

--- a/internal/panels/gitinfo/gitinfo.go
+++ b/internal/panels/gitinfo/gitinfo.go
@@ -148,6 +148,7 @@ const (
 	opPRMergeStrategy                    // awaiting merge strategy selection
 	opPRMergeConfirm                     // awaiting merge confirmation
 	opPRDeleteBranchAfterMerge           // awaiting post-merge branch deletion confirmation
+	opIssueCloseReopen                   // awaiting issue close/reopen confirmation
 )
 
 // ---------------------------------------------------------------------------
@@ -745,6 +746,8 @@ func (p *Panel) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 		return p.handlePRMergeResult(msg)
 	case prBranchDeleteResultMsg:
 		return p.handlePRBranchDeleteResult(msg)
+	case issueStateResultMsg:
+		return p.handleIssueStateResult(msg)
 
 	// CRUD actions dispatched via keymap.
 	case panels.ItemCreateMsg:
@@ -874,6 +877,7 @@ func (p *Panel) KeyBindings() []panels.KeyBinding {
 			panels.KeyBinding{Key: "a", Description: "Actions tab", Action: "tab_actions"},
 			panels.KeyBinding{Key: "W", Description: "Workflows tab", Action: "tab_workflows"},
 			panels.KeyBinding{Key: "L", Description: "Releases tab", Action: "tab_releases"},
+			panels.KeyBinding{Key: "c", Description: "Close/reopen issue (Issues tab)", Action: "close_reopen_issue"},
 		)
 	}
 	return bindings
@@ -1124,6 +1128,10 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 	case "m":
 		if p.activeTab == tabPRs && p.gh.client != nil {
 			return p.doMergePR()
+		}
+	case "c":
+		if p.activeTab == tabIssues && p.gh.client != nil {
+			return p.doCloseReopenIssue()
 		}
 	case "pgdown":
 		p.pageDown()
@@ -1766,6 +1774,8 @@ func (p *Panel) executeRightClickAction(action actions.ActionID) (panels.Panel, 
 			return p.copyAndToast(item.issue.HTMLURL)
 		case actions.ActionCopyNumber:
 			return p.copyAndToast(fmt.Sprintf("%d", item.issue.Number))
+		case actions.ActionCloseReopenIssue:
+			return p.doCloseReopenIssueFor(item.issue)
 		}
 	case kindPR:
 		switch action { //nolint:exhaustive // only relevant cases handled
@@ -2113,6 +2123,8 @@ func (p *Panel) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, tea.
 		return p.handlePRMergeConfirm(a)
 	case opPRDeleteBranchAfterMerge:
 		return p.handlePRDeleteBranchAfterMerge(a)
+	case opIssueCloseReopen:
+		return p.handleIssueCloseReopenConfirm(a)
 	}
 	return p, nil
 }

--- a/internal/panels/gitinfo/gitinfo_extra_test.go
+++ b/internal/panels/gitinfo/gitinfo_extra_test.go
@@ -1638,6 +1638,7 @@ func TestParseIssueStateName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			n, s, ok := parseIssueStateName(tt.name)
 			assert.Equal(t, tt.wantOK, ok)
 			assert.Equal(t, tt.wantNumber, n)

--- a/internal/panels/gitinfo/gitinfo_extra_test.go
+++ b/internal/panels/gitinfo/gitinfo_extra_test.go
@@ -1615,3 +1615,236 @@ func TestPRMessageTypes(t *testing.T) {
 	_ = panels.PRMergeFailedMsg{Number: 1, Err: errors.New("fail")}
 	_ = panels.PRMergedMsg{Number: 1, Strategy: "squash"}
 }
+
+// ---------------------------------------------------------------------------
+// Close/reopen issue (#258)
+// ---------------------------------------------------------------------------
+
+func TestParseIssueStateName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		wantNumber int
+		wantState  string
+		wantOK     bool
+	}{
+		{"42:closed", 42, "closed", true},
+		{"5:open", 5, "open", true},
+		{"bad", 0, "", false},
+		{"42:", 0, "", false},
+		{":closed", 0, "", false},
+		{"abc:closed", 0, "", false},
+		{"", 0, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n, s, ok := parseIssueStateName(tt.name)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantNumber, n)
+			assert.Equal(t, tt.wantState, s)
+		})
+	}
+}
+
+func TestDoCloseReopenIssueFor_OpenIssueClosesIt(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	_, cmd := p.doCloseReopenIssueFor(ghIssueItem{Number: 42, Title: "Fix bug", State: "open"})
+	assert.NotNil(t, cmd, "should show a confirm modal")
+	assert.Equal(t, opIssueCloseReopen, p.pending)
+	assert.Equal(t, "42:closed", p.pendingName)
+}
+
+func TestDoCloseReopenIssueFor_ClosedIssueReopensIt(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	_, cmd := p.doCloseReopenIssueFor(ghIssueItem{Number: 5, Title: "Old", State: "closed"})
+	assert.NotNil(t, cmd)
+	assert.Equal(t, opIssueCloseReopen, p.pending)
+	assert.Equal(t, "5:open", p.pendingName)
+}
+
+func TestDoCloseReopenIssueFor_NoGHClient(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	// ghClient is nil
+	_, cmd := p.doCloseReopenIssueFor(ghIssueItem{Number: 42, Title: "Fix bug", State: "open"})
+	assert.Nil(t, cmd, "should be no-op without a GitHub client")
+	assert.Equal(t, opNone, p.pending)
+}
+
+func TestDoCloseReopenIssue_WrongTab(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabBranches
+	p.tabItems[tabBranches] = []listItem{
+		{kind: kindLocalBranch, branch: git.Branch{Name: "main"}},
+	}
+	p.tabCursor[tabBranches] = 0
+	_, cmd := p.doCloseReopenIssue()
+	assert.Nil(t, cmd)
+}
+
+func TestDoCloseReopenIssue_EmptyCursor(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabIssues
+	p.tabItems[tabIssues] = []listItem{}
+	_, cmd := p.doCloseReopenIssue()
+	assert.Nil(t, cmd)
+}
+
+func TestExecuteRightClickAction_Issue_CloseReopen(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabIssues
+	p.tabItems[tabIssues] = []listItem{
+		{kind: kindIssue, issue: ghIssueItem{Number: 9, Title: "Bug", State: "open"}},
+	}
+	p.tabCursor[tabIssues] = 0
+	_, cmd := p.executeRightClickAction(actions.ActionCloseReopenIssue)
+	assert.NotNil(t, cmd, "right-click close/reopen should show confirm modal")
+	assert.Equal(t, opIssueCloseReopen, p.pending)
+	assert.Equal(t, "9:closed", p.pendingName)
+}
+
+func TestHandleKey_C_IssuesTab(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabIssues
+	p.tabItems[tabIssues] = []listItem{
+		{kind: kindIssue, issue: ghIssueItem{Number: 42, Title: "Test", State: "open"}},
+	}
+	p.tabCursor[tabIssues] = 0
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: 'c'})
+	assert.NotNil(t, cmd, "pressing 'c' on Issues tab should trigger close/reopen flow")
+	assert.Equal(t, opIssueCloseReopen, p.pending)
+}
+
+func TestHandleKey_C_NotIssuesTab(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabPRs
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: 'c'})
+	assert.Nil(t, cmd, "pressing 'c' outside Issues tab should be no-op")
+}
+
+func TestHandleKey_C_NoGHClient(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.activeTab = tabIssues
+	// ghClient is nil
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: 'c'})
+	assert.Nil(t, cmd, "pressing 'c' without ghClient should be no-op")
+}
+
+func TestHandleModalResult_IssueCloseReopen_Confirm(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.gh.owner = "owner"
+	p.gh.repo = "repo"
+	p.ctx = t.Context()
+	p.pending = opIssueCloseReopen
+	p.pendingName = "42:closed"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true})
+	assert.NotNil(t, cmd, "confirming should produce the close/reopen command")
+	assert.Equal(t, opNone, p.pending)
+}
+
+func TestHandleModalResult_IssueCloseReopen_Cancel(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.pending = opIssueCloseReopen
+	p.pendingName = "42:closed"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: false})
+	assert.Nil(t, cmd, "cancelling should be a no-op")
+	assert.Equal(t, opNone, p.pending)
+}
+
+func TestHandleModalResult_IssueCloseReopen_BadName(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.ctx = t.Context()
+	p.pending = opIssueCloseReopen
+	p.pendingName = "bad"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true})
+	assert.Nil(t, cmd, "malformed pending name should produce nil cmd")
+}
+
+func TestHandleIssueStateResult_CloseSuccess(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.allIssues = []ghIssueItem{{Number: 42, Title: "Bug", State: "open"}}
+	p.tabItems[tabIssues] = []listItem{
+		{kind: kindIssue, issue: p.gh.allIssues[0]},
+	}
+
+	_, cmd := p.handleIssueStateResult(issueStateResultMsg{number: 42, newState: "closed"})
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "closed", p.gh.allIssues[0].State)
+	assert.Equal(t, "closed", p.tabItems[tabIssues][0].issue.State)
+}
+
+func TestHandleIssueStateResult_ReopenSuccess(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.allIssues = []ghIssueItem{{Number: 7, Title: "Old", State: "closed"}}
+	p.tabItems[tabIssues] = []listItem{
+		{kind: kindIssue, issue: p.gh.allIssues[0]},
+	}
+
+	_, cmd := p.handleIssueStateResult(issueStateResultMsg{number: 7, newState: "open"})
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "open", p.gh.allIssues[0].State)
+	assert.Equal(t, "open", p.tabItems[tabIssues][0].issue.State)
+}
+
+func TestHandleIssueStateResult_Error(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.allIssues = []ghIssueItem{{Number: 42, Title: "Bug", State: "open"}}
+
+	_, cmd := p.handleIssueStateResult(issueStateResultMsg{
+		number:   42,
+		newState: "closed",
+		err:      errors.New("network error"),
+	})
+	assert.NotNil(t, cmd, "should produce an error toast")
+	assert.Equal(t, "open", p.gh.allIssues[0].State, "state should be unchanged on error")
+}
+
+func TestCloseReopenIssueCmd_ReturnsResult(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.gh.owner = "owner"
+	p.gh.repo = "repo"
+	p.ctx = t.Context()
+
+	cmd := p.closeReopenIssueCmd(42, "closed")
+	assert.NotNil(t, cmd)
+	msg := cmd()
+	res, ok := msg.(issueStateResultMsg)
+	assert.True(t, ok, "should return an issueStateResultMsg")
+	assert.Equal(t, 42, res.number)
+	assert.Equal(t, "closed", res.newState)
+	assert.NoError(t, res.err)
+}

--- a/internal/panels/gitinfo/gitinfo_github.go
+++ b/internal/panels/gitinfo/gitinfo_github.go
@@ -1814,9 +1814,9 @@ func (p *Panel) doCloseReopenIssueFor(iss ghIssueItem) (panels.Panel, tea.Cmd) {
 	if p.gh.client == nil || iss.Number == 0 {
 		return p, nil
 	}
-	target, verb := "closed", "Close"
-	if strings.EqualFold(iss.State, "closed") {
-		target, verb = "open", "Reopen"
+	target, verb := stateClosed, "Close"
+	if strings.EqualFold(iss.State, stateClosed) {
+		target, verb = prStateOpen, "Reopen"
 	}
 	p.clearPending()
 	p.pending = opIssueCloseReopen
@@ -1858,7 +1858,7 @@ func (p *Panel) closeReopenIssueCmd(number int, targetState string) tea.Cmd {
 	ctx := p.ctx
 	return func() tea.Msg {
 		var err error
-		if targetState == "open" {
+		if targetState == prStateOpen {
 			err = client.ReopenIssue(ctx, owner, repo, number)
 		} else {
 			err = client.CloseIssue(ctx, owner, repo, number)
@@ -1869,8 +1869,8 @@ func (p *Panel) closeReopenIssueCmd(number int, targetState string) tea.Cmd {
 
 // handleIssueStateResult processes the async result of a close/reopen op.
 func (p *Panel) handleIssueStateResult(msg issueStateResultMsg) (panels.Panel, tea.Cmd) {
-	verb := "closed"
-	if msg.newState == "open" {
+	verb := stateClosed
+	if msg.newState == prStateOpen {
 		verb = "reopened"
 	}
 	if msg.err != nil {

--- a/internal/panels/gitinfo/gitinfo_github.go
+++ b/internal/panels/gitinfo/gitinfo_github.go
@@ -4,6 +4,7 @@ package gitinfo
 import (
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1789,9 +1790,123 @@ func (p *Panel) handlePRBranchDeleteResult(msg prBranchDeleteResultMsg) (panels.
 	)
 }
 
-// ---------------------------------------------------------------------------
-// GitHub item rendering
-// ---------------------------------------------------------------------------
+// issueStateResultMsg carries the result of closing or reopening an issue.
+type issueStateResultMsg struct {
+	newState string // "open" or "closed"
+	err      error
+	number   int
+}
+
+// doCloseReopenIssue closes or reopens the issue under the cursor on the
+// Issues tab. Open issues are closed; closed issues are reopened.
+func (p *Panel) doCloseReopenIssue() (panels.Panel, tea.Cmd) {
+	items := p.tabItems[p.activeTab]
+	cursor := p.tabCursor[p.activeTab]
+	if cursor < 0 || cursor >= len(items) || items[cursor].kind != kindIssue {
+		return p, nil
+	}
+	return p.doCloseReopenIssueFor(items[cursor].issue)
+}
+
+// doCloseReopenIssueFor prepares a confirmation modal to close or reopen the
+// given issue. The target state is derived from the issue's current state.
+func (p *Panel) doCloseReopenIssueFor(iss ghIssueItem) (panels.Panel, tea.Cmd) {
+	if p.gh.client == nil || iss.Number == 0 {
+		return p, nil
+	}
+	target, verb := "closed", "Close"
+	if strings.EqualFold(iss.State, "closed") {
+		target, verb = "open", "Reopen"
+	}
+	p.clearPending()
+	p.pending = opIssueCloseReopen
+	// Encode the issue number and target state for the modal handler.
+	p.pendingName = fmt.Sprintf("%d:%s", iss.Number, target)
+	return p, notify.ShowConfirm(
+		fmt.Sprintf("%s Issue #%d", verb, iss.Number),
+		iss.Title,
+	)
+}
+
+// handleIssueCloseReopenConfirm runs the async close/reopen once the user
+// confirms the modal. The pending name is "<number>:<targetState>".
+func (p *Panel) handleIssueCloseReopenConfirm(a modalArgs) (panels.Panel, tea.Cmd) {
+	number, target, ok := parseIssueStateName(a.name)
+	if !ok {
+		return p, nil
+	}
+	return p, p.closeReopenIssueCmd(number, target)
+}
+
+// parseIssueStateName splits a "<number>:<state>" pending name.
+func parseIssueStateName(name string) (number int, state string, ok bool) {
+	idx := strings.LastIndex(name, ":")
+	if idx <= 0 || idx == len(name)-1 {
+		return 0, "", false
+	}
+	n, err := strconv.Atoi(name[:idx])
+	if err != nil {
+		return 0, "", false
+	}
+	return n, name[idx+1:], true
+}
+
+// closeReopenIssueCmd returns a tea.Cmd that closes or reopens an issue.
+func (p *Panel) closeReopenIssueCmd(number int, targetState string) tea.Cmd {
+	client := p.gh.client
+	owner, repo := p.gh.owner, p.gh.repo
+	ctx := p.ctx
+	return func() tea.Msg {
+		var err error
+		if targetState == "open" {
+			err = client.ReopenIssue(ctx, owner, repo, number)
+		} else {
+			err = client.CloseIssue(ctx, owner, repo, number)
+		}
+		return issueStateResultMsg{number: number, newState: targetState, err: err}
+	}
+}
+
+// handleIssueStateResult processes the async result of a close/reopen op.
+func (p *Panel) handleIssueStateResult(msg issueStateResultMsg) (panels.Panel, tea.Cmd) {
+	verb := "closed"
+	if msg.newState == "open" {
+		verb = "reopened"
+	}
+	if msg.err != nil {
+		errStr := msg.err.Error()
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: fmt.Sprintf("Issue #%d %s failed: %s", msg.number, verb, errStr),
+				Level:   notify.Error,
+			}
+		}
+	}
+	// Update cached issue state.
+	for i := range p.gh.allIssues {
+		if p.gh.allIssues[i].Number == msg.number {
+			p.gh.allIssues[i].State = msg.newState
+			break
+		}
+	}
+	// Update the visible tab item too.
+	for i := range p.tabItems[tabIssues] {
+		if p.tabItems[tabIssues][i].kind == kindIssue && p.tabItems[tabIssues][i].issue.Number == msg.number {
+			p.tabItems[tabIssues][i].issue.State = msg.newState
+			break
+		}
+	}
+	return p, tea.Batch(
+		func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: fmt.Sprintf("Issue #%d %s", msg.number, verb),
+				Level:   notify.Success,
+			}
+		},
+		p.loadGitHubData(),
+	)
+}
+
 // renderIssue renders a GitHub issue line: "  #42 Fix auth token...   bug"
 func (p *Panel) renderIssue(item listItem, width int, isCursor bool) string {
 	iss := item.issue


### PR DESCRIPTION
## What

Adds a close/reopen action to the Issues tab in the Git Info / GitHub panel. Select an issue and press `c` (or use the right-click context menu) to toggle it between open and closed.

## Why

You can already browse issues in the panel, but any state change meant leaving the terminal for the browser. Closing a finished issue or reopening one that needs more work is a common action that should stay in the flow.

## How it works

- `c` on the Issues tab (GitHub client only) opens a confirmation modal showing the issue title.
- Open issues are closed; closed issues are reopened. The direction is picked from the issue's current state, so the same key does the right thing.
- The GitHub call (`CloseIssue` / `ReopenIssue`) runs asynchronously. On success the local issue state updates right away, the list reloads, and a success toast appears. Errors surface as an error toast and leave state unchanged.
- Also wired into the right-click context menu as a new `close/reopen issue` action.

## Tests

- Registry: `ItemIssue` includes the new action; label check.
- Key handling: `c` on Issues tab triggers the flow; no-op on other tabs and without a GitHub client.
- `doCloseReopenIssueFor` picks close vs reopen from state and encodes the pending name.
- Modal confirm/cancel/bad-name paths.
- `handleIssueStateResult` updates cached + visible state on success, leaves it unchanged on error.
- `closeReopenIssueCmd` returns the expected result message.
- `parseIssueStateName` table test.
- Keybindings JSON + generated docs updated.

Closes #258