### PR TITLE
feat(gitinfo): filter Issues and PRs by state (open/closed/all)

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -135,6 +135,7 @@ GitHub panel (panel 3).
 | `o` | Open in browser |
 | `y` | Copy to clipboard |
 | `m` | Merge PR (PRs tab) |
+| `S` | Cycle state filter open/closed/all (Issues/PRs tab) |
 | `r` | Rerun (Actions tab) |
 | `x` | Cancel (Actions tab) |
 | `D` | Dispatch workflow |

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -115,6 +115,7 @@
         { "key": "o", "action": "Open in browser" },
         { "key": "y", "action": "Copy to clipboard" },
         { "key": "m", "action": "Merge PR (PRs tab)" },
+        { "key": "S", "action": "Cycle state filter open/closed/all (Issues/PRs tab)" },
         { "key": "r", "action": "Rerun (Actions tab)" },
         { "key": "x", "action": "Cancel (Actions tab)" },
         { "key": "D", "action": "Dispatch workflow" }

--- a/internal/panels/gitinfo/gitinfo.go
+++ b/internal/panels/gitinfo/gitinfo.go
@@ -304,6 +304,8 @@ type githubState struct {
 	cfg         config.GitHubConfig
 	issueFilter IssueFilterKind
 	prFilter    PRFilterKind
+	issueState  stateFilterKind
+	prState     stateFilterKind
 	repoPrivate bool
 	pageSize    int
 }
@@ -874,6 +876,7 @@ func (p *Panel) KeyBindings() []panels.KeyBinding {
 			panels.KeyBinding{Key: "a", Description: "Actions tab", Action: "tab_actions"},
 			panels.KeyBinding{Key: "W", Description: "Workflows tab", Action: "tab_workflows"},
 			panels.KeyBinding{Key: "L", Description: "Releases tab", Action: "tab_releases"},
+			panels.KeyBinding{Key: "S", Description: "Cycle state filter (Issues/PRs tab)", Action: "cycle_state_filter"},
 		)
 	}
 	return bindings
@@ -1158,6 +1161,17 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 			return p.cyclePRFilter()
 		default:
 			return p.doFetch()
+		}
+	case "S":
+		switch p.activeTab {
+		case tabIssues:
+			if p.gh.client != nil {
+				return p.cycleIssueStateFilter()
+			}
+		case tabPRs:
+			if p.gh.client != nil {
+				return p.cyclePRStateFilter()
+			}
 		}
 	case "g":
 		p.moveToFirst()
@@ -2361,9 +2375,15 @@ func (p *Panel) renderTabBar(width int) string {
 	if p.gh.issueFilter != issueFilterAll {
 		issuesCount = p.gh.issueFilter.String()
 	}
+	if p.gh.issueState != stateFilterOpen {
+		issuesCount = p.gh.issueState.String() + " " + issuesCount
+	}
 	prsCount := p.ghTabCountStr(tabPRs)
 	if p.gh.prFilter != prFilterAll {
 		prsCount = p.gh.prFilter.String()
+	}
+	if p.gh.prState != stateFilterOpen {
+		prsCount = p.gh.prState.String() + " " + prsCount
 	}
 	ghTabs := []tabDef{
 		{id: tabIssues, name: labelIssues, short: "Iss", count: issuesCount},

--- a/internal/panels/gitinfo/gitinfo.go
+++ b/internal/panels/gitinfo/gitinfo.go
@@ -1163,7 +1163,7 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 			return p.doFetch()
 		}
 	case "S":
-		switch p.activeTab {
+		switch p.activeTab { //nolint:exhaustive // only relevant cases handled
 		case tabIssues:
 			if p.gh.client != nil {
 				return p.cycleIssueStateFilter()

--- a/internal/panels/gitinfo/gitinfo_extra_test.go
+++ b/internal/panels/gitinfo/gitinfo_extra_test.go
@@ -1615,3 +1615,166 @@ func TestPRMessageTypes(t *testing.T) {
 	_ = panels.PRMergeFailedMsg{Number: 1, Err: errors.New("fail")}
 	_ = panels.PRMergedMsg{Number: 1, Strategy: "squash"}
 }
+
+// ---------------------------------------------------------------------------
+// State filter (#260): open / closed / all for Issues and PRs
+// ---------------------------------------------------------------------------
+
+func TestStateFilterKind_String(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "Open", stateFilterOpen.String())
+	assert.Equal(t, "Closed", stateFilterClosed.String())
+	assert.Equal(t, labelAll, stateFilterAll.String())
+}
+
+func TestStateFilterKind_APIValue(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "open", stateFilterOpen.apiValue())
+	assert.Equal(t, "closed", stateFilterClosed.apiValue())
+	assert.Equal(t, "all", stateFilterAll.apiValue())
+}
+
+func TestCycleIssueStateFilter_CyclesAndReloads(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.gh.pageSize = 30
+	p.ctx = t.Context()
+	// Seed some state that should be reset on cycle.
+	p.gh.allIssues = []ghIssueItem{{Number: 1}}
+	p.tabItems[tabIssues] = []listItem{{kind: kindIssue}}
+	p.tabCursor[tabIssues] = 3
+	p.tabOffset[tabIssues] = 2
+
+	_, cmd := p.cycleIssueStateFilter()
+	assert.Equal(t, stateFilterClosed, p.gh.issueState)
+	assert.Nil(t, p.gh.allIssues, "cached issues should be cleared for a fresh fetch")
+	assert.Equal(t, 0, p.tabCursor[tabIssues])
+	assert.Equal(t, 0, p.tabOffset[tabIssues])
+	assert.True(t, p.tabPaging[tabIssues].loading)
+	assert.NotNil(t, cmd, "should return a reload command")
+
+	_, _ = p.cycleIssueStateFilter()
+	assert.Equal(t, stateFilterAll, p.gh.issueState)
+	_, _ = p.cycleIssueStateFilter()
+	assert.Equal(t, stateFilterOpen, p.gh.issueState, "should wrap back to open")
+}
+
+func TestCyclePRStateFilter_CyclesAndReloads(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = &mockGHClientFull{}
+	p.gh.pageSize = 30
+	p.ctx = t.Context()
+	p.gh.allPRs = []ghPRItem{{Number: 1}}
+	p.tabItems[tabPRs] = []listItem{{kind: kindPR}}
+	p.tabCursor[tabPRs] = 4
+	p.tabOffset[tabPRs] = 1
+
+	_, cmd := p.cyclePRStateFilter()
+	assert.Equal(t, stateFilterClosed, p.gh.prState)
+	assert.Nil(t, p.gh.allPRs)
+	assert.Equal(t, 0, p.tabCursor[tabPRs])
+	assert.Equal(t, 0, p.tabOffset[tabPRs])
+	assert.True(t, p.tabPaging[tabPRs].loading)
+	assert.NotNil(t, cmd)
+
+	_, _ = p.cyclePRStateFilter()
+	assert.Equal(t, stateFilterAll, p.gh.prState)
+	_, _ = p.cyclePRStateFilter()
+	assert.Equal(t, stateFilterOpen, p.gh.prState)
+}
+
+func TestCycleStateFilter_NoGHClient(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	// client nil
+	_, cmd := p.cycleIssueStateFilter()
+	assert.Nil(t, cmd)
+	assert.Equal(t, stateFilterOpen, p.gh.issueState)
+	_, cmd = p.cyclePRStateFilter()
+	assert.Nil(t, cmd)
+	assert.Equal(t, stateFilterOpen, p.gh.prState)
+}
+
+func TestLoadIssuesPage_UsesStateFilter(t *testing.T) {
+	t.Parallel()
+	mock := &mockGHClientFull{}
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = mock
+	p.gh.pageSize = 30
+	p.ctx = t.Context()
+	p.gh.issueState = stateFilterClosed
+
+	cmd := p.loadIssuesPage(1, true)
+	_ = cmd()
+	assert.NotNil(t, mock.lastIssuesOpts)
+	assert.Equal(t, "closed", mock.lastIssuesOpts.State)
+}
+
+func TestLoadPRsPage_UsesStateFilter(t *testing.T) {
+	t.Parallel()
+	mock := &mockGHClientFull{}
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = mock
+	p.gh.pageSize = 30
+	p.ctx = t.Context()
+	p.gh.prState = stateFilterAll
+
+	cmd := p.loadPRsPage(1, true)
+	_ = cmd()
+	assert.NotNil(t, mock.lastPRsOpts)
+	assert.Equal(t, "all", mock.lastPRsOpts.State)
+}
+
+func TestHandleKey_S_IssuesTab(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.gh.client = &mockGHClientFull{}
+	p.gh.pageSize = 30
+	p.ctx = t.Context()
+	p.activeTab = tabIssues
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: 'S', Text: "S"})
+	assert.NotNil(t, cmd, "pressing 'S' on Issues tab should reload")
+	assert.Equal(t, stateFilterClosed, p.gh.issueState)
+}
+
+func TestHandleKey_S_PRsTab(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.gh.client = &mockGHClientFull{}
+	p.gh.pageSize = 30
+	p.ctx = t.Context()
+	p.activeTab = tabPRs
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: 'S', Text: "S"})
+	assert.NotNil(t, cmd, "pressing 'S' on PRs tab should reload")
+	assert.Equal(t, stateFilterClosed, p.gh.prState)
+}
+
+func TestHandleKey_S_OtherTab(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.gh.client = &mockGHClientFull{}
+	p.activeTab = tabActions
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: 'S', Text: "S"})
+	assert.Nil(t, cmd, "pressing 'S' outside Issues/PRs should be a no-op")
+	assert.Equal(t, stateFilterOpen, p.gh.issueState)
+}
+
+func TestHandleKey_S_NoGHClient(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.Focused = true
+	p.activeTab = tabIssues
+	// client nil
+
+	_, cmd := p.handleKey(tea.KeyPressMsg{Code: 'S', Text: "S"})
+	assert.Nil(t, cmd)
+	assert.Equal(t, stateFilterOpen, p.gh.issueState)
+}

--- a/internal/panels/gitinfo/gitinfo_github.go
+++ b/internal/panels/gitinfo/gitinfo_github.go
@@ -269,7 +269,7 @@ func (s stateFilterKind) String() string {
 func (s stateFilterKind) apiValue() string {
 	switch s {
 	case stateFilterClosed:
-		return "closed"
+		return stateClosed
 	case stateFilterAll:
 		return "all"
 	default:

--- a/internal/panels/gitinfo/gitinfo_github.go
+++ b/internal/panels/gitinfo/gitinfo_github.go
@@ -242,6 +242,41 @@ func (f PRFilterKind) String() string {
 	}
 }
 
+// stateFilterKind identifies which item states (open/closed/all) are fetched
+// for the Issues and PRs tabs. Unlike the client-side quick-filters, this
+// controls the server-side State parameter, so closed and merged items are
+// only fetched when the filter allows it.
+type stateFilterKind int
+
+const (
+	stateFilterOpen stateFilterKind = iota
+	stateFilterClosed
+	stateFilterAll
+)
+
+func (s stateFilterKind) String() string {
+	switch s {
+	case stateFilterClosed:
+		return "Closed"
+	case stateFilterAll:
+		return labelAll
+	default:
+		return "Open"
+	}
+}
+
+// apiValue returns the value passed to the GitHub API State parameter.
+func (s stateFilterKind) apiValue() string {
+	switch s {
+	case stateFilterClosed:
+		return "closed"
+	case stateFilterAll:
+		return "all"
+	default:
+		return prStateOpen
+	}
+}
+
 // ghDataLoadedMsg carries the result of an async GitHub data load.
 type ghDataLoadedMsg struct {
 	err         error
@@ -661,9 +696,10 @@ func (p *Panel) loadIssuesPage(page int, replace bool) tea.Cmd {
 	owner, repo := p.gh.owner, p.gh.repo
 	ctx := p.ctx
 	pageSize := p.gh.pageSize
+	state := p.gh.issueState.apiValue()
 	return func() tea.Msg {
 		issues, pr, err := client.ListIssuesPage(ctx, owner, repo, &gh.IssueListByRepoOptions{
-			State:       prStateOpen,
+			State:       state,
 			ListOptions: gh.ListOptions{Page: page, PerPage: pageSize},
 		})
 		if err != nil {
@@ -713,9 +749,10 @@ func (p *Panel) loadPRsPage(page int, replace bool) tea.Cmd {
 	owner, repo := p.gh.owner, p.gh.repo
 	ctx := p.ctx
 	pageSize := p.gh.pageSize
+	state := p.gh.prState.apiValue()
 	return func() tea.Msg {
 		prs, pr, err := client.ListPRsPage(ctx, owner, repo, &gh.PullRequestListOptions{
-			State:       prStateOpen,
+			State:       state,
 			ListOptions: gh.ListOptions{Page: page, PerPage: pageSize},
 		})
 		if err != nil {
@@ -1123,6 +1160,36 @@ func (p *Panel) cyclePRFilter() (panels.Panel, tea.Cmd) {
 			Filter: filter,
 		}
 	}
+}
+
+// cycleIssueStateFilter advances the Issues state filter (open -> closed ->
+// all) and reloads from GitHub, since closed issues are not held locally.
+func (p *Panel) cycleIssueStateFilter() (panels.Panel, tea.Cmd) {
+	if p.gh.client == nil {
+		return p, nil
+	}
+	p.gh.issueState = (p.gh.issueState + 1) % 3
+	p.gh.allIssues = nil
+	p.tabItems[tabIssues] = nil
+	p.tabCursor[tabIssues] = 0
+	p.tabOffset[tabIssues] = 0
+	p.tabPaging[tabIssues] = tabPagination{loading: true, nextPage: 1}
+	return p, p.loadIssuesPage(1, true)
+}
+
+// cyclePRStateFilter advances the PRs state filter (open -> closed -> all) and
+// reloads from GitHub, since closed and merged PRs are not held locally.
+func (p *Panel) cyclePRStateFilter() (panels.Panel, tea.Cmd) {
+	if p.gh.client == nil {
+		return p, nil
+	}
+	p.gh.prState = (p.gh.prState + 1) % 3
+	p.gh.allPRs = nil
+	p.tabItems[tabPRs] = nil
+	p.tabCursor[tabPRs] = 0
+	p.tabOffset[tabPRs] = 0
+	p.tabPaging[tabPRs] = tabPagination{loading: true, nextPage: 1}
+	return p, p.loadPRsPage(1, true)
 }
 
 func (p *Panel) applyIssueFilter() {

--- a/internal/panels/gitinfo/gitinfo_test.go
+++ b/internal/panels/gitinfo/gitinfo_test.go
@@ -2492,6 +2492,9 @@ type mockGHClientFull struct {
 	cancelErr  error
 	mergeErr   error
 	getPRCalls int
+
+	lastIssuesOpts *gh.IssueListByRepoOptions
+	lastPRsOpts    *gh.PullRequestListOptions
 }
 
 func (m *mockGHClientFull) CurrentUser(_ context.Context) (*gh.User, error) {
@@ -2636,11 +2639,13 @@ func (m *mockGHClientFull) GetReleaseByTag(_ context.Context, _, _, _ string) (*
 	return nil, nil
 }
 
-func (m *mockGHClientFull) ListIssuesPage(_ context.Context, _, _ string, _ *gh.IssueListByRepoOptions) ([]*gh.Issue, ghclient.PageResult, error) {
+func (m *mockGHClientFull) ListIssuesPage(_ context.Context, _, _ string, opts *gh.IssueListByRepoOptions) ([]*gh.Issue, ghclient.PageResult, error) {
+	m.lastIssuesOpts = opts
 	return m.issues, ghclient.PageResult{}, m.issuesErr
 }
 
-func (m *mockGHClientFull) ListPRsPage(_ context.Context, _, _ string, _ *gh.PullRequestListOptions) ([]*gh.PullRequest, ghclient.PageResult, error) {
+func (m *mockGHClientFull) ListPRsPage(_ context.Context, _, _ string, opts *gh.PullRequestListOptions) ([]*gh.PullRequest, ghclient.PageResult, error) {
+	m.lastPRsOpts = opts
 	return m.prs, ghclient.PageResult{}, m.prsErr
 }
 


### PR DESCRIPTION
Adds a state filter to the Issues and PRs tabs so you can look at closed and merged work, not just open items.

## What
- Press `S` on the Issues or PRs tab to cycle the state filter: open -> closed -> all.
- The active state shows in the tab header (for example `Closed 12`).
- The filter controls the GitHub API `State` parameter, so closed issues and merged PRs are fetched on demand rather than being filtered out after the fact.
- Cycling resets paging and reloads page one for the active tab.

## Why
The Issues and PRs tabs only ever fetched open items, so there was no way to review closed issues or merged PRs from grut. The existing `f` quick-filter is client-side over the open set, which cannot surface anything the API never returned.

## How
- New `stateFilterKind` enum (open/closed/all) with `String` and `apiValue` helpers.
- Per-tab `issueState` and `prState` fields on the GitHub panel state.
- `loadIssuesPage` and `loadPRsPage` now send the selected state instead of a hardcoded `open`.
- New `S` key wired in the gitinfo panel, guarded to the Issues/PRs tabs when a GitHub client is present.

## Tests
- Enum `String`/`apiValue` coverage.
- Cycle, reset, wrap-around, and no-client guard tests for both tabs.
- Load-page tests that assert the state threads into the API options.
- Key-handling tests for `S` on Issues, PRs, other tabs, and with no client.
- `go build ./...`, `go vet ./...`, and `go test ./...` pass.

Closes #260