### PR TITLE
feat(gitdiff): expand and collapse diff context lines

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -179,6 +179,24 @@ Navigation keys (j/k/g/G/PgDn/PgUp) scroll content. Click+drag to select text, d
 
 ---
 
+## Git Diff
+
+Dedicated diff viewer panel.
+
+| Key | Action |
+|-----|--------|
+| `j/k` | Scroll up/down |
+| `PgDn/PgUp` | Page down/up |
+| `g/G` | Jump to top/bottom |
+| `t` | Toggle inline/side-by-side view |
+| `n/N` | Next/previous hunk |
+| `[/]` | Previous/next file |
+| `R` | Toggle review annotations |
+| `+/-` | More/less diff context lines |
+| `0` | Reset diff context to default |
+
+---
+
 ## Edit Mode
 
 Active when editing a file inline (press e in Preview to enter).

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -154,6 +154,22 @@
       "note": "Navigation keys (j/k/g/G/PgDn/PgUp) scroll content. Click+drag to select text, double-click to select a word."
     },
     {
+      "id": "gitdiff",
+      "title": "Git Diff",
+      "description": "Dedicated diff viewer panel.",
+      "bindings": [
+        { "key": "j/k", "action": "Scroll up/down" },
+        { "key": "PgDn/PgUp", "action": "Page down/up" },
+        { "key": "g/G", "action": "Jump to top/bottom" },
+        { "key": "t", "action": "Toggle inline/side-by-side view" },
+        { "key": "n/N", "action": "Next/previous hunk" },
+        { "key": "[/]", "action": "Previous/next file" },
+        { "key": "R", "action": "Toggle review annotations" },
+        { "key": "+/-", "action": "More/less diff context lines" },
+        { "key": "0", "action": "Reset diff context to default" }
+      ]
+    },
+    {
       "id": "edit_mode",
       "title": "Edit Mode",
       "description": "Active when editing a file inline (press e in Preview to enter).",

--- a/internal/keybindings/keybindings_test.go
+++ b/internal/keybindings/keybindings_test.go
@@ -34,7 +34,7 @@ func TestSections_ExpectedSections(t *testing.T) {
 	for i, s := range secs {
 		ids[i] = s.ID
 	}
-	expected := []string{"global", "navigation", "filetree", "gitstatus", "gitinfo", "github", "commits", "preview", "edit_mode"}
+	expected := []string{"global", "navigation", "filetree", "gitstatus", "gitinfo", "github", "commits", "preview", "gitdiff", "edit_mode"}
 	assert.Equal(t, expected, ids)
 }
 

--- a/internal/panels/gitdiff/constants.go
+++ b/internal/panels/gitdiff/constants.go
@@ -6,3 +6,12 @@ const (
 	severityInfo    = "info"
 	severityHint    = "hint"
 )
+
+const (
+	// defaultDiffContext matches git's default -U value (3 lines).
+	defaultDiffContext = 3
+	// contextStep is how many context lines each +/- keypress adjusts by.
+	contextStep = 3
+	// maxDiffContext caps context expansion to keep reloads reasonable.
+	maxDiffContext = 100
+)

--- a/internal/panels/gitdiff/gitdiff.go
+++ b/internal/panels/gitdiff/gitdiff.go
@@ -60,6 +60,8 @@ type GitDiff struct {
 	reviewFindings []panels.AIReviewFinding // findings for the current file
 	panels.BasePanel
 	fileIdx int // current file index for multi-file navigation
+	// contextLines is the number of surrounding lines requested via -U<n>.
+	contextLines int
 	// Display state
 	scrollY int      // viewport scroll offset (lines)
 	mode    viewMode // inline or side-by-side
@@ -68,6 +70,8 @@ type GitDiff struct {
 	staged                bool // whether viewing staged (index) changes
 	loading               bool // true while async diff fetch is in progress
 	showReviewAnnotations bool // toggle for inline annotation display
+	// preserveOnLoad keeps scroll/file position across a context reload.
+	preserveOnLoad bool
 }
 
 // diffLoadedMsg is the result of an async diff fetch (F01: no blocking in Update).
@@ -86,9 +90,10 @@ var _ panels.Panel = (*GitDiff)(nil)
 // (fallback colors are used).
 func New(gitClient git.StatusReader, th *theme.Theme) *GitDiff {
 	return &GitDiff{
-		BasePanel: panels.BasePanel{PanelTitle: "gitdiff"},
-		gitClient: gitClient,
-		theme:     th,
+		BasePanel:    panels.BasePanel{PanelTitle: "gitdiff"},
+		gitClient:    gitClient,
+		theme:        th,
+		contextLines: defaultDiffContext,
 	}
 }
 
@@ -155,9 +160,16 @@ func (d *GitDiff) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 			d.loading = false
 			d.diffs = msg.diffs
 			d.err = msg.err
-			d.fileIdx = 0
-			d.scrollY = 0
-			d.rebuildLines()
+			if d.preserveOnLoad {
+				// Context reload: keep the reader roughly where they were.
+				d.preserveOnLoad = false
+				d.rebuildLines()
+				d.clampScroll()
+			} else {
+				d.fileIdx = 0
+				d.scrollY = 0
+				d.rebuildLines()
+			}
 		}
 		return d, nil
 	case panels.PanelMouseRightClickMsg:
@@ -200,6 +212,8 @@ func (d *GitDiff) handleRepoChanged(msg panels.RepoChangedMsg) (panels.Panel, te
 	d.compareCommitA = ""
 	d.compareCommitB = ""
 	d.compareThree = false
+	d.contextLines = defaultDiffContext
+	d.preserveOnLoad = false
 	return d, nil
 }
 
@@ -230,10 +244,17 @@ func (d *GitDiff) startRefDiffLoad(path, commitA, commitB string, threeDot bool)
 	d.hunkStarts = nil
 	d.fileStarts = nil
 	d.loading = true
+	return d.loadRefDiffCmd(path, commitA, commitB, threeDot)
+}
+
+// loadRefDiffCmd fetches a ref-comparison diff async without resetting
+// scroll or file position, so it can back both initial loads and reloads.
+func (d *GitDiff) loadRefDiffCmd(path, commitA, commitB string, threeDot bool) tea.Cmd {
 	d.diffGen++
 	gen := d.diffGen
 	gitClient := d.gitClient
 	ctx := d.ctx
+	contextLines := d.contextLines
 	return func() tea.Msg {
 		result := diffLoadedMsg{path: path, generation: gen}
 		if gitClient == nil {
@@ -248,6 +269,7 @@ func (d *GitDiff) startRefDiffLoad(path, commitA, commitB string, threeDot bool)
 			CommitB:  commitB,
 			ThreeDot: threeDot,
 			Path:     path,
+			Context:  contextLines,
 		})
 		result.diffs = diffs
 		result.err = err
@@ -282,8 +304,63 @@ func (d *GitDiff) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		d.prevFile()
 	case "R":
 		d.toggleReviewAnnotations()
+	case "+", "=":
+		return d, d.increaseContext()
+	case "-", "_":
+		return d, d.decreaseContext()
+	case "0":
+		return d, d.resetContext()
 	}
 	return d, nil
+}
+
+// increaseContext widens the diff context by one step and reloads.
+func (d *GitDiff) increaseContext() tea.Cmd {
+	n := d.contextLines + contextStep
+	if n > maxDiffContext {
+		n = maxDiffContext
+	}
+	if n == d.contextLines {
+		return nil
+	}
+	d.contextLines = n
+	return d.reloadWithContext()
+}
+
+// decreaseContext narrows the diff context by one step (floor 0) and reloads.
+func (d *GitDiff) decreaseContext() tea.Cmd {
+	n := d.contextLines - contextStep
+	if n < 0 {
+		n = 0
+	}
+	if n == d.contextLines {
+		return nil
+	}
+	d.contextLines = n
+	return d.reloadWithContext()
+}
+
+// resetContext restores the default context and reloads if it changed.
+func (d *GitDiff) resetContext() tea.Cmd {
+	if d.contextLines == defaultDiffContext {
+		return nil
+	}
+	d.contextLines = defaultDiffContext
+	return d.reloadWithContext()
+}
+
+// reloadWithContext re-fetches the current diff with the current context
+// value, preserving scroll/file position. Returns nil when nothing is loaded.
+func (d *GitDiff) reloadWithContext() tea.Cmd {
+	if d.path == "" && !d.compareMode {
+		return nil
+	}
+	d.loading = true
+	d.preserveOnLoad = true
+	if d.compareMode {
+		return d.loadRefDiffCmd(d.path, d.compareCommitA, d.compareCommitB, d.compareThree)
+	}
+	return d.loadDiffCmd(d.path, d.staged)
 }
 
 // handleMouseWheel scrolls the diff viewport.
@@ -355,6 +432,8 @@ func (d *GitDiff) KeyBindings() []panels.KeyBinding {
 		{Key: "n/N", Description: "Next/previous hunk", Action: "hunk_nav"},
 		{Key: "[/]", Description: "Previous/next file", Action: "file_nav"},
 		{Key: "R", Description: "Toggle review annotations", Action: "toggle_review"},
+		{Key: "+/-", Description: "More/less diff context", Action: "context_adjust"},
+		{Key: "0", Description: "Reset diff context", Action: "context_reset"},
 	}
 }
 
@@ -386,6 +465,7 @@ func (d *GitDiff) loadDiffCmd(path string, staged bool) tea.Cmd {
 	gen := d.diffGen
 	gitClient := d.gitClient
 	ctx := d.ctx
+	contextLines := d.contextLines
 	return func() tea.Msg {
 		result := diffLoadedMsg{path: path, generation: gen}
 		if gitClient == nil {
@@ -396,8 +476,9 @@ func (d *GitDiff) loadDiffCmd(path string, staged bool) tea.Cmd {
 			ctx = context.Background()
 		}
 		diffs, err := gitClient.Diff(ctx, git.DiffOpts{
-			Staged: staged,
-			Path:   path,
+			Staged:  staged,
+			Path:    path,
+			Context: contextLines,
 		})
 		result.diffs = diffs
 		result.err = err
@@ -674,9 +755,14 @@ func (d *GitDiff) renderViewport(_ int, height int) string {
 	}
 	d.viewportBuf = visible // retain backing array for next frame
 	content := strings.Join(visible, "\n")
-	// Add scroll indicator
+	// Add scroll indicator plus the current diff context value.
 	indicator := d.scrollIndicator(len(d.lines), height)
-	content += "\n" + d.dimStyle().Render(indicator)
+	status := indicator
+	if status != "" {
+		status += "   "
+	}
+	status += fmt.Sprintf("ctx %d", d.contextLines)
+	content += "\n" + d.dimStyle().Render(status)
 	return content
 }
 

--- a/internal/panels/gitdiff/gitdiff_test.go
+++ b/internal/panels/gitdiff/gitdiff_test.go
@@ -1114,3 +1114,96 @@ func TestRepoChangedMsg_ClearsState(t *testing.T) {
 	assert.Nil(t, d.err, "err should be nil")
 	assert.Nil(t, cmd, "no command should be returned")
 }
+
+// --- Diff context expansion ---
+
+func TestContextDefault(t *testing.T) {
+	p := New(nil, nil)
+	assert.Equal(t, defaultDiffContext, p.contextLines)
+}
+
+func TestKeyBindingsIncludeContext(t *testing.T) {
+	p := New(nil, nil)
+	actions := map[string]bool{}
+	for _, b := range p.KeyBindings() {
+		actions[b.Action] = true
+	}
+	assert.True(t, actions["context_adjust"], "expected context_adjust binding")
+	assert.True(t, actions["context_reset"], "expected context_reset binding")
+}
+
+// contextRecordingPanel wires a mock that records the last DiffOpts.Context
+// and returns a panel already showing a working-tree diff.
+func contextRecordingPanel(t *testing.T, captured *int) *GitDiff {
+	t.Helper()
+	mock := &mockGitClient{
+		DiffFunc: func(_ context.Context, opts git.DiffOpts) ([]git.FileDiff, error) {
+			*captured = opts.Context
+			return []git.FileDiff{sampleDiff()}, nil
+		},
+	}
+	p := New(mock, nil)
+	p.Init(context.Background())
+	p.SetSize(80, 24)
+	p.Focus()
+	_, cmd := p.Update(panels.FileSelectedMsg{Path: "file.go"})
+	require.NotNil(t, cmd)
+	p.Update(cmd())
+	return p
+}
+
+func TestIncreaseContextRefetches(t *testing.T) {
+	var captured int
+	p := contextRecordingPanel(t, &captured)
+	assert.Equal(t, defaultDiffContext, captured, "initial load uses default context")
+
+	_, cmd := p.Update(keyMsg("+"))
+	require.NotNil(t, cmd, "increasing context should trigger a reload")
+	assert.Equal(t, defaultDiffContext+contextStep, p.contextLines)
+	p.Update(cmd())
+	assert.Equal(t, defaultDiffContext+contextStep, captured, "reload should use the new context")
+}
+
+func TestDecreaseContextFloorsAtZero(t *testing.T) {
+	var captured int
+	p := contextRecordingPanel(t, &captured)
+
+	// Drop below zero: 3 -> 0 (floored), further presses are no-ops.
+	_, cmd := p.Update(keyMsg("-"))
+	require.NotNil(t, cmd)
+	p.Update(cmd())
+	assert.Equal(t, 0, p.contextLines)
+	assert.Equal(t, 0, captured)
+
+	_, cmd = p.Update(keyMsg("-"))
+	assert.Nil(t, cmd, "decreasing at zero should be a no-op")
+	assert.Equal(t, 0, p.contextLines)
+}
+
+func TestResetContext(t *testing.T) {
+	var captured int
+	p := contextRecordingPanel(t, &captured)
+
+	if _, cmd := p.Update(keyMsg("+")); cmd != nil {
+		p.Update(cmd())
+	}
+	assert.NotEqual(t, defaultDiffContext, p.contextLines)
+
+	_, cmd := p.Update(keyMsg("0"))
+	require.NotNil(t, cmd, "reset from a non-default value should reload")
+	p.Update(cmd())
+	assert.Equal(t, defaultDiffContext, p.contextLines)
+	assert.Equal(t, defaultDiffContext, captured)
+
+	// Reset again is a no-op at default.
+	_, cmd = p.Update(keyMsg("0"))
+	assert.Nil(t, cmd)
+}
+
+func TestContextValueShownInView(t *testing.T) {
+	p := newTestPanel(nil)
+	p.SetSize(80, 24)
+	p.SetDiffs([]git.FileDiff{sampleDiff()})
+	out := p.View(80, 24)
+	assert.Contains(t, out, "ctx 3", "view should show the current context value")
+}


### PR DESCRIPTION
## Summary

Adds keys to widen and narrow the amount of context shown around each change in the Git Diff panel. When you are reading a hunk and need to see more of the surrounding code, press `+` to add context lines and `-` to remove them. Press `0` to return to the default of three lines. The current value is shown in the panel status line as `ctx N`.

Each adjustment re-fetches the diff with `git diff -U<n>` and keeps your scroll position, so widening context does not throw away where you were reading.

Closes #273

## What changed

- `internal/panels/gitdiff/gitdiff.go`: added a `contextLines` value (default 3), `+`/`-` to adjust by a step, and `0` to reset. Both working-tree and ref-comparison loads now pass `DiffOpts.Context`, and a context reload preserves scroll and file position.
- `internal/panels/gitdiff/constants.go`: added `defaultDiffContext`, `contextStep`, and `maxDiffContext`.
- `internal/keybindings/keybindings.json` and `docs/keybindings.md`: added a Git Diff section documenting the panel keys, including the new context controls.
- Tests: panel-level coverage for the default value, keybindings, increase, decrease floor, reset, and the visible status value. The git layer already covers building the `-U` argument.

## How it works

```mermaid
flowchart LR
    A[Press plus] --> B[context = min max, context + step]
    C[Press minus] --> D[context = max 0, context - step]
    E[Press zero] --> F[context = default 3]
    B --> G[Re-fetch diff with -U context]
    D --> G
    F --> G
    G --> H[Rebuild lines, keep scroll]
    H --> I[Status line shows ctx N]
```

## Acceptance criteria

- `+` and `-` change the context line count and re-render the current diff.
- The diff is re-fetched using `DiffOpts.Context`.
- The current context value is visible in the panel status line.
- `0` resets to the default context of 3.
- Keybindings are registered in `KeyBindings()`, mirrored in `internal/keybindings/keybindings.json`, and shown in the help overlay.
- Unit tests cover the state transitions and the `-U` argument.

## Testing

- `go build ./...`
- `go vet ./internal/panels/gitdiff/ ./internal/keybindings/`
- `go test ./internal/panels/gitdiff/ ./internal/keybindings/`
- `go test ./internal/git/ -run TestClient_Diff_CustomContext`