### PR TITLE
feat(gitstatus): untracked file cleanup overlay

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -89,6 +89,7 @@ Active when the file tree is in git filter mode (press f to cycle).
 | `space` | Toggle select for bulk |
 | `enter/l` | Expand file diff |
 | `h` | Enter hunk mode |
+| `X` | Clean untracked files (preview and select) |
 | `Esc` | Exit hunk/line mode |
 
 ---

--- a/internal/git/clean.go
+++ b/internal/git/clean.go
@@ -1,0 +1,118 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// CleanCandidate is a single path that "git clean" would remove.
+type CleanCandidate struct {
+	// Path is the repository-relative path, exactly as git reports it.
+	// Directories carry a trailing slash.
+	Path string
+	// Ignored is true when the path is a candidate only because ignored
+	// files were included (git clean -X), not a plain untracked file.
+	Ignored bool
+}
+
+// CleanOpts controls a clean preview or removal.
+type CleanOpts struct {
+	// IncludeIgnored also considers files matched by .gitignore.
+	IncludeIgnored bool
+	// Paths restricts a removal to the given repository-relative paths.
+	// It is ignored by CleanPreview.
+	Paths []string
+}
+
+// forceCLocale pins git's human-readable output to English so the dry-run
+// "Would remove" lines can be parsed regardless of the user's locale.
+var forceCLocale = []string{"LC_ALL=C", "LANG=C"}
+
+// CleanPreview runs "git clean" in dry-run mode and returns the paths that
+// would be removed. Plain untracked candidates are listed first; when
+// IncludeIgnored is set, ignored candidates are appended and marked Ignored.
+func (c *Client) CleanPreview(ctx context.Context, opts CleanOpts) ([]CleanCandidate, error) {
+	untracked, err := c.cleanDryRun(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]CleanCandidate, 0, len(untracked))
+	for _, p := range untracked {
+		candidates = append(candidates, CleanCandidate{Path: p})
+	}
+
+	if opts.IncludeIgnored {
+		ignored, err := c.cleanDryRun(ctx, true)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range ignored {
+			candidates = append(candidates, CleanCandidate{Path: p, Ignored: true})
+		}
+	}
+	return candidates, nil
+}
+
+// cleanDryRun runs "git clean -nd" (or "-ndX" for ignored-only) and returns
+// the reported paths. Using -X (uppercase) for the ignored pass keeps ignored
+// candidates cleanly separated from plain untracked ones.
+func (c *Client) cleanDryRun(ctx context.Context, ignoredOnly bool) ([]string, error) {
+	args := []string{"clean", "-n", "-d"}
+	if ignoredOnly {
+		args = append(args, "-X")
+	}
+	out, err := c.runWithEnv(ctx, forceCLocale, args...)
+	if err != nil {
+		return nil, fmt.Errorf("clean preview: %w", err)
+	}
+	return parseCleanDryRun(out), nil
+}
+
+// parseCleanDryRun extracts the removable paths from "git clean -n" output.
+// Under the C locale each removable entry is printed as "Would remove <path>".
+// Lines like "Would skip repository <path>" are intentionally ignored because
+// git will not remove nested repositories.
+func parseCleanDryRun(out string) []string {
+	const prefix = "Would remove "
+	var paths []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.HasPrefix(line, prefix) {
+			p := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+			if p != "" {
+				paths = append(paths, p)
+			}
+		}
+	}
+	return paths
+}
+
+// Clean removes the given untracked paths with "git clean -fd" (adding -x when
+// IncludeIgnored is set). It deletes only the paths in opts.Paths; an empty
+// list is a no-op so a removal can never wipe the whole working tree by
+// accident. Every path is validated before it reaches git.
+func (c *Client) Clean(ctx context.Context, opts CleanOpts) error {
+	if len(opts.Paths) == 0 {
+		return nil
+	}
+	for _, p := range opts.Paths {
+		if err := ValidateRepoRelativePath(p); err != nil {
+			return fmt.Errorf("clean path %q: %w", p, err)
+		}
+	}
+
+	return c.queue.Exec(ctx, func() error {
+		args := []string{"clean", "-f", "-d"}
+		if opts.IncludeIgnored {
+			args = append(args, "-x")
+		}
+		args = append(args, "--")
+		args = append(args, opts.Paths...)
+		if _, err := c.run(ctx, args...); err != nil {
+			return fmt.Errorf("clean: %w", err)
+		}
+		c.cache.Invalidate()
+		return nil
+	})
+}

--- a/internal/git/clean_test.go
+++ b/internal/git/clean_test.go
@@ -1,0 +1,126 @@
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCleanDryRun(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single file", "Would remove junk.txt\n", []string{"junk.txt"}},
+		{
+			"file and dir",
+			"Would remove junk.txt\nWould remove build/\n",
+			[]string{"junk.txt", "build/"},
+		},
+		{
+			"skips nested repository lines",
+			"Would remove a.txt\nWould skip repository nested/\nWould remove b.txt\n",
+			[]string{"a.txt", "b.txt"},
+		},
+		{
+			"crlf line endings",
+			"Would remove a.txt\r\nWould remove b.txt\r\n",
+			[]string{"a.txt", "b.txt"},
+		},
+		{"ignores unrelated lines", "removing nothing\nblah\n", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, parseCleanDryRun(tt.in))
+		})
+	}
+}
+
+func TestClient_CleanPreview(t *testing.T) {
+	t.Parallel()
+	dir := initTestRepo(t)
+	client, err := NewClient(dir)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// Ignore *.log via the repo-local exclude file so .gitignore itself
+	// does not show up as an untracked candidate.
+	excludePath := filepath.Join(dir, ".git", "info", "exclude")
+	require.NoError(t, os.WriteFile(excludePath, []byte("*.log\n"), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "junk.txt"), []byte("x"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "debug.log"), []byte("y"), 0o644))
+
+	// Without ignored files: only the plain untracked file appears.
+	got, err := client.CleanPreview(ctx, CleanOpts{})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "junk.txt", got[0].Path)
+	assert.False(t, got[0].Ignored)
+
+	// With ignored files: both appear, and the ignored one is flagged.
+	got, err = client.CleanPreview(ctx, CleanOpts{IncludeIgnored: true})
+	require.NoError(t, err)
+	paths := map[string]bool{}
+	ignored := map[string]bool{}
+	for _, c := range got {
+		paths[c.Path] = true
+		ignored[c.Path] = c.Ignored
+	}
+	assert.True(t, paths["junk.txt"])
+	assert.True(t, paths["debug.log"])
+	assert.False(t, ignored["junk.txt"])
+	assert.True(t, ignored["debug.log"])
+}
+
+func TestClient_Clean_RemovesSelectedOnly(t *testing.T) {
+	t.Parallel()
+	dir := initTestRepo(t)
+	client, err := NewClient(dir)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "junk.txt"), []byte("x"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "keep.txt"), []byte("y"), 0o644))
+
+	require.NoError(t, client.Clean(ctx, CleanOpts{Paths: []string{"junk.txt"}}))
+
+	_, err = os.Stat(filepath.Join(dir, "junk.txt"))
+	assert.True(t, os.IsNotExist(err), "selected file should be removed")
+	_, err = os.Stat(filepath.Join(dir, "keep.txt"))
+	assert.NoError(t, err, "unselected file must be kept")
+}
+
+func TestClient_Clean_EmptyPathsNoop(t *testing.T) {
+	t.Parallel()
+	dir := initTestRepo(t)
+	client, err := NewClient(dir)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "junk.txt"), []byte("x"), 0o644))
+
+	require.NoError(t, client.Clean(ctx, CleanOpts{}))
+	_, err = os.Stat(filepath.Join(dir, "junk.txt"))
+	assert.NoError(t, err, "empty path list must not remove anything")
+}
+
+func TestClient_Clean_RejectsTraversal(t *testing.T) {
+	t.Parallel()
+	dir := initTestRepo(t)
+	client, err := NewClient(dir)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	err = client.Clean(ctx, CleanOpts{Paths: []string{"../escape.txt"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "clean path")
+}

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -88,6 +89,13 @@ func (c *Client) InvalidateCache() {
 // All git commands go through this method. Arguments are validated,
 // context cancellation is respected, and stderr is captured for errors.
 func (c *Client) run(ctx context.Context, args ...string) (string, error) {
+	return c.runWithEnv(ctx, nil, args...)
+}
+
+// runWithEnv behaves like run but appends extraEnv to the child process
+// environment. It is used when a command needs a deterministic locale
+// (e.g. LC_ALL=C) so its human-readable output can be parsed reliably.
+func (c *Client) runWithEnv(ctx context.Context, extraEnv []string, args ...string) (string, error) {
 	// On Windows, file paths after "--" contain backslashes which
 	// ValidateArg rejects. Convert to forward slashes (git handles both)
 	// before validation, since exec.Command doesn't use a shell.
@@ -110,6 +118,9 @@ func (c *Client) run(ctx context.Context, args ...string) (string, error) {
 	}
 	cmd := exec.CommandContext(ctx, "git", normalized...)
 	cmd.Dir = c.repoDir
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 	stdout := &limitedBuffer{max: maxGitOutputSize}
 	var stderr bytes.Buffer
 	cmd.Stdout = stdout

--- a/internal/git/gittest/mock_client.go
+++ b/internal/git/gittest/mock_client.go
@@ -70,6 +70,8 @@ type MockClient struct {
 	RevertContinueFunc func(ctx context.Context) error
 	RevertAbortFunc    func(ctx context.Context) error
 	ResetFunc          func(ctx context.Context, ref string, mode git.ResetMode) error
+	CleanPreviewFunc   func(ctx context.Context, opts git.CleanOpts) ([]git.CleanCandidate, error)
+	CleanFunc          func(ctx context.Context, opts git.CleanOpts) error
 }
 
 // Compile-time check that MockClient implements git.GitClient.
@@ -117,6 +119,20 @@ func (m *MockClient) IsRepo(ctx context.Context) (bool, error) {
 		return m.IsRepoFunc(ctx)
 	}
 	return true, nil
+}
+
+func (m *MockClient) CleanPreview(ctx context.Context, opts git.CleanOpts) ([]git.CleanCandidate, error) {
+	if m.CleanPreviewFunc != nil {
+		return m.CleanPreviewFunc(ctx, opts)
+	}
+	return nil, nil
+}
+
+func (m *MockClient) Clean(ctx context.Context, opts git.CleanOpts) error {
+	if m.CleanFunc != nil {
+		return m.CleanFunc(ctx, opts)
+	}
+	return nil
 }
 
 func (m *MockClient) DiffTreeFiles(ctx context.Context, hash string) ([]string, error) {

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -73,6 +73,7 @@
         { "key": "space", "action": "Toggle select for bulk" },
         { "key": "enter/l", "action": "Expand file diff" },
         { "key": "h", "action": "Enter hunk mode" },
+        { "key": "X", "action": "Clean untracked files (preview and select)" },
         { "key": "Esc", "action": "Exit hunk/line mode" }
       ]
     },

--- a/internal/panels/gitstatus/clean.go
+++ b/internal/panels/gitstatus/clean.go
@@ -1,0 +1,294 @@
+package gitstatus
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/jongio/grut/internal/git"
+	"github.com/jongio/grut/internal/notify"
+	"github.com/jongio/grut/internal/panels"
+)
+
+// cleanPreviewLoadedMsg carries the result of an async CleanPreview call.
+type cleanPreviewLoadedMsg struct {
+	err        error
+	candidates []git.CleanCandidate
+}
+
+// cleanResultMsg carries the result of a Clean removal.
+type cleanResultMsg struct {
+	err   error
+	count int
+}
+
+// openCleanOverlay activates the cleanup overlay and kicks off a dry-run
+// preview of the files git clean would remove.
+func (p *GitStatus) openCleanOverlay() (panels.Panel, tea.Cmd) {
+	p.cleanActive = true
+	p.cleanLoading = true
+	p.cleanCursor = 0
+	p.cleanOffset = 0
+	p.cleanCandidates = nil
+	p.cleanSelected = make(map[string]bool)
+	return p, p.loadCleanPreviewCmd()
+}
+
+// closeCleanOverlay tears down the overlay without removing anything.
+func (p *GitStatus) closeCleanOverlay() {
+	p.cleanActive = false
+	p.cleanLoading = false
+	p.cleanCandidates = nil
+	p.cleanSelected = make(map[string]bool)
+	p.cleanCursor = 0
+	p.cleanOffset = 0
+}
+
+// loadCleanPreviewCmd fetches the dry-run clean candidates asynchronously.
+func (p *GitStatus) loadCleanPreviewCmd() tea.Cmd {
+	ctx := p.ctx
+	client := p.git
+	includeIgnored := p.cleanIncludeIgnored
+	return func() tea.Msg {
+		candidates, err := client.CleanPreview(ctx, git.CleanOpts{IncludeIgnored: includeIgnored})
+		return cleanPreviewLoadedMsg{candidates: candidates, err: err}
+	}
+}
+
+// handleCleanPreviewLoaded stores preview results, preserving any selections
+// for paths that are still present.
+func (p *GitStatus) handleCleanPreviewLoaded(msg cleanPreviewLoadedMsg) (panels.Panel, tea.Cmd) {
+	p.cleanLoading = false
+	if msg.err != nil {
+		p.closeCleanOverlay()
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{Message: "Clean preview failed: " + msg.err.Error(), Level: notify.Error}
+		}
+	}
+	p.cleanCandidates = msg.candidates
+	// Drop selections whose paths no longer appear in the candidate set.
+	present := make(map[string]bool, len(msg.candidates))
+	for _, c := range msg.candidates {
+		present[c.Path] = true
+	}
+	for path := range p.cleanSelected {
+		if !present[path] {
+			delete(p.cleanSelected, path)
+		}
+	}
+	if p.cleanCursor >= len(p.cleanCandidates) {
+		p.cleanCursor = max(0, len(p.cleanCandidates)-1)
+	}
+	return p, nil
+}
+
+// handleCleanResult reacts to a completed removal: on success it closes the
+// overlay and refreshes status, on failure it surfaces a toast.
+func (p *GitStatus) handleCleanResult(msg cleanResultMsg) (panels.Panel, tea.Cmd) {
+	p.closeCleanOverlay()
+	if msg.err != nil {
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{Message: "Clean failed: " + msg.err.Error(), Level: notify.Error}
+		}
+	}
+	p.invalidateDiffCaches()
+	p.loading = true
+	toast := func() tea.Msg {
+		return notify.ShowToastMsg{
+			Message: fmt.Sprintf("Removed %d untracked file(s)", msg.count),
+			Level:   notify.Success,
+		}
+	}
+	return p, tea.Batch(p.loadStatusCmd(), toast)
+}
+
+// handleCleanKey processes keys while the cleanup overlay is open.
+func (p *GitStatus) handleCleanKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "escape", "q":
+		p.closeCleanOverlay()
+		return p, nil
+	case "j", "down":
+		if p.cleanCursor < len(p.cleanCandidates)-1 {
+			p.cleanCursor++
+			p.ensureCleanCursorVisible()
+		}
+	case "k", "up":
+		if p.cleanCursor > 0 {
+			p.cleanCursor--
+			p.ensureCleanCursorVisible()
+		}
+	case " ", "space":
+		p.toggleCleanSelection()
+	case "a":
+		p.toggleSelectAllClean()
+	case "i":
+		p.cleanIncludeIgnored = !p.cleanIncludeIgnored
+		p.cleanLoading = true
+		return p, p.loadCleanPreviewCmd()
+	case "enter":
+		return p.confirmClean()
+	}
+	return p, nil
+}
+
+func (p *GitStatus) ensureCleanCursorVisible() {
+	p.cleanOffset = panels.EnsureCursorVisible(p.cleanCursor, p.cleanOffset, p.Height)
+}
+
+func (p *GitStatus) toggleCleanSelection() {
+	if p.cleanCursor < 0 || p.cleanCursor >= len(p.cleanCandidates) {
+		return
+	}
+	path := p.cleanCandidates[p.cleanCursor].Path
+	if p.cleanSelected[path] {
+		delete(p.cleanSelected, path)
+	} else {
+		p.cleanSelected[path] = true
+	}
+}
+
+// toggleSelectAllClean selects every candidate, or clears the selection if
+// everything is already selected.
+func (p *GitStatus) toggleSelectAllClean() {
+	if len(p.cleanCandidates) == 0 {
+		return
+	}
+	if len(p.cleanSelected) == len(p.cleanCandidates) {
+		p.cleanSelected = make(map[string]bool)
+		return
+	}
+	p.cleanSelected = make(map[string]bool, len(p.cleanCandidates))
+	for _, c := range p.cleanCandidates {
+		p.cleanSelected[c.Path] = true
+	}
+}
+
+// confirmClean asks for confirmation before removing the selected paths.
+func (p *GitStatus) confirmClean() (panels.Panel, tea.Cmd) {
+	n := len(p.cleanSelected)
+	if n == 0 {
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{Message: "No files selected to clean", Level: notify.Info}
+		}
+	}
+	p.clearPending()
+	p.pendingOp = opClean
+	return p, notify.ShowConfirm("Clean Untracked Files",
+		fmt.Sprintf("Permanently remove %d selected file(s)? This cannot be undone.", n))
+}
+
+// cleanSelectedCmd removes the currently selected paths. Ignored files are
+// only removed when at least one selected path is ignored, so git receives -x
+// exactly when it is needed.
+func (p *GitStatus) cleanSelectedCmd() tea.Cmd {
+	paths := make([]string, 0, len(p.cleanSelected))
+	includeIgnored := false
+	for _, c := range p.cleanCandidates {
+		if p.cleanSelected[c.Path] {
+			paths = append(paths, c.Path)
+			if c.Ignored {
+				includeIgnored = true
+			}
+		}
+	}
+	ctx := p.ctx
+	client := p.git
+	return func() tea.Msg {
+		err := client.Clean(ctx, git.CleanOpts{Paths: paths, IncludeIgnored: includeIgnored})
+		return cleanResultMsg{err: err, count: len(paths)}
+	}
+}
+
+// renderCleanOverlay draws the cleanup overlay: a header with counts, the
+// selectable candidate list (untracked first, ignored separated), and a hint
+// footer.
+func (p *GitStatus) renderCleanOverlay(width, height int) string {
+	title := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(p.colors.SectionHeader)).Bold(true).
+		Render("Clean untracked files")
+
+	if p.cleanLoading {
+		return p.padOverlay([]string{title, "", p.styleDim.Render("Scanning working tree...")}, width, height)
+	}
+	if len(p.cleanCandidates) == 0 {
+		return p.padOverlay([]string{title, "", p.styleStaged.Render("Nothing to clean")}, width, height)
+	}
+
+	untracked, ignored := 0, 0
+	for _, c := range p.cleanCandidates {
+		if c.Ignored {
+			ignored++
+		} else {
+			untracked++
+		}
+	}
+	ignoredHint := "off"
+	if p.cleanIncludeIgnored {
+		ignoredHint = "on"
+	}
+	counts := p.styleDim.Render(fmt.Sprintf(
+		"Untracked: %d   Ignored: %d (%s, press i)   Selected: %d",
+		untracked, ignored, ignoredHint, len(p.cleanSelected),
+	))
+
+	lines := []string{title, counts, ""}
+
+	// Reserve the header (3 lines) and footer (2 lines) from the list window.
+	listHeight := height - len(lines) - 2
+	if listHeight < 1 {
+		listHeight = 1
+	}
+	end := p.cleanOffset + listHeight
+	if end > len(p.cleanCandidates) {
+		end = len(p.cleanCandidates)
+	}
+	sepShown := false
+	for i := p.cleanOffset; i < end; i++ {
+		c := p.cleanCandidates[i]
+		if c.Ignored && !sepShown {
+			lines = append(lines, p.styleDim.Render("Ignored files:"))
+			sepShown = true
+		}
+		lines = append(lines, p.renderCleanRow(c, i == p.cleanCursor, width))
+	}
+
+	footer := p.styleDim.Render("space select · a all · i ignored · enter remove · esc cancel")
+	lines = append(lines, "", footer)
+	return p.padOverlay(lines, width, height)
+}
+
+// renderCleanRow renders a single candidate row with a checkbox and cursor.
+func (p *GitStatus) renderCleanRow(c git.CleanCandidate, atCursor bool, width int) string {
+	cursor := "  "
+	if atCursor {
+		cursor = "▸ "
+	}
+	check := "○"
+	if p.cleanSelected[c.Path] {
+		check = "●"
+	}
+	style := p.styleUntracked
+	if c.Ignored {
+		style = p.styleDim
+	}
+	line := cursor + check + " " + c.Path
+	rendered := style.Render(line)
+	if atCursor {
+		return lipgloss.NewStyle().Width(width).Background(lipgloss.Color(p.colors.CursorBg)).Render(rendered)
+	}
+	return lipgloss.NewStyle().Width(width).Render(rendered)
+}
+
+// padOverlay joins overlay lines and pads to the panel height.
+func (p *GitStatus) padOverlay(lines []string, width, height int) string {
+	empty := lipgloss.NewStyle().Width(width).Render("")
+	for len(lines) < height {
+		lines = append(lines, empty)
+	}
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/panels/gitstatus/clean.go
+++ b/internal/panels/gitstatus/clean.go
@@ -106,7 +106,7 @@ func (p *GitStatus) handleCleanResult(msg cleanResultMsg) (panels.Panel, tea.Cmd
 // handleCleanKey processes keys while the cleanup overlay is open.
 func (p *GitStatus) handleCleanKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 	switch msg.String() {
-	case "esc", "escape", "q":
+	case "esc", keyEscape, "q":
 		p.closeCleanOverlay()
 		return p, nil
 	case "j", "down":
@@ -119,7 +119,7 @@ func (p *GitStatus) handleCleanKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) 
 			p.cleanCursor--
 			p.ensureCleanCursorVisible()
 		}
-	case " ", "space":
+	case " ", keySpace:
 		p.toggleCleanSelection()
 	case "a":
 		p.toggleSelectAllClean()

--- a/internal/panels/gitstatus/gitstatus.go
+++ b/internal/panels/gitstatus/gitstatus.go
@@ -67,6 +67,12 @@ const (
 // unbounded memory growth during long sessions.
 const maxDiffCacheEntries = 50
 
+// Key name constants for KeyPressMsg.String() comparisons.
+const (
+	keyEscape = "escape"
+	keySpace  = "space"
+)
+
 // ---------------------------------------------------------------------------
 // Section groups
 // ---------------------------------------------------------------------------
@@ -417,7 +423,7 @@ func (p *GitStatus) KeyBindings() []panels.KeyBinding {
 		{Key: "h", Description: "Enter hunk mode", Action: "hunk_mode"},
 		{Key: "d", Description: "Discard unstaged changes", Action: "discard"},
 		{Key: "y", Description: "Copy hunk (or file path) to clipboard", Action: "copy"},
-		{Key: "space", Description: "Toggle select for bulk", Action: "toggle_select"},
+		{Key: keySpace, Description: "Toggle select for bulk", Action: "toggle_select"},
 		{Key: "a", Description: "Stage all", Action: "stage_all"},
 		{Key: "U", Description: "Unstage all", Action: "unstage_all"},
 		{Key: "R", Description: "Refresh status", Action: "refresh"},
@@ -912,7 +918,7 @@ func (p *GitStatus) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		return p.handleCleanKey(msg)
 	}
 	// Escape from hunk/line mode back to file mode.
-	if key == "esc" || key == "escape" {
+	if key == "esc" || key == keyEscape {
 		if p.mode != modeFile {
 			p.mode = modeFile
 			p.activeFile = ""
@@ -937,7 +943,7 @@ func (p *GitStatus) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		return p.stageAtCursor()
 	case "u":
 		return p.unstageAtCursor()
-	case " ", "space":
+	case " ", keySpace:
 		p.toggleSelection()
 	case "a":
 		return p.stageAll()

--- a/internal/panels/gitstatus/gitstatus.go
+++ b/internal/panels/gitstatus/gitstatus.go
@@ -134,6 +134,8 @@ type GitClient interface {
 	StageLine(ctx context.Context, path string, hunk git.Hunk, lineIdx int) error
 	UnstageLine(ctx context.Context, path string, hunk git.Hunk, lineIdx int) error
 	DiscardFile(ctx context.Context, path string) error
+	CleanPreview(ctx context.Context, opts git.CleanOpts) ([]git.CleanCandidate, error)
+	Clean(ctx context.Context, opts git.CleanOpts) error
 }
 
 // GitStatus is the git status panel. It implements [panels.Panel].
@@ -176,6 +178,14 @@ type GitStatus struct {
 	styleUnstaged      lipgloss.Style
 	styleUntracked     lipgloss.Style
 	styleDefault       lipgloss.Style
+	// Clean overlay state: preview of untracked files and their selection.
+	cleanCandidates     []git.CleanCandidate
+	cleanSelected       map[string]bool
+	cleanCursor         int
+	cleanOffset         int
+	cleanActive         bool
+	cleanLoading        bool
+	cleanIncludeIgnored bool
 }
 
 // Compile-time interface check.
@@ -190,6 +200,7 @@ func New(client GitClient, th *theme.Theme) *GitStatus {
 		selected:      make(map[string]bool),
 		expandedFiles: make(map[string]bool),
 		diffCache:     make(map[string][]git.Hunk),
+		cleanSelected: make(map[string]bool),
 		theme:         th,
 		colors:        colors,
 	}
@@ -313,6 +324,10 @@ func (p *GitStatus) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 		p.invalidateDiffCaches()
 		p.loading = true
 		return p, p.loadStatusCmd()
+	case cleanPreviewLoadedMsg:
+		return p.handleCleanPreviewLoaded(msg)
+	case cleanResultMsg:
+		return p.handleCleanResult(msg)
 	case panels.RefreshGitStatusMsg:
 		p.loading = true
 		return p, p.loadStatusCmd()
@@ -338,6 +353,9 @@ func (p *GitStatus) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 func (p *GitStatus) View(width, height int) string {
 	if width <= 0 || height <= 0 {
 		return ""
+	}
+	if p.cleanActive {
+		return p.renderCleanOverlay(width, height)
 	}
 	// Rebuild rows only when the underlying data has changed.
 	if p.rowsDirty {
@@ -403,6 +421,7 @@ func (p *GitStatus) KeyBindings() []panels.KeyBinding {
 		{Key: "a", Description: "Stage all", Action: "stage_all"},
 		{Key: "U", Description: "Unstage all", Action: "unstage_all"},
 		{Key: "R", Description: "Refresh status", Action: "refresh"},
+		{Key: "X", Description: "Clean untracked files (preview and select)", Action: "clean"},
 		{Key: "Esc", Description: "Exit hunk/line mode", Action: "escape"},
 	}
 }
@@ -666,6 +685,7 @@ const (
 	opRightClickPick  = "right_click_pick"
 	opFirstUseConfirm = "first_use_confirm"
 	opDiscard         = "discard"
+	opClean           = "clean"
 )
 
 // SetActionsCfg stores the actions configuration for right-click menus.
@@ -726,6 +746,8 @@ func (p *GitStatus) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, 
 		return p.executeRightClickAction(actions.ActionID(msg.Value))
 	case opDiscard:
 		return p, p.discardCmd(path)
+	case opClean:
+		return p, p.cleanSelectedCmd()
 	}
 	return p, nil
 }
@@ -886,6 +908,9 @@ func (p *GitStatus) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		return p, nil
 	}
 	key := msg.String()
+	if p.cleanActive {
+		return p.handleCleanKey(msg)
+	}
 	// Escape from hunk/line mode back to file mode.
 	if key == "esc" || key == "escape" {
 		if p.mode != modeFile {
@@ -928,6 +953,8 @@ func (p *GitStatus) handleKey(msg tea.KeyPressMsg) (panels.Panel, tea.Cmd) {
 		p.diffCache = make(map[string][]git.Hunk)
 		p.mode = modeFile
 		return p, p.loadStatusCmd()
+	case "X":
+		return p.openCleanOverlay()
 	}
 	return p, nil
 }

--- a/internal/panels/gitstatus/gitstatus_test.go
+++ b/internal/panels/gitstatus/gitstatus_test.go
@@ -1417,3 +1417,162 @@ func TestDiscardResultMsg_Error(t *testing.T) {
 	assert.NotNil(t, p.err)
 	assert.Nil(t, cmd, "should not reload on error")
 }
+
+// ---------------------------------------------------------------------------
+// Clean overlay (git clean preview + selective remove)
+// ---------------------------------------------------------------------------
+
+func cleanTestPanel(t *testing.T, mock *mockGitClient) *GitStatus {
+	t.Helper()
+	p := newTestPanel(t, mock)
+	p.Focus()
+	p.SetSize(80, 24)
+	return p
+}
+
+func TestCleanOverlayOpensAndPreviews(t *testing.T) {
+	mock := newMockGitClient(mockGitClientOptions{})
+	var previewOpts git.CleanOpts
+	mock.CleanPreviewFunc = func(_ context.Context, opts git.CleanOpts) ([]git.CleanCandidate, error) {
+		previewOpts = opts
+		cands := []git.CleanCandidate{{Path: "junk.txt"}, {Path: "build/"}}
+		if opts.IncludeIgnored {
+			cands = append(cands, git.CleanCandidate{Path: "debug.log", Ignored: true})
+		}
+		return cands, nil
+	}
+	p := cleanTestPanel(t, mock)
+
+	_, cmd := p.Update(keyMsg('X'))
+	require.True(t, p.cleanActive)
+	require.True(t, p.cleanLoading)
+	require.NotNil(t, cmd)
+	assert.False(t, previewOpts.IncludeIgnored)
+
+	p.Update(cmd())
+	assert.False(t, p.cleanLoading)
+	require.Len(t, p.cleanCandidates, 2)
+
+	out := p.View(80, 24)
+	assert.Contains(t, out, "Clean untracked files")
+	assert.Contains(t, out, "junk.txt")
+}
+
+func TestCleanIncludeIgnoredReloads(t *testing.T) {
+	mock := newMockGitClient(mockGitClientOptions{})
+	var previewOpts git.CleanOpts
+	mock.CleanPreviewFunc = func(_ context.Context, opts git.CleanOpts) ([]git.CleanCandidate, error) {
+		previewOpts = opts
+		cands := []git.CleanCandidate{{Path: "junk.txt"}}
+		if opts.IncludeIgnored {
+			cands = append(cands, git.CleanCandidate{Path: "debug.log", Ignored: true})
+		}
+		return cands, nil
+	}
+	p := cleanTestPanel(t, mock)
+	_, cmd := p.Update(keyMsg('X'))
+	p.Update(cmd())
+	require.Len(t, p.cleanCandidates, 1)
+
+	_, cmd = p.Update(keyMsg('i'))
+	require.True(t, p.cleanIncludeIgnored)
+	require.True(t, p.cleanLoading)
+	require.NotNil(t, cmd)
+	p.Update(cmd())
+	assert.True(t, previewOpts.IncludeIgnored)
+	require.Len(t, p.cleanCandidates, 2)
+}
+
+func TestCleanSelectConfirmAndRemove(t *testing.T) {
+	mock := newMockGitClient(mockGitClientOptions{})
+	mock.CleanPreviewFunc = func(_ context.Context, _ git.CleanOpts) ([]git.CleanCandidate, error) {
+		return []git.CleanCandidate{{Path: "junk.txt"}, {Path: "keep.txt"}}, nil
+	}
+	var cleanOpts git.CleanOpts
+	mock.CleanFunc = func(_ context.Context, opts git.CleanOpts) error {
+		cleanOpts = opts
+		return nil
+	}
+	p := cleanTestPanel(t, mock)
+	_, cmd := p.Update(keyMsg('X'))
+	p.Update(cmd())
+
+	// Select the first candidate (junk.txt) only.
+	p.Update(keyMsg(' '))
+	assert.True(t, p.cleanSelected["junk.txt"])
+
+	// Enter triggers a confirmation and sets the pending op.
+	_, cmd = p.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assert.Equal(t, opClean, p.pendingOp)
+	require.NotNil(t, cmd)
+
+	// Accepting the modal removes only the selected path.
+	_, cmd = p.Update(notify.ModalResultMsg{Accept: true})
+	require.NotNil(t, cmd)
+	p.Update(cmd())
+	assert.Equal(t, []string{"junk.txt"}, cleanOpts.Paths)
+	assert.False(t, cleanOpts.IncludeIgnored)
+	assert.False(t, p.cleanActive, "overlay should close after removal")
+}
+
+func TestCleanIgnoredSelectionForcesIncludeIgnored(t *testing.T) {
+	mock := newMockGitClient(mockGitClientOptions{})
+	mock.CleanPreviewFunc = func(_ context.Context, _ git.CleanOpts) ([]git.CleanCandidate, error) {
+		return []git.CleanCandidate{{Path: "debug.log", Ignored: true}}, nil
+	}
+	var cleanOpts git.CleanOpts
+	mock.CleanFunc = func(_ context.Context, opts git.CleanOpts) error {
+		cleanOpts = opts
+		return nil
+	}
+	p := cleanTestPanel(t, mock)
+	p.cleanIncludeIgnored = true
+	_, cmd := p.Update(keyMsg('X'))
+	p.Update(cmd())
+
+	p.Update(keyMsg('a')) // select all
+	_, _ = p.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	_, cmd = p.Update(notify.ModalResultMsg{Accept: true})
+	require.NotNil(t, cmd)
+	p.Update(cmd())
+	assert.Equal(t, []string{"debug.log"}, cleanOpts.Paths)
+	assert.True(t, cleanOpts.IncludeIgnored, "ignored selection must pass -x")
+}
+
+func TestCleanEnterWithNoSelectionDoesNotConfirm(t *testing.T) {
+	mock := newMockGitClient(mockGitClientOptions{})
+	mock.CleanPreviewFunc = func(_ context.Context, _ git.CleanOpts) ([]git.CleanCandidate, error) {
+		return []git.CleanCandidate{{Path: "junk.txt"}}, nil
+	}
+	p := cleanTestPanel(t, mock)
+	_, cmd := p.Update(keyMsg('X'))
+	p.Update(cmd())
+
+	_, cmd = p.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assert.Equal(t, "", p.pendingOp, "empty selection must not arm a removal")
+	assert.NotNil(t, cmd, "should surface an informational toast")
+}
+
+func TestCleanEscCloses(t *testing.T) {
+	mock := newMockGitClient(mockGitClientOptions{})
+	mock.CleanPreviewFunc = func(_ context.Context, _ git.CleanOpts) ([]git.CleanCandidate, error) {
+		return []git.CleanCandidate{{Path: "junk.txt"}}, nil
+	}
+	p := cleanTestPanel(t, mock)
+	_, cmd := p.Update(keyMsg('X'))
+	p.Update(cmd())
+	p.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	assert.False(t, p.cleanActive)
+}
+
+func TestCleanKeyBindingRegistered(t *testing.T) {
+	mock := &mockGitClient{}
+	p := New(mock, nil)
+	found := false
+	for _, b := range p.KeyBindings() {
+		if b.Action == "clean" {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected a clean key binding")
+}

--- a/magefile.go
+++ b/magefile.go
@@ -347,6 +347,8 @@ var deadcodeAllowlist = []string{
 	"MockClient.RevertContinue",
 	"MockClient.RevertAbort",
 	"MockClient.Reset",
+	"MockClient.Clean",
+	"MockClient.CleanPreview",
 }
 
 // Default target when running `mage` with no args.


### PR DESCRIPTION
## What this does

Adds a cleanup overlay to the Git Status panel for safely removing untracked files. Press `X` to open a preview built from `git clean` dry-run output, multi-select the entries you want gone, then confirm. Only the selected paths are removed. Including ignored files is opt-in and listed separately from plain untracked files.

Closes #272

## How it works

```mermaid
flowchart TD
    A[Press X in Git Status] --> B[git clean -nd dry run]
    B --> C{Include ignored?}
    C -- yes --> D[git clean -ndX for ignored]
    C -- no --> E[Untracked only]
    D --> F[List candidates, ignored marked separately]
    E --> F
    F --> G[Multi-select with space]
    G --> H{Confirm removal?}
    H -- no --> I[Close, nothing removed]
    H -- yes --> J[git clean -fd -- selected paths]
    J --> K[Refresh status and file tree]
```

## Changes

- New `internal/git/clean.go`: `CleanPreview` runs `git clean -nd` (untracked) and, when requested, `git clean -ndX` (ignored only) so ignored candidates are separated. `Clean` runs `git clean -fd -- <paths>` (adds `-x` when ignored are included). Empty path list is a no-op for safety, and every path is validated with `ValidateRepoRelativePath` before it reaches git.
- Dry-run output is parsed under a forced C locale so the "Would remove" prefix is stable across languages.
- New cleanup overlay in `internal/panels/gitstatus/clean.go`: candidate list, multi-select, select-all, cursor, counts, and a confirmation step that reuses the existing destructive-operation prompt.
- Keybinding `X` registered in the single source of truth (`keybindings.json`), mirrored in the panel `KeyBindings()` and regenerated `docs/keybindings.md`.

## Testing

- `internal/git`: table tests for dry-run parsing plus integration tests against a real repo for preview and remove behavior, including the opt-in ignored path.
- `internal/panels/gitstatus`: overlay open/close, selection toggles, select-all, confirm dispatch, and rendering.
- `go build ./...`, `go vet ./...`, `gofumpt -l` clean.

## Safety

- Nothing is removed without explicit confirmation.
- Removal is scoped to the exact selected paths; no selection means no operation.
- Ignored files require an explicit opt-in and are visually separated from untracked files.
- All paths are validated before being passed to git.