### PR TITLE
feat(commits): pickaxe content search (find commits by code changed)

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -154,6 +154,7 @@ Commits panel (panel 4).
 | `A` | Amend last commit |
 | `r` | Reword last commit |
 | `/` | Search commits |
+| `S` | Search commit content (pickaxe) |
 
 ---
 

--- a/internal/git/log.go
+++ b/internal/git/log.go
@@ -61,6 +61,18 @@ func (c *Client) Log(ctx context.Context, opts LogOpts) ([]Commit, error) {
 		}
 		args = append(args, "--grep="+opts.Grep)
 	}
+	if opts.Pickaxe != "" {
+		if err := ValidateArg(opts.Pickaxe); err != nil {
+			return nil, fmt.Errorf("log pickaxe: %w", err)
+		}
+		// Concatenated as a single argument (-S<term> / -G<term>) so the
+		// term can never be parsed as a separate option (CWE-88).
+		if opts.PickaxeRegex {
+			args = append(args, "-G"+opts.Pickaxe)
+		} else {
+			args = append(args, "-S"+opts.Pickaxe)
+		}
+	}
 	if opts.All {
 		args = append(args, "--all")
 	}

--- a/internal/git/log_pickaxe_test.go
+++ b/internal/git/log_pickaxe_test.go
@@ -1,0 +1,72 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLog_Pickaxe(t *testing.T) {
+	dir := initTestRepo(t)
+	ctx := context.Background()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = dir
+		cmd.Env = testGitEnv()
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+
+	const token = "ZZ_UNIQUE_TOKEN"
+
+	// Commit that introduces the token.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.go"),
+		[]byte("package main\n\nconst apiToken = \""+token+"\"\n"), 0o644))
+	run("add", ".")
+	run("commit", "-m", "add token")
+
+	// Commit that removes it.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.go"),
+		[]byte("package main\n"), 0o644))
+	run("add", ".")
+	run("commit", "-m", "remove token")
+
+	// Unrelated commit that never touches the token.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "other.txt"),
+		[]byte("hello\n"), 0o644))
+	run("add", ".")
+	run("commit", "-m", "other")
+
+	client, err := NewClient(dir)
+	require.NoError(t, err)
+
+	// -S finds only the commits that changed the occurrence count of the token.
+	got, err := client.Log(ctx, LogOpts{Pickaxe: token})
+	require.NoError(t, err)
+	subjects := make([]string, len(got))
+	for i, c := range got {
+		subjects[i] = c.Subject
+	}
+	assert.ElementsMatch(t, []string{"add token", "remove token"}, subjects)
+
+	// -G matches the diff against a regular expression.
+	gotG, err := client.Log(ctx, LogOpts{Pickaxe: "ZZ_.*_TOKEN", PickaxeRegex: true})
+	require.NoError(t, err)
+	assert.Len(t, gotG, 2)
+
+	// Scoping to an unrelated path yields no pickaxe matches.
+	gotScoped, err := client.Log(ctx, LogOpts{Pickaxe: token, Path: "other.txt"})
+	require.NoError(t, err)
+	assert.Empty(t, gotScoped)
+
+	// A term starting with a dash is rejected before reaching git.
+	_, err = client.Log(ctx, LogOpts{Pickaxe: "-x"})
+	require.Error(t, err)
+}

--- a/internal/git/types.go
+++ b/internal/git/types.go
@@ -121,17 +121,22 @@ type DiffLine struct {
 
 // LogOpts configures a git log operation.
 type LogOpts struct {
-	Since    string // Show commits after this date
-	Until    string // Show commits before this date
-	Author   string // Filter by author
-	Grep     string // Filter by commit message
-	Path     string // Filter by path
-	Ref      string // Starting ref (default HEAD)
-	MaxCount int    // Max number of commits to return
-	Skip     int    // Number of commits to skip (for pagination)
-	All      bool   // Show all refs
-	Graph    bool   // Include graph data
-	OmitBody bool   // Skip commit body text for list-only views
+	Since  string // Show commits after this date
+	Until  string // Show commits before this date
+	Author string // Filter by author
+	Grep   string // Filter by commit message
+	// Pickaxe narrows the log to commits that change the number of
+	// occurrences of this string (git -S), or, when PickaxeRegex is set,
+	// commits whose diff matches this expression (git -G).
+	Pickaxe      string
+	PickaxeRegex bool
+	Path         string // Filter by path
+	Ref          string // Starting ref (default HEAD)
+	MaxCount     int    // Max number of commits to return
+	Skip         int    // Number of commits to skip (for pagination)
+	All          bool   // Show all refs
+	Graph        bool   // Include graph data
+	OmitBody     bool   // Skip commit body text for list-only views
 }
 
 // CommitOpts configures a git commit operation.

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -131,7 +131,8 @@
         { "key": "y", "action": "Copy SHA" },
         { "key": "A", "action": "Amend last commit" },
         { "key": "r", "action": "Reword last commit" },
-        { "key": "/", "action": "Search commits" }
+        { "key": "/", "action": "Search commits" },
+        { "key": "S", "action": "Search commit content (pickaxe)" }
       ]
     },
     {

--- a/internal/panels/commits/commits.go
+++ b/internal/panels/commits/commits.go
@@ -132,6 +132,11 @@ type Panel struct {
 	allLoaded    bool
 	// Search state.
 	searchMode bool
+	// Pickaxe content-search state (server-side git -S / -G). pickaxeTerm
+	// doubles as the editable input buffer and the applied filter.
+	pickaxeMode  bool
+	pickaxeTerm  string
+	pickaxeRegex bool
 	// Detail view state.
 	detailMode bool
 	// PR-commits mode: shows commits in a pull request.
@@ -177,12 +182,16 @@ func (p *Panel) loadCommitsCmd(skip int, appendMode bool) tea.Cmd {
 	if (p.filter == filterFile || p.filter == filterFolder) && p.filterPath != "" {
 		pathFilter = p.filterPath
 	}
+	pickaxe := p.pickaxeTerm
+	pickaxeRegex := p.pickaxeRegex
 	return func() tea.Msg {
 		commits, err := client.Log(ctx, git.LogOpts{
-			Ref:      ref,
-			MaxCount: pageSize,
-			Skip:     skip,
-			Path:     pathFilter,
+			Ref:          ref,
+			MaxCount:     pageSize,
+			Skip:         skip,
+			Path:         pathFilter,
+			Pickaxe:      pickaxe,
+			PickaxeRegex: pickaxeRegex,
 		})
 		if err != nil {
 			return notify.ShowToastMsg{
@@ -329,6 +338,7 @@ func (p *Panel) KeyBindings() []panels.KeyBinding {
 		{Key: "G", Description: "Go to bottom", Action: "go_bottom"},
 		{Key: "y", Description: "Copy commit hash", Action: "copy_hash"},
 		{Key: "/", Description: "Search commits", Action: "search"},
+		{Key: "S", Description: "Search commit content (pickaxe)", Action: "pickaxe"},
 		{Key: "A", Description: "Amend last commit", Action: "amend"},
 		{Key: "r", Description: "Reword last commit", Action: "reword"},
 	}
@@ -485,6 +495,8 @@ func (p *Panel) resetState() {
 	p.offset = 0
 	p.searchMode = false
 	p.searchQuery = ""
+	p.pickaxeMode = false
+	p.pickaxeTerm = ""
 	p.filteredIdx = nil
 	p.detailMode = false
 	p.detailLines = nil
@@ -604,16 +616,23 @@ func (p *Panel) renderList(width, height int) string {
 		loadingStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(p.colors.Dim))
 		lines = append(lines, commitrender.TruncateOrPad(loadingStyle.Render("  Loading more commits..."), width))
 	}
-	// Search bar at bottom if in search mode.
-	if p.searchMode {
-		searchLine := p.renderSearchBar(width)
+	// Bottom status bar: pickaxe content-search takes precedence over the
+	// client-side subject search when both are relevant.
+	var barLine string
+	switch {
+	case p.pickaxeMode || p.pickaxeTerm != "":
+		barLine = p.renderPickaxeBar(width)
+	case p.searchMode:
+		barLine = p.renderSearchBar(width)
+	}
+	if barLine != "" {
 		if len(lines) >= height {
-			lines[height-1] = searchLine
+			lines[height-1] = barLine
 		} else {
 			for len(lines) < height-1 {
 				lines = append(lines, strings.Repeat(" ", width))
 			}
-			lines = append(lines, searchLine)
+			lines = append(lines, barLine)
 		}
 	}
 	// Pad remaining height.
@@ -633,6 +652,24 @@ func (p *Panel) renderSearchBar(width int) string {
 		prompt += fmt.Sprintf("  [%d matches]", matchCount)
 	}
 	return searchStyle.Width(width).Render(prompt)
+}
+
+func (p *Panel) renderPickaxeBar(width int) string {
+	barStyle := lipgloss.NewStyle().
+		Background(lipgloss.Color(p.colors.SearchBg)).
+		Foreground(lipgloss.Color(p.colors.SearchFg))
+	mode := "text"
+	if p.pickaxeRegex {
+		mode = "regex"
+	}
+	prompt := " pickaxe(" + mode + "): " + p.pickaxeTerm
+	switch {
+	case p.pickaxeMode:
+		prompt += "  (Tab: regex, Enter: search, Esc: clear)"
+	case p.pickaxeTerm != "":
+		prompt += fmt.Sprintf("  [%d results]", len(p.commits))
+	}
+	return barStyle.Width(width).Render(prompt)
 }
 
 func (p *Panel) renderDetail(width, height int) string {
@@ -759,6 +796,9 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 	if !p.focused {
 		return p, nil
 	}
+	if p.pickaxeMode {
+		return p.handlePickaxeKey(msg)
+	}
 	if p.searchMode {
 		return p.handleSearchKey(msg)
 	}
@@ -785,6 +825,8 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 	case "/":
 		p.searchMode = true
 		p.searchQuery = ""
+	case "S":
+		p.pickaxeMode = true
 	case "A":
 		return p, func() tea.Msg { return panels.AmendRequestMsg{} }
 	case "r":
@@ -797,7 +839,12 @@ func (p *Panel) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 			return p, func() tea.Msg { return panels.RewordRequestMsg{OldMessage: msg} }
 		}
 	case "esc": //nolint:goconst // inline string is more readable here
-		// Progressive reset: PR-commits mode → selected commit → filter → nothing.
+		// Progressive reset: pickaxe → PR-commits mode → selected commit → filter → nothing.
+		if p.pickaxeTerm != "" {
+			p.pickaxeTerm = ""
+			p.resetState()
+			return p, p.loadCommitsCmd(0, false)
+		}
 		if p.prCommitsMode {
 			return p.exitPRCommitsMode()
 		}
@@ -833,6 +880,40 @@ func (p *Panel) handleSearchKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		if len(ch) == 1 && ch[0] >= ' ' {
 			p.searchQuery += ch
 			p.applySearch()
+		}
+	}
+	return p, nil
+}
+
+func (p *Panel) handlePickaxeKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
+	switch msg.String() {
+	case keyEnter:
+		// Run the content search server-side. Empty term clears the filter.
+		p.pickaxeMode = false
+		p.cursor = 0
+		p.offset = 0
+		p.allLoaded = false
+		return p, p.loadCommitsCmd(0, false)
+	case "esc":
+		hadTerm := p.pickaxeTerm != ""
+		p.pickaxeMode = false
+		p.pickaxeTerm = ""
+		if hadTerm {
+			p.cursor = 0
+			p.offset = 0
+			p.allLoaded = false
+			return p, p.loadCommitsCmd(0, false)
+		}
+	case "tab":
+		p.pickaxeRegex = !p.pickaxeRegex
+	case "backspace":
+		if len(p.pickaxeTerm) > 0 {
+			p.pickaxeTerm = p.pickaxeTerm[:len(p.pickaxeTerm)-1]
+		}
+	default:
+		ch := msg.String()
+		if len(ch) == 1 && ch[0] >= ' ' {
+			p.pickaxeTerm += ch
 		}
 	}
 	return p, nil

--- a/internal/panels/commits/commits_test.go
+++ b/internal/panels/commits/commits_test.go
@@ -1437,7 +1437,7 @@ func TestKeyBindings(t *testing.T) {
 	for _, b := range bindings {
 		actions[b.Action] = true
 	}
-	for _, expected := range []string{"cursor_down", "cursor_up", "detail", "page_down", "page_up", "go_top", "go_bottom", "copy_hash", "search"} {
+	for _, expected := range []string{"cursor_down", "cursor_up", "detail", "page_down", "page_up", "go_top", "go_bottom", "copy_hash", "search", "pickaxe"} {
 		if !actions[expected] {
 			t.Errorf("expected action %q in key bindings", expected)
 		}
@@ -1576,5 +1576,96 @@ func TestRepoChangedMsg_ResetsStateAndReloads(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Error("a reload command should be returned")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pickaxe content search (server-side -S / -G)
+// ---------------------------------------------------------------------------
+
+func TestPickaxeEnterRunsServerSearch(t *testing.T) {
+	mock := &mockGitOps{commits: defaultCommits()}
+	p := newTestPanel(mock)
+	p.Focus()
+	p.SetSize(80, 20)
+
+	// Enter pickaxe mode with "S".
+	p.Update(tea.KeyPressMsg{Code: -1, Text: "S"})
+	if !p.pickaxeMode {
+		t.Fatal("expected pickaxeMode=true after S")
+	}
+
+	// Type a search term.
+	for _, ch := range "needle" {
+		p.Update(tea.KeyPressMsg{Code: ch})
+	}
+	if p.pickaxeTerm != "needle" {
+		t.Fatalf("expected pickaxeTerm=needle, got %q", p.pickaxeTerm)
+	}
+
+	// Confirm with Enter: runs the server-side search.
+	_, cmd := p.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if p.pickaxeMode {
+		t.Error("expected pickaxeMode=false after Enter")
+	}
+	if cmd != nil {
+		cmd()
+	}
+	if mock.lastOpts.Pickaxe != "needle" {
+		t.Errorf("expected LogOpts.Pickaxe=needle, got %q", mock.lastOpts.Pickaxe)
+	}
+	if mock.lastOpts.PickaxeRegex {
+		t.Error("expected LogOpts.PickaxeRegex=false in text mode")
+	}
+}
+
+func TestPickaxeTabTogglesRegex(t *testing.T) {
+	mock := &mockGitOps{commits: defaultCommits()}
+	p := newTestPanel(mock)
+	p.Focus()
+	p.SetSize(80, 20)
+
+	p.Update(tea.KeyPressMsg{Code: -1, Text: "S"})
+	for _, ch := range "foo" {
+		p.Update(tea.KeyPressMsg{Code: ch})
+	}
+	p.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if !p.pickaxeRegex {
+		t.Fatal("expected pickaxeRegex=true after Tab")
+	}
+	_, cmd := p.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd != nil {
+		cmd()
+	}
+	if !mock.lastOpts.PickaxeRegex {
+		t.Error("expected LogOpts.PickaxeRegex=true after Tab toggle")
+	}
+}
+
+func TestPickaxeEscClears(t *testing.T) {
+	mock := &mockGitOps{commits: defaultCommits()}
+	p := newTestPanel(mock)
+	p.Focus()
+	p.SetSize(80, 20)
+
+	// Run a pickaxe search first.
+	p.Update(tea.KeyPressMsg{Code: -1, Text: "S"})
+	for _, ch := range "bar" {
+		p.Update(tea.KeyPressMsg{Code: ch})
+	}
+	if _, cmd := p.Update(tea.KeyPressMsg{Code: tea.KeyEnter}); cmd != nil {
+		cmd()
+	}
+
+	// Esc clears the pickaxe term and reloads.
+	_, cmd := p.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	if p.pickaxeTerm != "" {
+		t.Errorf("expected pickaxeTerm cleared after Esc, got %q", p.pickaxeTerm)
+	}
+	if cmd != nil {
+		cmd()
+	}
+	if mock.lastOpts.Pickaxe != "" {
+		t.Errorf("expected LogOpts.Pickaxe empty after Esc reload, got %q", mock.lastOpts.Pickaxe)
 	}
 }


### PR DESCRIPTION
## Summary

Adds a pickaxe content search to the Commits panel so you can find commits by the code they changed, not just by commit message. Press `S`, type a term, and the log reloads to show only commits whose diff added or removed that string. Press `Tab` to switch to regular expression mode.

This complements the existing `/` subject filter, which only matches commit message text. Pickaxe answers the common question "which commit introduced or removed this line of code?" without leaving the panel.

Closes #271

## What changed

- `internal/git/types.go`: added `Pickaxe` and `PickaxeRegex` fields to `LogOpts`.
- `internal/git/log.go`: builds `git log -S<term>` (text) or `-G<term>` (regex) when a pickaxe term is set. The term is passed as a single validated argument.
- `internal/panels/commits/commits.go`: new pickaxe input mode bound to `S`, with `Tab` to toggle regex, `Enter` to run the server-side search, and `Esc` to clear. A bottom status bar shows the mode, the term, and the result count.
- `internal/keybindings/keybindings.json` and `docs/keybindings.md`: documented the new `S` binding.
- Tests: `internal/git/log_pickaxe_test.go` (integration against a real repo) plus commits panel unit tests covering enter, regex toggle, and clear.

## How it works

```mermaid
flowchart TD
    A[Commits panel] -->|press S| B[Pickaxe input mode]
    B -->|type term| C{Regex?}
    C -->|Tab toggles| C
    C -->|Enter, text| D[git log -S term]
    C -->|Enter, regex| E[git log -G term]
    D --> F[Reload commit list]
    E --> F
    F --> G[Status bar shows term and result count]
    B -->|Esc| H[Clear term and reload full log]
```

## Acceptance criteria

- Pressing `S` opens a content-search prompt in the Commits panel.
- Entering a term and pressing `Enter` reloads the list to only commits that changed that content.
- `Tab` switches between literal and regex matching.
- `Esc` clears the search and restores the full list.
- The active term and result count are visible while a pickaxe search is applied.

## Testing

- `go build ./...`
- `go vet ./internal/panels/commits/ ./internal/git/ ./internal/keybindings/`
- `go test ./internal/panels/commits/ ./internal/keybindings/`
- `go test ./internal/git/ -run TestLog_Pickaxe`