### PR TITLE
feat(gitinfo): assign selected issue or PR to yourself

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -135,6 +135,7 @@ GitHub panel (panel 3).
 | `o` | Open in browser |
 | `y` | Copy to clipboard |
 | `m` | Merge PR (PRs tab) |
+| `A` | Assign to me (Issues/PRs tab) |
 | `r` | Rerun (Actions tab) |
 | `x` | Cancel (Actions tab) |
 | `D` | Dispatch workflow |

--- a/internal/actions/registry.go
+++ b/internal/actions/registry.go
@@ -72,6 +72,7 @@ const (
 	ActionDownloadAssets   ActionID = "download_assets"
 	ActionCheckoutBranch   ActionID = "checkout_branch"
 	ActionMergePR          ActionID = "merge_pr"
+	ActionAssignSelf       ActionID = "assign_self"
 	ActionOpenInDefaultApp ActionID = "open_in_default_app"
 	ActionShowContextMenu  ActionID = "context_menu"
 	ActionPush             ActionID = "push"
@@ -93,8 +94,8 @@ var Registry = map[ItemType]ItemActions{
 	ItemWorktree:     {Default: ActionChangeDirectory, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionOpenTerminal, ActionCopyPath}, Description: "change to this worktree's directory"},
 	ItemRemote:       {Default: ActionOpenInBrowser, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionCopyURL}, Description: "open this remote in your browser"},
 	ItemStashEntry:   {Default: ActionPromptAction, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionApply, ActionPop, ActionDrop}, Description: "choose a stash action (apply/pop/drop)"},
-	ItemIssue:        {Default: ActionOpenInBrowser, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionCopyURL, ActionCopyNumber}, Description: "open this issue in your browser"},
-	ItemPR:           {Default: ActionOpenInBrowser, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionMergePR, ActionCopyURL, ActionCopyNumber, ActionCheckoutBranch}, Description: "open this pull request in your browser"},
+	ItemIssue:        {Default: ActionOpenInBrowser, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionAssignSelf, ActionCopyURL, ActionCopyNumber}, Description: "open this issue in your browser"},
+	ItemPR:           {Default: ActionOpenInBrowser, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionMergePR, ActionAssignSelf, ActionCopyURL, ActionCopyNumber, ActionCheckoutBranch}, Description: "open this pull request in your browser"},
 	ItemActionRun:    {Default: ActionOpenInBrowser, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionRerun, ActionCopyURL}, Description: "open this workflow run in your browser"},
 	ItemWorkflow:     {Default: ActionDispatch, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionOpenInBrowser, ActionCopyURL}, Description: "dispatch this workflow"},
 	ItemRelease:      {Default: ActionOpenInBrowser, RightClick: ActionShowContextMenu, Alternatives: []ActionID{ActionDownloadAssets, ActionCopyURL, ActionCopyName}, Description: "open this release in your browser"},
@@ -161,6 +162,7 @@ var actionLabels = map[ActionID]string{
 	ActionDownloadAssets:   "download assets",
 	ActionCheckoutBranch:   "checkout branch",
 	ActionMergePR:          "merge PR",
+	ActionAssignSelf:       "assign to me",
 	ActionShowContextMenu:  "context menu",
 	ActionPush:             "push",
 	ActionChangeDirectory:  "change directory",

--- a/internal/actions/registry_test.go
+++ b/internal/actions/registry_test.go
@@ -65,7 +65,7 @@ func TestAllActions(t *testing.T) {
 		},
 		{
 			ItemPR,
-			[]ActionID{ActionOpenInBrowser, ActionMergePR, ActionCopyURL, ActionCopyNumber, ActionCheckoutBranch},
+			[]ActionID{ActionOpenInBrowser, ActionMergePR, ActionAssignSelf, ActionCopyURL, ActionCopyNumber, ActionCheckoutBranch},
 		},
 		{
 			ItemStashEntry,
@@ -105,6 +105,14 @@ func TestAllActionsNoAlternatives(t *testing.T) {
 
 func TestAllActionsUnknownType(t *testing.T) {
 	assert.Nil(t, AllActions("nonexistent"))
+}
+
+func TestAllActions_IssueAndPRIncludeAssignSelf(t *testing.T) {
+	assert.Contains(t, AllActions(ItemIssue), ActionAssignSelf,
+		"issue actions should include assign-to-me")
+	assert.Contains(t, AllActions(ItemPR), ActionAssignSelf,
+		"PR actions should include assign-to-me")
+	assert.Equal(t, "assign to me", ActionLabel(ActionAssignSelf))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -181,6 +181,15 @@ func (c *clientImpl) ReopenIssue(ctx context.Context, owner, repo string, number
 	return c.EditIssue(ctx, owner, repo, number, req)
 }
 
+func (c *clientImpl) AddAssignees(ctx context.Context, owner, repo string, number int, assignees []string) error {
+	_, _, err := c.gh.Issues.AddAssignees(ctx, owner, repo, number, assignees)
+	if err != nil {
+		return fmt.Errorf("add assignees to #%d: %w", number, err)
+	}
+	c.cache.Invalidate(fmt.Sprintf("issue:%s/%s:%d", owner, repo, number))
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // PRReader
 // ---------------------------------------------------------------------------

--- a/internal/github/interfaces.go
+++ b/internal/github/interfaces.go
@@ -27,6 +27,7 @@ type IssueWriter interface {
 	CommentOnIssue(ctx context.Context, owner, repo string, number int, body string) error
 	CloseIssue(ctx context.Context, owner, repo string, number int) error
 	ReopenIssue(ctx context.Context, owner, repo string, number int) error
+	AddAssignees(ctx context.Context, owner, repo string, number int, assignees []string) error
 }
 
 // PRReader provides read-only access to GitHub pull requests.

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -115,6 +115,7 @@
         { "key": "o", "action": "Open in browser" },
         { "key": "y", "action": "Copy to clipboard" },
         { "key": "m", "action": "Merge PR (PRs tab)" },
+        { "key": "A", "action": "Assign to me (Issues/PRs tab)" },
         { "key": "r", "action": "Rerun (Actions tab)" },
         { "key": "x", "action": "Cancel (Actions tab)" },
         { "key": "D", "action": "Dispatch workflow" }

--- a/internal/panels/gitinfo/constants.go
+++ b/internal/panels/gitinfo/constants.go
@@ -85,6 +85,12 @@ const (
 	stateClosed  = "closed"
 )
 
+// Assignable item kind labels used in assign-to-me toasts and result messages.
+const (
+	assignKindIssue = "issue"
+	assignKindPR    = "PR"
+)
+
 // Workflow state strings.
 const (
 	stateActive             = "active"

--- a/internal/panels/gitinfo/gitinfo.go
+++ b/internal/panels/gitinfo/gitinfo.go
@@ -148,6 +148,7 @@ const (
 	opPRMergeStrategy                    // awaiting merge strategy selection
 	opPRMergeConfirm                     // awaiting merge confirmation
 	opPRDeleteBranchAfterMerge           // awaiting post-merge branch deletion confirmation
+	opAssignSelf                         // awaiting assign-to-me confirmation
 )
 
 // ---------------------------------------------------------------------------
@@ -745,6 +746,8 @@ func (p *Panel) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 		return p.handlePRMergeResult(msg)
 	case prBranchDeleteResultMsg:
 		return p.handlePRBranchDeleteResult(msg)
+	case assignSelfResultMsg:
+		return p.handleAssignSelfResult(msg)
 
 	// CRUD actions dispatched via keymap.
 	case panels.ItemCreateMsg:
@@ -874,6 +877,7 @@ func (p *Panel) KeyBindings() []panels.KeyBinding {
 			panels.KeyBinding{Key: "a", Description: "Actions tab", Action: "tab_actions"},
 			panels.KeyBinding{Key: "W", Description: "Workflows tab", Action: "tab_workflows"},
 			panels.KeyBinding{Key: "L", Description: "Releases tab", Action: "tab_releases"},
+			panels.KeyBinding{Key: "A", Description: "Assign to me (Issues/PRs tab)", Action: "assign_self"},
 		)
 	}
 	return bindings
@@ -1124,6 +1128,10 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 	case "m":
 		if p.activeTab == tabPRs && p.gh.client != nil {
 			return p.doMergePR()
+		}
+	case "A":
+		if (p.activeTab == tabIssues || p.activeTab == tabPRs) && p.gh.client != nil {
+			return p.doAssignSelf()
 		}
 	case "pgdown":
 		p.pageDown()
@@ -1766,6 +1774,8 @@ func (p *Panel) executeRightClickAction(action actions.ActionID) (panels.Panel, 
 			return p.copyAndToast(item.issue.HTMLURL)
 		case actions.ActionCopyNumber:
 			return p.copyAndToast(fmt.Sprintf("%d", item.issue.Number))
+		case actions.ActionAssignSelf:
+			return p.doAssignSelfFor("issue", item.issue.Number)
 		}
 	case kindPR:
 		switch action { //nolint:exhaustive // only relevant cases handled
@@ -1789,6 +1799,8 @@ func (p *Panel) executeRightClickAction(action actions.ActionID) (panels.Panel, 
 			return p, notify.ShowConfirm("Checkout PR Branch", fmt.Sprintf("Switch to branch %q?", ref))
 		case actions.ActionMergePR:
 			return p.doMergePR()
+		case actions.ActionAssignSelf:
+			return p.doAssignSelfFor("PR", item.pr.Number)
 		}
 	case kindActionRun:
 		switch action { //nolint:exhaustive // only relevant cases handled
@@ -2113,6 +2125,8 @@ func (p *Panel) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, tea.
 		return p.handlePRMergeConfirm(a)
 	case opPRDeleteBranchAfterMerge:
 		return p.handlePRDeleteBranchAfterMerge(a)
+	case opAssignSelf:
+		return p.handleAssignSelfConfirm(a)
 	}
 	return p, nil
 }

--- a/internal/panels/gitinfo/gitinfo.go
+++ b/internal/panels/gitinfo/gitinfo.go
@@ -1775,7 +1775,7 @@ func (p *Panel) executeRightClickAction(action actions.ActionID) (panels.Panel, 
 		case actions.ActionCopyNumber:
 			return p.copyAndToast(fmt.Sprintf("%d", item.issue.Number))
 		case actions.ActionAssignSelf:
-			return p.doAssignSelfFor("issue", item.issue.Number)
+			return p.doAssignSelfFor(assignKindIssue, item.issue.Number)
 		}
 	case kindPR:
 		switch action { //nolint:exhaustive // only relevant cases handled
@@ -1800,7 +1800,7 @@ func (p *Panel) executeRightClickAction(action actions.ActionID) (panels.Panel, 
 		case actions.ActionMergePR:
 			return p.doMergePR()
 		case actions.ActionAssignSelf:
-			return p.doAssignSelfFor("PR", item.pr.Number)
+			return p.doAssignSelfFor(assignKindPR, item.pr.Number)
 		}
 	case kindActionRun:
 		switch action { //nolint:exhaustive // only relevant cases handled

--- a/internal/panels/gitinfo/gitinfo_extra_test.go
+++ b/internal/panels/gitinfo/gitinfo_extra_test.go
@@ -1639,6 +1639,7 @@ func TestParseAssignSelfName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			kind, n, ok := parseAssignSelfName(tt.name)
 			assert.Equal(t, tt.wantOK, ok)
 			assert.Equal(t, tt.wantKind, kind)

--- a/internal/panels/gitinfo/gitinfo_extra_test.go
+++ b/internal/panels/gitinfo/gitinfo_extra_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	gh "github.com/google/go-github/v88/github"
 	"github.com/jongio/grut/internal/actions"
 	"github.com/jongio/grut/internal/git"
 	"github.com/jongio/grut/internal/notify"
@@ -1614,4 +1615,299 @@ func TestPRMessageTypes(t *testing.T) {
 	_ = panels.PRMergeRequestedMsg{Number: 1, Title: "test", HeadBranch: "main"}
 	_ = panels.PRMergeFailedMsg{Number: 1, Err: errors.New("fail")}
 	_ = panels.PRMergedMsg{Number: 1, Strategy: "squash"}
+}
+
+// ---------------------------------------------------------------------------
+// Assign to me (#259)
+// ---------------------------------------------------------------------------
+
+func TestParseAssignSelfName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		wantKind   string
+		wantNumber int
+		wantOK     bool
+	}{
+		{"issue:42", "issue", 42, true},
+		{"PR:7", "PR", 7, true},
+		{"bad", "", 0, false},
+		{"issue:", "", 0, false},
+		{":42", "", 0, false},
+		{"issue:abc", "", 0, false},
+		{"", "", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind, n, ok := parseAssignSelfName(tt.name)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantKind, kind)
+			assert.Equal(t, tt.wantNumber, n)
+		})
+	}
+}
+
+func TestDoAssignSelf_Issue(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.gh.user = "octocat"
+	p.activeTab = tabIssues
+	p.tabItems[tabIssues] = []listItem{
+		{kind: kindIssue, issue: ghIssueItem{Number: 42, Title: "Bug", State: "open"}},
+	}
+	p.tabCursor[tabIssues] = 0
+	_, cmd := p.doAssignSelf()
+	assert.NotNil(t, cmd, "should show a confirm modal")
+	assert.Equal(t, opAssignSelf, p.pending)
+	assert.Equal(t, "issue:42", p.pendingName)
+}
+
+func TestDoAssignSelf_PR(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.gh.user = "octocat"
+	p.activeTab = tabPRs
+	p.tabItems[tabPRs] = []listItem{
+		{kind: kindPR, pr: ghPRItem{Number: 7, Title: "Feature", State: "open"}},
+	}
+	p.tabCursor[tabPRs] = 0
+	_, cmd := p.doAssignSelf()
+	assert.NotNil(t, cmd)
+	assert.Equal(t, opAssignSelf, p.pending)
+	assert.Equal(t, "PR:7", p.pendingName)
+}
+
+func TestDoAssignSelf_EmptyCursor(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabIssues
+	p.tabItems[tabIssues] = []listItem{}
+	_, cmd := p.doAssignSelf()
+	assert.Nil(t, cmd)
+}
+
+func TestDoAssignSelfFor_NoGHClient(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	// ghClient is nil
+	_, cmd := p.doAssignSelfFor("issue", 42)
+	assert.Nil(t, cmd)
+	assert.Equal(t, opNone, p.pending)
+}
+
+func TestExecuteRightClickAction_Issue_AssignSelf(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.gh.user = "octocat"
+	p.activeTab = tabIssues
+	p.tabItems[tabIssues] = []listItem{
+		{kind: kindIssue, issue: ghIssueItem{Number: 9, Title: "Bug", State: "open"}},
+	}
+	p.tabCursor[tabIssues] = 0
+	_, cmd := p.executeRightClickAction(actions.ActionAssignSelf)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, opAssignSelf, p.pending)
+	assert.Equal(t, "issue:9", p.pendingName)
+}
+
+func TestExecuteRightClickAction_PR_AssignSelf(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.gh.user = "octocat"
+	p.activeTab = tabPRs
+	p.tabItems[tabPRs] = []listItem{
+		{kind: kindPR, pr: ghPRItem{Number: 15, Title: "Feature", State: "open"}},
+	}
+	p.tabCursor[tabPRs] = 0
+	_, cmd := p.executeRightClickAction(actions.ActionAssignSelf)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, opAssignSelf, p.pending)
+	assert.Equal(t, "PR:15", p.pendingName)
+}
+
+func TestHandleKey_A_IssuesTab(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.gh.client = &mockGHClientFull{}
+	p.gh.user = "octocat"
+	p.activeTab = tabIssues
+	p.tabItems[tabIssues] = []listItem{
+		{kind: kindIssue, issue: ghIssueItem{Number: 42, Title: "Test", State: "open"}},
+	}
+	p.tabCursor[tabIssues] = 0
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: 'A', Text: "A"})
+	assert.NotNil(t, cmd, "pressing 'A' on Issues tab should trigger assign flow")
+	assert.Equal(t, opAssignSelf, p.pending)
+}
+
+func TestHandleKey_A_PRsTab(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.gh.client = &mockGHClientFull{}
+	p.gh.user = "octocat"
+	p.activeTab = tabPRs
+	p.tabItems[tabPRs] = []listItem{
+		{kind: kindPR, pr: ghPRItem{Number: 7, Title: "Test", State: "open"}},
+	}
+	p.tabCursor[tabPRs] = 0
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: 'A', Text: "A"})
+	assert.NotNil(t, cmd, "pressing 'A' on PRs tab should trigger assign flow")
+	assert.Equal(t, opAssignSelf, p.pending)
+}
+
+func TestHandleKey_A_OtherTab(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabBranches
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: 'A', Text: "A"})
+	assert.Nil(t, cmd, "pressing 'A' outside Issues/PRs tab should be no-op")
+}
+
+func TestHandleKey_A_NoGHClient(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.activeTab = tabIssues
+	// ghClient is nil
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: 'A', Text: "A"})
+	assert.Nil(t, cmd, "pressing 'A' without ghClient should be no-op")
+}
+
+func TestHandleModalResult_AssignSelf_Confirm(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.gh.owner = "owner"
+	p.gh.repo = "repo"
+	p.gh.user = "octocat"
+	p.ctx = t.Context()
+	p.pending = opAssignSelf
+	p.pendingName = "issue:42"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true})
+	assert.NotNil(t, cmd, "confirming should produce the assign command")
+	assert.Equal(t, opNone, p.pending)
+}
+
+func TestHandleModalResult_AssignSelf_Cancel(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.pending = opAssignSelf
+	p.pendingName = "issue:42"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: false})
+	assert.Nil(t, cmd, "cancelling should be a no-op")
+	assert.Equal(t, opNone, p.pending)
+}
+
+func TestHandleModalResult_AssignSelf_BadName(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.ctx = t.Context()
+	p.pending = opAssignSelf
+	p.pendingName = "bad"
+
+	_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true})
+	assert.Nil(t, cmd, "malformed pending name should produce nil cmd")
+}
+
+func TestHandleAssignSelfResult_IssueSuccess(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.allIssues = []ghIssueItem{{Number: 42, Title: "Bug", State: "open"}}
+	p.tabItems[tabIssues] = []listItem{
+		{kind: kindIssue, issue: p.gh.allIssues[0]},
+	}
+
+	_, cmd := p.handleAssignSelfResult(assignSelfResultMsg{kind: "issue", number: 42, login: "octocat"})
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "octocat", p.gh.allIssues[0].Assignee)
+	assert.Equal(t, "octocat", p.tabItems[tabIssues][0].issue.Assignee)
+}
+
+func TestHandleAssignSelfResult_PRSuccess(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	_, cmd := p.handleAssignSelfResult(assignSelfResultMsg{kind: "PR", number: 7, login: "octocat"})
+	assert.NotNil(t, cmd, "PR assignment success should still toast + reload")
+}
+
+func TestHandleAssignSelfResult_Error(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.allIssues = []ghIssueItem{{Number: 42, Title: "Bug", State: "open", Assignee: ""}}
+
+	_, cmd := p.handleAssignSelfResult(assignSelfResultMsg{
+		kind:   "issue",
+		number: 42,
+		err:    errors.New("network error"),
+	})
+	assert.NotNil(t, cmd, "should produce an error toast")
+	assert.Equal(t, "", p.gh.allIssues[0].Assignee, "assignee should be unchanged on error")
+}
+
+func TestAssignSelfCmd_UsesCachedLogin(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.gh.owner = "owner"
+	p.gh.repo = "repo"
+	p.gh.user = "octocat"
+	p.ctx = t.Context()
+
+	cmd := p.assignSelfCmd("issue", 42)
+	assert.NotNil(t, cmd)
+	msg := cmd()
+	res, ok := msg.(assignSelfResultMsg)
+	assert.True(t, ok)
+	assert.Equal(t, 42, res.number)
+	assert.Equal(t, "octocat", res.login)
+	assert.NoError(t, res.err)
+}
+
+func TestAssignSelfCmd_FetchesLoginWhenEmpty(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{user: &gh.User{Login: gh.Ptr("fetched-user")}}
+	p.gh.owner = "owner"
+	p.gh.repo = "repo"
+	p.gh.user = "" // not cached
+	p.ctx = t.Context()
+
+	cmd := p.assignSelfCmd("PR", 7)
+	msg := cmd()
+	res, ok := msg.(assignSelfResultMsg)
+	assert.True(t, ok)
+	assert.Equal(t, "fetched-user", res.login)
+	assert.NoError(t, res.err)
+}
+
+func TestAssignSelfCmd_AddAssigneesError(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{addAssigneesErr: errors.New("forbidden")}
+	p.gh.owner = "owner"
+	p.gh.repo = "repo"
+	p.gh.user = "octocat"
+	p.ctx = t.Context()
+
+	cmd := p.assignSelfCmd("issue", 42)
+	msg := cmd()
+	res, ok := msg.(assignSelfResultMsg)
+	assert.True(t, ok)
+	assert.Error(t, res.err)
 }

--- a/internal/panels/gitinfo/gitinfo_github.go
+++ b/internal/panels/gitinfo/gitinfo_github.go
@@ -4,6 +4,7 @@ package gitinfo
 import (
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1786,6 +1787,139 @@ func (p *Panel) handlePRBranchDeleteResult(msg prBranchDeleteResultMsg) (panels.
 			}
 		},
 		p.loadData(),
+	)
+}
+
+// assignSelfResultMsg carries the result of assigning an issue or PR to the
+// current user.
+type assignSelfResultMsg struct {
+	kind   string // "issue" or "PR"
+	login  string
+	err    error
+	number int
+}
+
+// doAssignSelf assigns the item under the cursor (Issues or PRs tab) to the
+// current user.
+func (p *Panel) doAssignSelf() (panels.Panel, tea.Cmd) {
+	items := p.tabItems[p.activeTab]
+	cursor := p.tabCursor[p.activeTab]
+	if cursor < 0 || cursor >= len(items) {
+		return p, nil
+	}
+	switch items[cursor].kind { //nolint:exhaustive // only issues and PRs are assignable
+	case kindIssue:
+		return p.doAssignSelfFor("issue", items[cursor].issue.Number)
+	case kindPR:
+		return p.doAssignSelfFor("PR", items[cursor].pr.Number)
+	default:
+		return p, nil
+	}
+}
+
+// doAssignSelfFor prepares a confirmation modal to assign the given issue or
+// PR to the current user.
+func (p *Panel) doAssignSelfFor(kind string, number int) (panels.Panel, tea.Cmd) {
+	if p.gh.client == nil || number == 0 {
+		return p, nil
+	}
+	p.clearPending()
+	p.pending = opAssignSelf
+	// Encode the kind and number for the modal handler.
+	p.pendingName = fmt.Sprintf("%s:%d", kind, number)
+	who := p.gh.user
+	if who == "" {
+		who = "yourself"
+	}
+	return p, notify.ShowConfirm(
+		fmt.Sprintf("Assign %s #%d", kind, number),
+		fmt.Sprintf("Assign this %s to %s?", kind, who),
+	)
+}
+
+// handleAssignSelfConfirm runs the async assignment after modal confirmation.
+// The pending name is "<kind>:<number>".
+func (p *Panel) handleAssignSelfConfirm(a modalArgs) (panels.Panel, tea.Cmd) {
+	kind, number, ok := parseAssignSelfName(a.name)
+	if !ok {
+		return p, nil
+	}
+	return p, p.assignSelfCmd(kind, number)
+}
+
+// parseAssignSelfName splits a "<kind>:<number>" pending name.
+func parseAssignSelfName(name string) (kind string, number int, ok bool) {
+	idx := strings.LastIndex(name, ":")
+	if idx <= 0 || idx == len(name)-1 {
+		return "", 0, false
+	}
+	n, err := strconv.Atoi(name[idx+1:])
+	if err != nil {
+		return "", 0, false
+	}
+	return name[:idx], n, true
+}
+
+// assignSelfCmd assigns the issue/PR to the current user asynchronously. If the
+// current user login is not cached, it is fetched first.
+func (p *Panel) assignSelfCmd(kind string, number int) tea.Cmd {
+	client := p.gh.client
+	owner, repo := p.gh.owner, p.gh.repo
+	ctx := p.ctx
+	login := p.gh.user
+	return func() tea.Msg {
+		who := login
+		if who == "" {
+			user, err := client.CurrentUser(ctx)
+			if err != nil {
+				return assignSelfResultMsg{kind: kind, number: number, err: err}
+			}
+			if user != nil && user.Login != nil {
+				who = *user.Login
+			}
+		}
+		if who == "" {
+			return assignSelfResultMsg{kind: kind, number: number, err: fmt.Errorf("could not determine current user")}
+		}
+		err := client.AddAssignees(ctx, owner, repo, number, []string{who})
+		return assignSelfResultMsg{kind: kind, number: number, login: who, err: err}
+	}
+}
+
+// handleAssignSelfResult processes the async result of an assign-to-me op.
+func (p *Panel) handleAssignSelfResult(msg assignSelfResultMsg) (panels.Panel, tea.Cmd) {
+	if msg.err != nil {
+		errStr := msg.err.Error()
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: fmt.Sprintf("Assign %s #%d failed: %s", msg.kind, msg.number, errStr),
+				Level:   notify.Error,
+			}
+		}
+	}
+	// Reflect assignment locally for issues (PR items do not display assignee).
+	if msg.kind == "issue" {
+		for i := range p.gh.allIssues {
+			if p.gh.allIssues[i].Number == msg.number {
+				p.gh.allIssues[i].Assignee = msg.login
+				break
+			}
+		}
+		for i := range p.tabItems[tabIssues] {
+			if p.tabItems[tabIssues][i].kind == kindIssue && p.tabItems[tabIssues][i].issue.Number == msg.number {
+				p.tabItems[tabIssues][i].issue.Assignee = msg.login
+				break
+			}
+		}
+	}
+	return p, tea.Batch(
+		func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: fmt.Sprintf("Assigned %s #%d to %s", msg.kind, msg.number, msg.login),
+				Level:   notify.Success,
+			}
+		},
+		p.loadGitHubData(),
 	)
 }
 

--- a/internal/panels/gitinfo/gitinfo_github.go
+++ b/internal/panels/gitinfo/gitinfo_github.go
@@ -1809,9 +1809,9 @@ func (p *Panel) doAssignSelf() (panels.Panel, tea.Cmd) {
 	}
 	switch items[cursor].kind { //nolint:exhaustive // only issues and PRs are assignable
 	case kindIssue:
-		return p.doAssignSelfFor("issue", items[cursor].issue.Number)
+		return p.doAssignSelfFor(assignKindIssue, items[cursor].issue.Number)
 	case kindPR:
-		return p.doAssignSelfFor("PR", items[cursor].pr.Number)
+		return p.doAssignSelfFor(assignKindPR, items[cursor].pr.Number)
 	default:
 		return p, nil
 	}
@@ -1898,7 +1898,7 @@ func (p *Panel) handleAssignSelfResult(msg assignSelfResultMsg) (panels.Panel, t
 		}
 	}
 	// Reflect assignment locally for issues (PR items do not display assignee).
-	if msg.kind == "issue" {
+	if msg.kind == assignKindIssue {
 		for i := range p.gh.allIssues {
 			if p.gh.allIssues[i].Number == msg.number {
 				p.gh.allIssues[i].Assignee = msg.login

--- a/internal/panels/gitinfo/gitinfo_test.go
+++ b/internal/panels/gitinfo/gitinfo_test.go
@@ -2527,6 +2527,7 @@ func (m *mockGHClientFull) ReopenIssue(_ context.Context, _, _ string, _ int) er
 func (m *mockGHClientFull) AddAssignees(_ context.Context, _, _ string, _ int, _ []string) error {
 	return m.addAssigneesErr
 }
+
 func (m *mockGHClientFull) ListPRs(_ context.Context, _, _ string, _ *gh.PullRequestListOptions) ([]*gh.PullRequest, error) {
 	return m.prs, m.prsErr
 }

--- a/internal/panels/gitinfo/gitinfo_test.go
+++ b/internal/panels/gitinfo/gitinfo_test.go
@@ -2472,26 +2472,27 @@ func TestRenderStashEntry_VeryNarrow(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 type mockGHClientFull struct {
-	user       *gh.User
-	userErr    error
-	issues     []*gh.Issue
-	issuesErr  error
-	prs        []*gh.PullRequest
-	prsErr     error
-	runs       []*gh.WorkflowRun
-	runsErr    error
-	prFiles    []*gh.CommitFile
-	prFilesErr error
-	prCommits  []*gh.RepositoryCommit
-	prCommErr  error
-	jobs       []*gh.WorkflowJob
-	jobsErr    error
-	jobLog     string
-	jobLogErr  error
-	rerunErr   error
-	cancelErr  error
-	mergeErr   error
-	getPRCalls int
+	user            *gh.User
+	userErr         error
+	issues          []*gh.Issue
+	issuesErr       error
+	prs             []*gh.PullRequest
+	prsErr          error
+	runs            []*gh.WorkflowRun
+	runsErr         error
+	prFiles         []*gh.CommitFile
+	prFilesErr      error
+	prCommits       []*gh.RepositoryCommit
+	prCommErr       error
+	jobs            []*gh.WorkflowJob
+	jobsErr         error
+	jobLog          string
+	jobLogErr       error
+	rerunErr        error
+	cancelErr       error
+	mergeErr        error
+	getPRCalls      int
+	addAssigneesErr error
 }
 
 func (m *mockGHClientFull) CurrentUser(_ context.Context) (*gh.User, error) {
@@ -2523,6 +2524,9 @@ func (m *mockGHClientFull) CommentOnIssue(_ context.Context, _, _ string, _ int,
 }
 func (m *mockGHClientFull) CloseIssue(_ context.Context, _, _ string, _ int) error  { return nil }
 func (m *mockGHClientFull) ReopenIssue(_ context.Context, _, _ string, _ int) error { return nil }
+func (m *mockGHClientFull) AddAssignees(_ context.Context, _, _ string, _ int, _ []string) error {
+	return m.addAssigneesErr
+}
 func (m *mockGHClientFull) ListPRs(_ context.Context, _, _ string, _ *gh.PullRequestListOptions) ([]*gh.PullRequest, error) {
 	return m.prs, m.prsErr
 }


### PR DESCRIPTION
Adds an `assign to me` action to the Issues and PRs tabs.

## What
- Press `A` on the Issues or PRs tab to assign the item under the cursor to the current user.
- Same action is available from the right-click action menu on issues and PRs.
- Uses the additive `AddAssignees` API, so any existing assignees are preserved.
- Issue rows show the new assignee right away; both tabs reload from GitHub after the write.

## Why
Triaging from the terminal meant leaving grut to grab an issue or PR. This closes that gap so you can claim work without a context switch.

## How
- New `ActionAssignSelf` in the action registry for both `ItemIssue` and `ItemPR`.
- New `AddAssignees` method on the GitHub client (and interface).
- Key `A` wired in the gitinfo panel, guarded to the Issues/PRs tabs when a GitHub client is present.
- Confirmation modal before the write, then an async command that resolves the current login (cached, or fetched) and posts the assignment.

## Tests
- Registry coverage for the new action on issues and PRs.
- Parse, guard, key-handling, modal-confirm, result, and command tests in the gitinfo package.
- `go build ./...` and `go test ./...` pass.

Closes #259