### PR TITLE
deps: upgrade all dependencies to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jongio/grut
 go 1.26.4
 
 require (
-	charm.land/bubbles/v2 v2.1.0
+	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-charm.land/bubbles/v2 v2.1.0 h1:YSnNh5cPYlYjPxRrzs5VEn3vwhtEn3jVGRBT3M7/I0g=
-charm.land/bubbles/v2 v2.1.0/go.mod h1:l97h4hym2hvWBVfmJDtrEHHCtkIKeTEb3TTJ4ZOB3wY=
+charm.land/bubbles/v2 v2.1.1 h1:7r55WzBxpo/R3z98hGmY7KKPd3ET6vsf0Fb9sDHOV60=
+charm.land/bubbles/v2 v2.1.1/go.mod h1:GE6M31gaWZVXzGw73OeuTTgy4lX+OtkH0E5ymnNsHxo=
 charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
 charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/glamour/v2 v2.0.1 h1:xl+r00A4aJWU0z8fgwKd9fQQ4rsphqGUzuEiXZP5n+c=


### PR DESCRIPTION
Automated dependency upgrade run (devx `deps` workflow).

## Upgrades
- **charm.land/bubbles/v2** `v2.1.0` → `v2.1.1`
- `go mod tidy` refreshed `go.sum`

All other dependencies were already at latest (jongio/grut#247 upgraded them recently):
- **Go:** go-github v88, mcp-go, anthropic-sdk-go, chroma v2, bubbletea/lipgloss/glamour v2 — no stable major bumps available (go-github v89/v90 and go-toml v3 don't exist; chroma v3 is alpha-only).
- **web/** (`npm`): astro 7, typescript 6, @astrojs/check — `npm-check-updates` reports all at latest.
- **cmd/screenshots/** (`npm`): playwright, @xterm/* — all at latest.

The `internal/extension/templates/{mcp-node,mcp-python}` manifests are embedded scaffolding examples (not project build deps) and were intentionally left unchanged.

## Breaking changes handled
None — the bubbles patch bump required no code changes.

## Verification (local, all green)
- `go build ./...`
- `go vet ./...`
- `go test ./...` (full suite, all packages pass)
- `gofmt -l` / `gofumpt -l` clean
- `golangci-lint` v2.12.2 — 0 issues
- `mage deadcode` — OK
- `govulncheck ./...` — no vulnerabilities

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
