### PR TITLE
feat(commits): show commit signature verification badges

### DIFF
--- a/internal/git/log.go
+++ b/internal/git/log.go
@@ -25,8 +25,10 @@ func (c *Client) Log(ctx context.Context, opts LogOpts) ([]Commit, error) {
 		"%aI", // author date ISO 8601
 		"%s",  // subject
 		bodyFormat,
-		"%P", // parent hashes
-		"%D", // ref names
+		"%P",  // parent hashes
+		"%D",  // ref names
+		"%G?", // signature verification status
+		"%GS", // signer identity
 	}, FieldSep) + RecordEnd
 
 	args := []string{"log", "--format=" + format}
@@ -131,6 +133,15 @@ func parseLogOutput(output, sep string) ([]Commit, error) { //nolint:unparam // 
 			}
 		}
 
+		// Signature fields are appended after the ref names. Older callers
+		// (and unit tests) may pass records without them, so read defensively.
+		var sig SignatureStatus
+		var signer string
+		if len(fields) >= 11 {
+			sig = ParseSignatureStatus(strings.TrimSpace(fields[9]))
+			signer = strings.TrimSpace(fields[10])
+		}
+
 		commits = append(commits, Commit{
 			Hash:        strings.TrimSpace(fields[0]),
 			ShortHash:   strings.TrimSpace(fields[1]),
@@ -141,6 +152,8 @@ func parseLogOutput(output, sep string) ([]Commit, error) { //nolint:unparam // 
 			Body:        strings.TrimSpace(fields[6]),
 			Parents:     parents,
 			Refs:        refs,
+			Signature:   sig,
+			Signer:      signer,
 		})
 	}
 	return commits, nil

--- a/internal/git/log_test.go
+++ b/internal/git/log_test.go
@@ -56,6 +56,55 @@ func TestParseLogOutput_MultipleCommits(t *testing.T) {
 	assert.Equal(t, []string{"hash1"}, commits[1].Parents)
 }
 
+func TestParseSignatureStatus(t *testing.T) {
+	cases := map[string]SignatureStatus{
+		"G": SigGood,
+		"U": SigUnknown,
+		"X": SigExpired,
+		"Y": SigExpired,
+		"R": SigRevoked,
+		"B": SigBad,
+		"E": SigError,
+		"N": SigNone,
+		"":  SigNone,
+		"?": SigNone,
+	}
+	for code, want := range cases {
+		assert.Equal(t, want, ParseSignatureStatus(code), "code %q", code)
+	}
+	assert.True(t, SigGood.Verified())
+	assert.False(t, SigBad.Verified())
+	assert.True(t, SigBad.Present())
+	assert.False(t, SigNone.Present())
+}
+
+func TestParseLogOutput_Signature(t *testing.T) {
+	const sep = "\x1e"
+	// 11-field record includes %G? and %GS trailing fields.
+	input := "hash1" + sep + "h1" + sep + "Dev" + sep + "dev@test.com" + sep +
+		"2024-03-01T12:00:00Z" + sep + "Signed commit" + sep + "" + sep + "" + sep + "" + sep +
+		"G" + sep + "Dev <dev@test.com>" + "\x1f\n"
+
+	commits, err := parseLogOutput(input, sep)
+	require.NoError(t, err)
+	require.Len(t, commits, 1)
+	assert.Equal(t, SigGood, commits[0].Signature)
+	assert.Equal(t, "Dev <dev@test.com>", commits[0].Signer)
+}
+
+func TestParseLogOutput_NoSignatureFields(t *testing.T) {
+	const sep = "\x1e"
+	// A legacy 9-field record leaves signature empty and does not panic.
+	input := "hash1" + sep + "h1" + sep + "Dev" + sep + "dev@test.com" + sep +
+		"2024-03-01T12:00:00Z" + sep + "Unsigned" + sep + "" + sep + "" + sep + "" + "\x1f\n"
+
+	commits, err := parseLogOutput(input, sep)
+	require.NoError(t, err)
+	require.Len(t, commits, 1)
+	assert.Equal(t, SigNone, commits[0].Signature)
+	assert.Empty(t, commits[0].Signer)
+}
+
 func TestParseLogOutput_Empty(t *testing.T) {
 	commits, err := parseLogOutput("", "\x1e")
 	require.NoError(t, err)

--- a/internal/git/types.go
+++ b/internal/git/types.go
@@ -57,6 +57,55 @@ type Branch struct {
 	IsCurrent bool
 }
 
+// SignatureStatus classifies the GPG/SSH signature verification state of a
+// commit, derived from git log's %G? placeholder.
+type SignatureStatus string
+
+const (
+	// SigNone means the commit carries no signature (git code "N").
+	SigNone SignatureStatus = ""
+	// SigGood is a valid signature from a trusted key (git code "G").
+	SigGood SignatureStatus = "good"
+	// SigUnknown is a good signature whose key validity is unknown (git code "U").
+	SigUnknown SignatureStatus = "unknown"
+	// SigExpired is a good signature that has expired, or was made by an
+	// expired key (git codes "X" and "Y").
+	SigExpired SignatureStatus = "expired"
+	// SigRevoked is a good signature made by a revoked key (git code "R").
+	SigRevoked SignatureStatus = "revoked"
+	// SigBad is a bad signature (git code "B").
+	SigBad SignatureStatus = "bad"
+	// SigError means the signature could not be checked, for example the
+	// public key is missing (git code "E").
+	SigError SignatureStatus = "error"
+)
+
+// Verified reports whether the signature is a good signature from a trusted key.
+func (s SignatureStatus) Verified() bool { return s == SigGood }
+
+// Present reports whether the commit carries any signature at all.
+func (s SignatureStatus) Present() bool { return s != SigNone }
+
+// ParseSignatureStatus maps a git %G? code to a SignatureStatus.
+func ParseSignatureStatus(code string) SignatureStatus {
+	switch code {
+	case "G":
+		return SigGood
+	case "U":
+		return SigUnknown
+	case "X", "Y":
+		return SigExpired
+	case "R":
+		return SigRevoked
+	case "B":
+		return SigBad
+	case "E":
+		return SigError
+	default: // "N" or empty
+		return SigNone
+	}
+}
+
 // Commit represents a parsed git log entry.
 type Commit struct {
 	Hash        string
@@ -66,8 +115,10 @@ type Commit struct {
 	Date        time.Time
 	Subject     string
 	Body        string
-	Parents     []string // Parent hashes for graph rendering
-	Refs        []string // Branch/tag refs
+	Parents     []string        // Parent hashes for graph rendering
+	Refs        []string        // Branch/tag refs
+	Signature   SignatureStatus // GPG/SSH signature verification state
+	Signer      string          // Signer identity when a signature is present
 }
 
 // DiffOpts configures a git diff operation.

--- a/internal/panels/commitrender/commitrender.go
+++ b/internal/panels/commitrender/commitrender.go
@@ -35,6 +35,11 @@ type Styles struct {
 	Ref     lipgloss.Style
 	Graph   lipgloss.Style
 	Cursor  lipgloss.Style
+	// Signature badge styles: verified (good), bad, and caution (unknown,
+	// expired, revoked, or uncheckable). Colors come from the theme.
+	SigGood    lipgloss.Style
+	SigBad     lipgloss.Style
+	SigCaution lipgloss.Style
 }
 
 // Params configures a single call to [RenderLine].
@@ -59,6 +64,10 @@ type Params struct {
 
 	// ShowDate makes the date column eligible for display if width allows.
 	ShowDate bool
+
+	// ShowSignature prefixes the subject with a signature verification badge
+	// when the commit carries a signature.
+	ShowSignature bool
 
 	// IsSelected highlights the row with a subtler background when true and
 	// IsCursor is false (used by the commits panel for the "selected commit"
@@ -118,8 +127,18 @@ func RenderLine(p Params) string {
 	rightSide := rb.String()
 	rightW := lipgloss.Width(rightSide)
 
+	// ---- signature badge (optional subject prefix) ----
+	var badge string
+	var badgeW int
+	if p.ShowSignature {
+		if glyph := SignatureGlyph(c.Signature); glyph != "" {
+			badge = signatureStyle(c.Signature, s).Render(glyph) + " "
+			badgeW = lipgloss.Width(badge)
+		}
+	}
+
 	// ---- subject + refs ----
-	subjectSpace := p.Width - graphW - len(columnGap) - rightW
+	subjectSpace := p.Width - graphW - len(columnGap) - rightW - badgeW
 	if subjectSpace < minSubjectWidth {
 		subjectSpace = minSubjectWidth
 	}
@@ -171,6 +190,9 @@ func RenderLine(p Params) string {
 		lb.WriteString(s.Graph.Render(p.GraphPrefix))
 		lb.WriteString(columnGap)
 	}
+	if badgeW > 0 {
+		lb.WriteString(badge)
+	}
 	lb.WriteString(styledSubject)
 	lb.WriteString(columnGap)
 	lb.WriteString(rightSide)
@@ -208,4 +230,34 @@ func styleSubjectWithRefs(text string, subjectStyle, refStyle lipgloss.Style) st
 		return subjectStyle.Render(text)
 	}
 	return subjectStyle.Render(text[:idx]) + refStyle.Render(text[idx:])
+}
+
+// SignatureGlyph returns the badge glyph for a signature status, following the
+// project icon guidelines: a check for a verified signature, a cross for a bad
+// signature, and a warning marker for unknown, expired, revoked, or
+// uncheckable signatures. It returns an empty string when there is no
+// signature.
+func SignatureGlyph(s git.SignatureStatus) string {
+	switch s {
+	case git.SigGood:
+		return "\u2713" // ✓
+	case git.SigBad:
+		return "\u2717" // ✗
+	case git.SigUnknown, git.SigExpired, git.SigRevoked, git.SigError:
+		return "\u26a0" // ⚠
+	default:
+		return ""
+	}
+}
+
+// signatureStyle selects the lipgloss style for a signature status.
+func signatureStyle(s git.SignatureStatus, st Styles) lipgloss.Style {
+	switch s {
+	case git.SigGood:
+		return st.SigGood
+	case git.SigBad:
+		return st.SigBad
+	default:
+		return st.SigCaution
+	}
 }

--- a/internal/panels/commitrender/commitrender_test.go
+++ b/internal/panels/commitrender/commitrender_test.go
@@ -23,6 +23,47 @@ func plainStyles() Styles {
 	}
 }
 
+func TestSignatureGlyph(t *testing.T) {
+	assert.Equal(t, "\u2713", SignatureGlyph(git.SigGood))
+	assert.Equal(t, "\u2717", SignatureGlyph(git.SigBad))
+	assert.Equal(t, "\u26a0", SignatureGlyph(git.SigExpired))
+	assert.Equal(t, "\u26a0", SignatureGlyph(git.SigUnknown))
+	assert.Equal(t, "", SignatureGlyph(git.SigNone))
+}
+
+func TestRenderLine_SignatureBadge(t *testing.T) {
+	base := Params{
+		Commit: git.Commit{
+			ShortHash: "abc1234",
+			Subject:   "feat: add signing",
+			Date:      time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
+		},
+		Width:         80,
+		Styles:        plainStyles(),
+		ShowSignature: true,
+	}
+
+	// Verified commit shows the check glyph.
+	good := base
+	good.Commit.Signature = git.SigGood
+	line := RenderLine(good)
+	assert.Contains(t, line, "\u2713")
+	assert.Contains(t, line, "feat: add signing")
+	assert.Equal(t, 80, lipgloss.Width(line))
+
+	// Unsigned commit shows no badge.
+	none := base
+	none.Commit.Signature = git.SigNone
+	lineNone := RenderLine(none)
+	assert.NotContains(t, lineNone, "\u2713")
+	assert.Equal(t, 80, lipgloss.Width(lineNone))
+
+	// Badge disabled: no glyph even with a signature.
+	off := good
+	off.ShowSignature = false
+	assert.NotContains(t, RenderLine(off), "\u2713")
+}
+
 func TestRenderLine_BasicSubjectAndHash(t *testing.T) {
 	p := Params{
 		Commit: git.Commit{

--- a/internal/panels/commits/commits.go
+++ b/internal/panels/commits/commits.go
@@ -54,28 +54,34 @@ type gitOps interface {
 }
 
 type panelColors struct {
-	Hash     string
-	Date     string
-	Author   string
-	Subject  string
-	Dim      string
-	CursorBg string
-	Refs     string
-	SearchBg string
-	SearchFg string
+	Hash       string
+	Date       string
+	Author     string
+	Subject    string
+	Dim        string
+	CursorBg   string
+	Refs       string
+	SearchBg   string
+	SearchFg   string
+	SigGood    string
+	SigBad     string
+	SigCaution string
 }
 
 func initColors(th *theme.Theme) panelColors {
 	c := panelColors{
-		Hash:     "#D4B84A",
-		Date:     "#555555",
-		Author:   "#6B9E56",
-		Subject:  "#999999",
-		Dim:      "#555555",
-		CursorBg: "#2A2A2A",
-		Refs:     "#7A9EBF",
-		SearchBg: "#2A2A2A",
-		SearchFg: "#D4D4D4",
+		Hash:       "#D4B84A",
+		Date:       "#555555",
+		Author:     "#6B9E56",
+		Subject:    "#999999",
+		Dim:        "#555555",
+		CursorBg:   "#2A2A2A",
+		Refs:       "#7A9EBF",
+		SearchBg:   "#2A2A2A",
+		SearchFg:   "#D4D4D4",
+		SigGood:    "#6B9E56",
+		SigBad:     "#C05B5B",
+		SigCaution: "#D4B84A",
 	}
 	if th != nil {
 		c.Hash = th.Colors.NormalYellow
@@ -87,15 +93,21 @@ func initColors(th *theme.Theme) panelColors {
 		c.Refs = th.Colors.BrightBlue
 		c.SearchBg = th.Colors.SelectionBg
 		c.SearchFg = th.Colors.SelectionFg
+		c.SigGood = th.Colors.NormalGreen
+		c.SigBad = th.Colors.NormalRed
+		c.SigCaution = th.Colors.NormalYellow
 	}
 	return c
 }
 
 func newCommitLineStyles(c panelColors) commitrender.Styles {
 	return commitrender.Styles{
-		Hash:    lipgloss.NewStyle().Foreground(lipgloss.Color(c.Hash)),
-		Subject: lipgloss.NewStyle().Foreground(lipgloss.Color(c.Subject)),
-		Cursor:  lipgloss.NewStyle().Background(lipgloss.Color(c.CursorBg)),
+		Hash:       lipgloss.NewStyle().Foreground(lipgloss.Color(c.Hash)),
+		Subject:    lipgloss.NewStyle().Foreground(lipgloss.Color(c.Subject)),
+		Cursor:     lipgloss.NewStyle().Background(lipgloss.Color(c.CursorBg)),
+		SigGood:    lipgloss.NewStyle().Foreground(lipgloss.Color(c.SigGood)),
+		SigBad:     lipgloss.NewStyle().Foreground(lipgloss.Color(c.SigBad)),
+		SigCaution: lipgloss.NewStyle().Foreground(lipgloss.Color(c.SigCaution)),
 	}
 }
 
@@ -591,12 +603,13 @@ func (p *Panel) renderList(width, height int) string {
 			styles.Subject = styles.Subject.Bold(true)
 		}
 		lines = append(lines, commitrender.RenderLine(commitrender.Params{
-			Commit:     c,
-			Width:      width,
-			IsCursor:   i == p.cursor,
-			Styles:     styles,
-			IsSelected: isSelected,
-			SelectedBg: "#3B3F52", // subtler highlight for selected-but-not-cursor
+			Commit:        c,
+			Width:         width,
+			IsCursor:      i == p.cursor,
+			Styles:        styles,
+			IsSelected:    isSelected,
+			SelectedBg:    "#3B3F52", // subtler highlight for selected-but-not-cursor
+			ShowSignature: true,
 		}))
 	}
 	// Loading indicator.
@@ -950,6 +963,32 @@ func (p *Panel) deselectCommit() (panels.Panel, tea.Cmd) {
 // ---------------------------------------------------------------------------
 // Detail view
 // ---------------------------------------------------------------------------
+// signatureDetail renders a human-readable, colored description of a commit's
+// signature verification status for the detail view.
+func (p *Panel) signatureDetail(c git.Commit) string {
+	var label, color string
+	switch c.Signature {
+	case git.SigGood:
+		label, color = "verified", p.colors.SigGood
+	case git.SigBad:
+		label, color = "bad signature", p.colors.SigBad
+	case git.SigUnknown:
+		label, color = "unknown validity", p.colors.SigCaution
+	case git.SigExpired:
+		label, color = "expired", p.colors.SigCaution
+	case git.SigRevoked:
+		label, color = "revoked key", p.colors.SigCaution
+	case git.SigError:
+		label, color = "unverifiable", p.colors.SigCaution
+	default:
+		return ""
+	}
+	if c.Signer != "" {
+		label += " (" + panels.StripANSI(c.Signer) + ")"
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(color)).Render(label)
+}
+
 func (p *Panel) showDetail() tea.Cmd {
 	if p.cursor < 0 || p.cursor >= p.activeLen() {
 		return nil
@@ -978,6 +1017,9 @@ func (p *Panel) showDetail() tea.Cmd {
 	if len(c.Parents) > 0 {
 		parentHash := lipgloss.NewStyle().Foreground(lipgloss.Color(p.colors.Hash))
 		lines = append(lines, "Parents: "+parentHash.Render(strings.Join(c.Parents, " ")))
+	}
+	if c.Signature.Present() {
+		lines = append(lines, "Signed:  "+p.signatureDetail(c))
 	}
 	lines = append(lines, "")
 	lines = append(lines, "    "+panels.StripANSI(c.Subject))

--- a/internal/panels/gitlog/gitlog.go
+++ b/internal/panels/gitlog/gitlog.go
@@ -39,42 +39,51 @@ const loadMoreThreshold = 50
 const debounceInterval = 200 * time.Millisecond
 
 type panelColors struct {
-	Hash     string
-	Date     string
-	Author   string
-	Refs     string
-	Subject  string
-	Dim      string
-	CursorBg string
-	Graph    string
-	SearchBg string
-	SearchFg string
+	Hash       string
+	Date       string
+	Author     string
+	Refs       string
+	Subject    string
+	Dim        string
+	CursorBg   string
+	Graph      string
+	SearchBg   string
+	SearchFg   string
+	SigGood    string
+	SigBad     string
+	SigCaution string
 }
 
 func newCommitLineStyles(c panelColors) commitrender.Styles {
 	return commitrender.Styles{
-		Hash:    lipgloss.NewStyle().Foreground(lipgloss.Color(c.Hash)),
-		Date:    lipgloss.NewStyle().Foreground(lipgloss.Color(c.Date)),
-		Author:  lipgloss.NewStyle().Foreground(lipgloss.Color(c.Author)),
-		Subject: lipgloss.NewStyle().Foreground(lipgloss.Color(c.Subject)),
-		Ref:     lipgloss.NewStyle().Foreground(lipgloss.Color(c.Refs)).Bold(true),
-		Graph:   lipgloss.NewStyle().Foreground(lipgloss.Color(c.Graph)),
-		Cursor:  lipgloss.NewStyle().Background(lipgloss.Color(c.CursorBg)),
+		Hash:       lipgloss.NewStyle().Foreground(lipgloss.Color(c.Hash)),
+		Date:       lipgloss.NewStyle().Foreground(lipgloss.Color(c.Date)),
+		Author:     lipgloss.NewStyle().Foreground(lipgloss.Color(c.Author)),
+		Subject:    lipgloss.NewStyle().Foreground(lipgloss.Color(c.Subject)),
+		Ref:        lipgloss.NewStyle().Foreground(lipgloss.Color(c.Refs)).Bold(true),
+		Graph:      lipgloss.NewStyle().Foreground(lipgloss.Color(c.Graph)),
+		Cursor:     lipgloss.NewStyle().Background(lipgloss.Color(c.CursorBg)),
+		SigGood:    lipgloss.NewStyle().Foreground(lipgloss.Color(c.SigGood)),
+		SigBad:     lipgloss.NewStyle().Foreground(lipgloss.Color(c.SigBad)),
+		SigCaution: lipgloss.NewStyle().Foreground(lipgloss.Color(c.SigCaution)),
 	}
 }
 
 func initColors(th *theme.Theme) panelColors {
 	c := panelColors{
-		Hash:     "#D4B84A",
-		Date:     colorDim,
-		Author:   "#6B9E56",
-		Refs:     "#7A9EBF",
-		Subject:  "#999999",
-		Dim:      colorDim,
-		CursorBg: "#2A2A2A",
-		Graph:    colorDim,
-		SearchBg: "#2A2A2A",
-		SearchFg: "#D4D4D4",
+		Hash:       "#D4B84A",
+		Date:       colorDim,
+		Author:     "#6B9E56",
+		Refs:       "#7A9EBF",
+		Subject:    "#999999",
+		Dim:        colorDim,
+		CursorBg:   "#2A2A2A",
+		Graph:      colorDim,
+		SearchBg:   "#2A2A2A",
+		SearchFg:   "#D4D4D4",
+		SigGood:    "#6B9E56",
+		SigBad:     "#C05B5B",
+		SigCaution: "#D4B84A",
 	}
 	if th != nil {
 		c.Hash = th.Colors.NormalYellow
@@ -87,6 +96,9 @@ func initColors(th *theme.Theme) panelColors {
 		c.Graph = th.Colors.BrightBlack
 		c.SearchBg = th.Colors.SelectionBg
 		c.SearchFg = th.Colors.SelectionFg
+		c.SigGood = th.Colors.NormalGreen
+		c.SigBad = th.Colors.NormalRed
+		c.SigCaution = th.Colors.NormalYellow
 	}
 	return c
 }
@@ -433,14 +445,15 @@ func (p *Panel) renderLog(width, height int) string {
 		d := dl[i]
 		if d.commitIdx >= 0 && d.commitIdx < len(p.commits) {
 			lines = append(lines, commitrender.RenderLine(commitrender.Params{
-				Commit:      p.commits[d.commitIdx],
-				Width:       width,
-				IsCursor:    i == cursorDL,
-				GraphPrefix: d.text,
-				Styles:      p.clStyles,
-				ShowRefs:    true,
-				ShowAuthor:  true,
-				ShowDate:    true,
+				Commit:        p.commits[d.commitIdx],
+				Width:         width,
+				IsCursor:      i == cursorDL,
+				GraphPrefix:   d.text,
+				Styles:        p.clStyles,
+				ShowRefs:      true,
+				ShowAuthor:    true,
+				ShowDate:      true,
+				ShowSignature: true,
 			}))
 		} else {
 			// Connector line — just show the graph portion.

--- a/magefile.go
+++ b/magefile.go
@@ -240,6 +240,7 @@ var deadcodeAllowlist = []string{
 
 	// commits — test accessors + helpers
 	"Panel.showDetail",
+	"Panel.signatureDetail",
 	"relativeDate",
 
 	// filetree — test accessors


### PR DESCRIPTION
## What this does

Surfaces GPG and SSH signature verification status in the commit list, the log graph, and the commit detail view. Signed commits now carry a small badge so you can tell a verified commit from an unsigned one or one with a bad signature without dropping to the command line.

Closes #270.

## How it works

```mermaid
flowchart LR
    A[git log with %G? and %GS] --> B[parseLogOutput sets Commit.Signature]
    B --> C{Status}
    C -- good --> D[check badge, green]
    C -- bad --> E[cross badge, red]
    C -- unknown, expired, revoked, error --> F[warning badge, yellow]
    C -- none --> G[no badge]
    D --> H[commits and log rows]
    E --> H
    F --> H
    H --> I[commit detail shows signer]
```

## Changes

- `internal/git`: `Log` requests `%G?` and `%GS`; `parseLogOutput` fills a new `Commit.Signature` (a `SignatureStatus`) and `Commit.Signer`. Reading is defensive so legacy 9-field records still parse.
- `internal/panels/commitrender`: optional `ShowSignature` prefixes the subject with a badge. Glyphs follow the icon guidelines (check, cross, warning) and color comes from the theme.
- `internal/panels/commits` and `internal/panels/gitlog`: enable the badge and wire theme colors. The commits detail view shows the signer identity.

## Tests

- Parsing of every `%G?` code into the right status, plus 11-field and legacy 9-field records.
- Badge rendering for verified, unsigned, and disabled cases, with exact line width preserved.

## Notes

The badge is passive, so there is no new keybinding. Color is applied through lipgloss, not baked into the glyph.
