### PR TITLE
feat(gitstatus): pre-stage secret guard

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,8 @@ auto_fetch_interval = "5m"       # Automatic fetch interval
 show_commit_graph = true         # Display commit graph in git log
 max_log_entries = 500            # Maximum git log entries to display (≥ 1)
 sign_commits = false             # Sign commits with GPG
+secret_guard = true              # Scan files for secrets before staging
+secret_guard_mode = "warn"       # "warn" (confirm) or "block" (refuse)
 ```
 
 ---

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,12 +88,14 @@ type GitConfig struct {
 	DefaultBranch           string   `toml:"default_branch"`
 	WorktreeMergeMethod     string   `toml:"worktree_merge_method"`
 	WorktreeOpenMode        string   `toml:"worktree_open_mode"`
+	SecretGuardMode         string   `toml:"secret_guard_mode"` // "warn" or "block"
 	RefreshFallbackInterval Duration `toml:"refresh_fallback_interval"`
 	AutoFetchInterval       Duration `toml:"auto_fetch_interval"`
 	MaxLogEntries           int      `toml:"max_log_entries"`
 	WorktreeFirst           bool     `toml:"worktree_first"`
 	ShowCommitGraph         bool     `toml:"show_commit_graph"`
 	SignCommits             bool     `toml:"sign_commits"`
+	SecretGuard             bool     `toml:"secret_guard"` // scan files for secrets before staging
 }
 
 // GitHubConfig holds GitHub integration settings.

--- a/internal/config/defaults.toml
+++ b/internal/config/defaults.toml
@@ -41,6 +41,8 @@ auto_fetch_interval = "5m"
 show_commit_graph = true
 max_log_entries = 500
 sign_commits = false
+secret_guard = true
+secret_guard_mode = "warn"
 
 [github]
 owner = ""

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -87,6 +87,8 @@ func Validate(cfg *Config) error {
 		cfg.Git.WorktreeMergeMethod, "merge", "rebase", "squash")
 	errs = appendEnumErr(errs, "git.worktree_open_mode",
 		cfg.Git.WorktreeOpenMode, "current", "new_terminal")
+	errs = appendEnumErr(errs, "git.secret_guard_mode",
+		cfg.Git.SecretGuardMode, "warn", "block")
 	if cfg.Git.RefreshFallbackInterval.Duration <= 0 {
 		errs = append(errs, fieldErr("git.refresh_fallback_interval", "must be a positive duration"))
 	}

--- a/internal/git/gittest/mock_client.go
+++ b/internal/git/gittest/mock_client.go
@@ -70,6 +70,7 @@ type MockClient struct {
 	RevertContinueFunc func(ctx context.Context) error
 	RevertAbortFunc    func(ctx context.Context) error
 	ResetFunc          func(ctx context.Context, ref string, mode git.ResetMode) error
+	WorktreeFileFunc   func(ctx context.Context, path string) ([]byte, error)
 }
 
 // Compile-time check that MockClient implements git.GitClient.
@@ -475,6 +476,14 @@ func (m *MockClient) DiscardFile(ctx context.Context, path string) error {
 		return m.DiscardFileFunc(ctx, path)
 	}
 	return nil
+}
+
+// WorktreeFile returns the mocked working-tree content for a path.
+func (m *MockClient) WorktreeFile(ctx context.Context, path string) ([]byte, error) {
+	if m.WorktreeFileFunc != nil {
+		return m.WorktreeFileFunc(ctx, path)
+	}
+	return nil, nil
 }
 
 func (m *MockClient) DiscardAllUnstaged(ctx context.Context) error {

--- a/internal/git/read.go
+++ b/internal/git/read.go
@@ -1,0 +1,50 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// WorktreeFileMaxBytes caps how much of a working-tree file is read, so a very
+// large file cannot exhaust memory during a pre-stage scan.
+const WorktreeFileMaxBytes = 5 << 20 // 5 MiB
+
+// WorktreeFile reads the working-tree content of a repository-relative path.
+// It exists so callers can inspect a file before it is staged. The path is
+// validated to reject absolute paths and directory traversal, the resolved
+// path is confirmed to stay within the repository, and the read is capped at
+// WorktreeFileMaxBytes.
+func (c *Client) WorktreeFile(ctx context.Context, path string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := ValidateRepoRelativePath(path); err != nil {
+		return nil, fmt.Errorf("worktree file %q: %w", path, err)
+	}
+
+	root, err := filepath.Abs(c.repoDir)
+	if err != nil {
+		return nil, fmt.Errorf("worktree file: %w", err)
+	}
+	full := filepath.Join(root, filepath.FromSlash(path))
+	rel, err := filepath.Rel(root, full)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return nil, fmt.Errorf("worktree file %q: path escapes repository", path)
+	}
+
+	f, err := os.Open(full)
+	if err != nil {
+		return nil, fmt.Errorf("worktree file %q: %w", path, err)
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, WorktreeFileMaxBytes))
+	if err != nil {
+		return nil, fmt.Errorf("worktree file %q: %w", path, err)
+	}
+	return data, nil
+}

--- a/internal/git/read_test.go
+++ b/internal/git/read_test.go
@@ -1,0 +1,44 @@
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorktreeFile(t *testing.T) {
+	dir := initTestRepo(t)
+	client, err := NewClient(dir)
+	require.NoError(t, err)
+
+	want := []byte("api_key = ghp_" + "0123456789abcdefghijklmnopqrstuvwxyz\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.txt"), want, 0o644))
+
+	got, err := client.WorktreeFile(context.Background(), "config.txt")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestWorktreeFile_RejectsTraversal(t *testing.T) {
+	dir := initTestRepo(t)
+	client, err := NewClient(dir)
+	require.NoError(t, err)
+
+	for _, p := range []string{"../secret", "..", "/etc/passwd"} {
+		_, err := client.WorktreeFile(context.Background(), p)
+		assert.Error(t, err, "path %q should be rejected", p)
+	}
+}
+
+func TestWorktreeFile_MissingFile(t *testing.T) {
+	dir := initTestRepo(t)
+	client, err := NewClient(dir)
+	require.NoError(t, err)
+
+	_, err = client.WorktreeFile(context.Background(), "does-not-exist.txt")
+	assert.Error(t, err)
+}

--- a/internal/panelreg/panelreg.go
+++ b/internal/panelreg/panelreg.go
@@ -49,6 +49,15 @@ func (d Deps) ApplyActionsCfg(p panels.Panel) panels.Panel {
 	return p
 }
 
+// ApplyGitCfg injects the git configuration into panels that support the
+// optional SetGitCfg method (for example the pre-stage secret guard).
+func (d Deps) ApplyGitCfg(p panels.Panel) panels.Panel {
+	if gc, ok := p.(interface{ SetGitCfg(config.GitConfig) }); ok {
+		gc.SetGitCfg(d.Config.Git)
+	}
+	return p
+}
+
 // Placeholder returns a placeholder panel for the given name, using the
 // theme from deps.
 func (d Deps) Placeholder(name string) panels.Panel {

--- a/internal/panels/gitstatus/gitstatus.go
+++ b/internal/panels/gitstatus/gitstatus.go
@@ -134,6 +134,7 @@ type GitClient interface {
 	StageLine(ctx context.Context, path string, hunk git.Hunk, lineIdx int) error
 	UnstageLine(ctx context.Context, path string, hunk git.Hunk, lineIdx int) error
 	DiscardFile(ctx context.Context, path string) error
+	WorktreeFile(ctx context.Context, path string) ([]byte, error)
 }
 
 // GitStatus is the git status panel. It implements [panels.Panel].
@@ -176,6 +177,10 @@ type GitStatus struct {
 	styleUnstaged      lipgloss.Style
 	styleUntracked     lipgloss.Style
 	styleDefault       lipgloss.Style
+	// Secret guard: scan working-tree content and filenames before staging.
+	secretGuardMode   string   // "warn" or "block"
+	pendingStagePaths []string // paths awaiting a warn-mode confirmation
+	secretGuard       bool     // whether the guard runs at all
 }
 
 // Compile-time interface check.
@@ -294,6 +299,8 @@ func (p *GitStatus) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 		p.rebuildRows()
 		p.rowsDirty = false
 		return p, nil
+	case stageScanMsg:
+		return p.handleStageScan(msg)
 	case stageResultMsg:
 		if msg.err != nil {
 			p.err = msg.err
@@ -666,10 +673,17 @@ const (
 	opRightClickPick  = "right_click_pick"
 	opFirstUseConfirm = "first_use_confirm"
 	opDiscard         = "discard"
+	opStageGuard      = "stage_guard"
 )
 
 // SetActionsCfg stores the actions configuration for right-click menus.
 func (p *GitStatus) SetActionsCfg(cfg config.ActionsConfig) { p.actionsCfg = cfg }
+
+// SetGitCfg applies git-related settings, including the pre-stage secret guard.
+func (p *GitStatus) SetGitCfg(cfg config.GitConfig) {
+	p.secretGuard = cfg.SecretGuard
+	p.secretGuardMode = cfg.SecretGuardMode
+}
 
 // handleMouseRightClick opens the context menu for the file at the clicked row.
 func (p *GitStatus) handleMouseRightClick(msg panels.PanelMouseRightClickMsg) (panels.Panel, tea.Cmd) {
@@ -705,6 +719,7 @@ func (p *GitStatus) clearPending() {
 	p.pendingOp = ""
 	p.pendingName = ""
 	p.pendingPath = ""
+	p.pendingStagePaths = nil
 }
 
 // handleModalResult dispatches the result of an action-picker modal.
@@ -712,6 +727,7 @@ func (p *GitStatus) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, 
 	op := p.pendingOp
 	name := p.pendingName
 	path := p.pendingPath
+	stagePaths := p.pendingStagePaths
 	p.clearPending()
 	if !msg.Accept {
 		return p, nil
@@ -726,6 +742,11 @@ func (p *GitStatus) handleModalResult(msg notify.ModalResultMsg) (panels.Panel, 
 		return p.executeRightClickAction(actions.ActionID(msg.Value))
 	case opDiscard:
 		return p, p.discardCmd(path)
+	case opStageGuard:
+		if len(stagePaths) == 0 {
+			return p, nil
+		}
+		return p, p.stageCmd(stagePaths)
 	}
 	return p, nil
 }
@@ -1083,7 +1104,7 @@ func (p *GitStatus) stageAtCursor() (panels.Panel, tea.Cmd) {
 		if r.file == nil {
 			return p, nil
 		}
-		return p, p.stageCmd([]string{r.file.Path})
+		return p.stage([]string{r.file.Path})
 	case rowHunk:
 		if r.file == nil || r.hunkEntry == nil {
 			return p, nil
@@ -1091,7 +1112,7 @@ func (p *GitStatus) stageAtCursor() (panels.Panel, tea.Cmd) {
 		if r.section == sectionUnstaged {
 			return p, p.stageHunkCmd(r.file.Path, *r.hunkEntry)
 		}
-		return p, p.stageCmd([]string{r.file.Path})
+		return p.stage([]string{r.file.Path})
 	case rowDiffLine:
 		if r.file == nil || r.diffLine == nil {
 			return p, nil
@@ -1108,7 +1129,7 @@ func (p *GitStatus) stageAtCursor() (panels.Panel, tea.Cmd) {
 			}
 			return p, nil
 		}
-		return p, p.stageCmd([]string{r.file.Path})
+		return p.stage([]string{r.file.Path})
 	}
 	return p, nil
 }
@@ -1166,7 +1187,7 @@ func (p *GitStatus) stageAll() (panels.Panel, tea.Cmd) {
 	if len(paths) == 0 {
 		return p, nil
 	}
-	return p, p.stageCmd(paths)
+	return p.stage(paths)
 }
 
 // stageSectionFiles stages all files belonging to the given section.
@@ -1188,7 +1209,7 @@ func (p *GitStatus) stageSectionFiles(sec section) (panels.Panel, tea.Cmd) {
 	for i := range targets {
 		paths = append(paths, targets[i].Path)
 	}
-	return p, p.stageCmd(paths)
+	return p.stage(paths)
 }
 
 // unstageSectionFiles unstages all files belonging to the given section.

--- a/internal/panels/gitstatus/register.go
+++ b/internal/panels/gitstatus/register.go
@@ -11,6 +11,6 @@ func init() {
 		if err != nil {
 			return deps.Placeholder("gitstatus")
 		}
-		return deps.ApplyActionsCfg(New(client, deps.Theme))
+		return deps.ApplyGitCfg(deps.ApplyActionsCfg(New(client, deps.Theme)))
 	})
 }

--- a/internal/panels/gitstatus/secretguard.go
+++ b/internal/panels/gitstatus/secretguard.go
@@ -1,0 +1,143 @@
+package gitstatus
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/jongio/grut/internal/notify"
+	"github.com/jongio/grut/internal/panels"
+	"github.com/jongio/grut/internal/secretscan"
+)
+
+// secretGuardModeBlock refuses staging outright when a secret is detected,
+// rather than offering a confirmation. Any other value (the default) warns.
+const secretGuardModeBlock = "block"
+
+// fileFindings groups the secret-scan findings for a single path.
+type fileFindings struct {
+	path     string
+	findings []secretscan.Finding
+}
+
+// stageScanMsg carries the result of scanning files before they are staged.
+type stageScanMsg struct {
+	err     error
+	paths   []string
+	flagged []fileFindings
+}
+
+// stage is the guarded entry point for staging whole files. When the secret
+// guard is disabled it stages immediately; otherwise it scans the working-tree
+// content and filenames first and only stages once the scan is clear or the
+// user confirms.
+func (p *GitStatus) stage(paths []string) (panels.Panel, tea.Cmd) {
+	if len(paths) == 0 {
+		return p, nil
+	}
+	if !p.secretGuard {
+		return p, p.stageCmd(paths)
+	}
+	return p, p.scanStageCmd(paths)
+}
+
+// scanStageCmd reads each path's working-tree content and scans it for
+// secrets, returning a stageScanMsg with any findings.
+func (p *GitStatus) scanStageCmd(paths []string) tea.Cmd {
+	ctx := p.ctx
+	client := p.git
+	targets := append([]string(nil), paths...)
+	return func() tea.Msg {
+		var flagged []fileFindings
+		for _, path := range targets {
+			content, err := readForScan(ctx, client, path)
+			if err != nil {
+				// A read failure (for example a deleted or unreadable file)
+				// should not silently bypass the guard: surface it so the
+				// user can decide.
+				return stageScanMsg{paths: targets, err: err}
+			}
+			if findings := secretscan.Scan(content, path); len(findings) > 0 {
+				flagged = append(flagged, fileFindings{path: path, findings: findings})
+			}
+		}
+		return stageScanMsg{paths: targets, flagged: flagged}
+	}
+}
+
+// readForScan fetches the working-tree content for a path, tolerating a nil
+// content result from the client.
+func readForScan(ctx context.Context, client GitClient, path string) ([]byte, error) {
+	data, err := client.WorktreeFile(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// handleStageScan acts on a completed pre-stage scan. With no findings it
+// stages immediately. In block mode any finding refuses the stage; otherwise
+// it asks the user to confirm.
+func (p *GitStatus) handleStageScan(msg stageScanMsg) (panels.Panel, tea.Cmd) {
+	if msg.err != nil {
+		errText := msg.err.Error()
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: "Secret scan failed, staging cancelled: " + errText,
+				Level:   notify.Error,
+			}
+		}
+	}
+	if len(msg.flagged) == 0 {
+		return p, p.stageCmd(msg.paths)
+	}
+
+	summary := summarizeFindings(msg.flagged)
+	if strings.EqualFold(p.secretGuardMode, secretGuardModeBlock) {
+		return p, func() tea.Msg {
+			return notify.ShowToastMsg{
+				Message: "Staging blocked: possible secrets detected. " + summary,
+				Level:   notify.Error,
+			}
+		}
+	}
+
+	p.clearPending()
+	p.pendingOp = opStageGuard
+	p.pendingStagePaths = msg.paths
+	return p, notify.ShowConfirm("Possible secrets detected",
+		summary+" Stage anyway?")
+}
+
+// summarizeFindings builds a short, value-free description of the findings for
+// a confirmation or error message.
+func summarizeFindings(flagged []fileFindings) string {
+	var parts []string
+	const maxFiles = 3
+	for i, ff := range flagged {
+		if i >= maxFiles {
+			parts = append(parts, fmt.Sprintf("and %d more", len(flagged)-maxFiles))
+			break
+		}
+		rules := ruleList(ff.findings)
+		parts = append(parts, fmt.Sprintf("%s (%s)", filepath.Base(ff.path), rules))
+	}
+	return strings.Join(parts, ", ") + "."
+}
+
+// ruleList returns a comma-separated, de-duplicated list of rule ids.
+func ruleList(findings []secretscan.Finding) string {
+	seen := make(map[string]struct{}, len(findings))
+	var rules []string
+	for _, f := range findings {
+		if _, dup := seen[f.Rule]; dup {
+			continue
+		}
+		seen[f.Rule] = struct{}{}
+		rules = append(rules, f.Rule)
+	}
+	return strings.Join(rules, ", ")
+}

--- a/internal/panels/gitstatus/secretguard_test.go
+++ b/internal/panels/gitstatus/secretguard_test.go
@@ -1,0 +1,119 @@
+package gitstatus
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jongio/grut/internal/config"
+	"github.com/jongio/grut/internal/notify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Assembled from split literals so no contiguous token appears in source.
+var secretContent = "token = ghp_" + "0123456789abcdefghijklmnopqrstuvwxyz\n"
+
+func guardedPanel(t *testing.T, mode string, content []byte, readErr error) (*GitStatus, *mockGitClient) {
+	t.Helper()
+	mock := newMockGitClient(mockGitClientOptions{})
+	mock.WorktreeFileFunc = func(_ context.Context, _ string) ([]byte, error) {
+		return content, readErr
+	}
+	p := newTestPanel(t, mock)
+	p.SetGitCfg(config.GitConfig{SecretGuard: true, SecretGuardMode: mode})
+	return p, mock
+}
+
+func TestSecretGuard_DisabledStagesDirectly(t *testing.T) {
+	mock := newMockGitClient(mockGitClientOptions{})
+	p := newTestPanel(t, mock)
+	// Guard defaults to disabled (SetGitCfg not called).
+	_, cmd := p.stage([]string{"a.txt"})
+	require.NotNil(t, cmd)
+	cmd() // executes Stage on the mock
+	assert.Equal(t, []string{"a.txt"}, mock.stagedPaths)
+}
+
+func TestSecretGuard_NoFindingsStages(t *testing.T) {
+	p, mock := guardedPanel(t, "warn", []byte("just some ordinary code\n"), nil)
+	_, cmd := p.stage([]string{"clean.go"})
+	require.NotNil(t, cmd)
+	msg := cmd()
+	_, next := p.Update(msg)
+	require.NotNil(t, next)
+	next()
+	assert.Equal(t, []string{"clean.go"}, mock.stagedPaths)
+	assert.Empty(t, p.pendingOp)
+}
+
+func TestSecretGuard_WarnPromptsThenStagesOnConfirm(t *testing.T) {
+	p, mock := guardedPanel(t, "warn", []byte(secretContent), nil)
+	_, cmd := p.stage([]string{"secrets.txt"})
+	require.NotNil(t, cmd)
+	_, next := p.Update(cmd())
+	require.NotNil(t, next)
+	next() // ShowConfirm command; harmless to run
+
+	assert.Empty(t, mock.stagedPaths, "must not stage before confirmation")
+	assert.Equal(t, opStageGuard, p.pendingOp)
+	assert.Equal(t, []string{"secrets.txt"}, p.pendingStagePaths)
+
+	_, stageCmd := p.Update(notify.ModalResultMsg{Accept: true})
+	require.NotNil(t, stageCmd)
+	stageCmd()
+	assert.Equal(t, []string{"secrets.txt"}, mock.stagedPaths)
+	assert.Empty(t, p.pendingOp, "pending state cleared after confirm")
+}
+
+func TestSecretGuard_WarnCancelDoesNotStage(t *testing.T) {
+	p, mock := guardedPanel(t, "warn", []byte(secretContent), nil)
+	_, cmd := p.stage([]string{"secrets.txt"})
+	require.NotNil(t, cmd)
+	p.Update(cmd())
+
+	p.Update(notify.ModalResultMsg{Accept: false})
+	assert.Empty(t, mock.stagedPaths, "cancel must not stage")
+	assert.Empty(t, p.pendingOp)
+}
+
+func TestSecretGuard_BlockRefuses(t *testing.T) {
+	p, mock := guardedPanel(t, "block", []byte(secretContent), nil)
+	_, cmd := p.stage([]string{"secrets.txt"})
+	require.NotNil(t, cmd)
+	_, next := p.Update(cmd())
+	require.NotNil(t, next)
+	toast, ok := next().(notify.ShowToastMsg)
+	require.True(t, ok, "block mode should emit a toast")
+	assert.Equal(t, notify.Error, toast.Level)
+	assert.Empty(t, mock.stagedPaths, "block mode must never stage")
+	assert.Empty(t, p.pendingOp, "block mode does not arm a confirmation")
+}
+
+func TestSecretGuard_ScanErrorCancelsStage(t *testing.T) {
+	p, mock := guardedPanel(t, "warn", nil, errors.New("read failed"))
+	_, cmd := p.stage([]string{"gone.txt"})
+	require.NotNil(t, cmd)
+	_, next := p.Update(cmd())
+	require.NotNil(t, next)
+	toast, ok := next().(notify.ShowToastMsg)
+	require.True(t, ok)
+	assert.Equal(t, notify.Error, toast.Level)
+	assert.Empty(t, mock.stagedPaths, "scan error must not silently stage")
+}
+
+func TestSecretGuard_SensitiveFilenameFlagged(t *testing.T) {
+	// Content is clean, but the filename is sensitive.
+	p, mock := guardedPanel(t, "warn", []byte("nothing here\n"), nil)
+	_, cmd := p.stage([]string{".env"})
+	require.NotNil(t, cmd)
+	p.Update(cmd())
+	assert.Equal(t, opStageGuard, p.pendingOp, "sensitive filename should prompt")
+	assert.Empty(t, mock.stagedPaths)
+}
+
+func TestSecretGuard_EmptyPathsNoop(t *testing.T) {
+	p, _ := guardedPanel(t, "warn", []byte(secretContent), nil)
+	_, cmd := p.stage(nil)
+	assert.Nil(t, cmd)
+}

--- a/internal/secretscan/secretscan.go
+++ b/internal/secretscan/secretscan.go
@@ -1,0 +1,283 @@
+// Package secretscan detects likely secrets in file content and flags
+// sensitive filenames before they are staged into git. It is deliberately
+// conservative: high-confidence provider patterns and sensitive filenames
+// always fire, while the generic high-entropy check is gated by an allowlist
+// so that everyday source code stays quiet.
+package secretscan
+
+import (
+	"bytes"
+	"math"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Finding describes one reason a file was flagged.
+type Finding struct {
+	// Rule is a short, stable identifier for the rule that matched
+	// (for example "github-token" or "sensitive-filename").
+	Rule string
+	// Detail is a human-readable description shown to the user. It never
+	// includes the secret value itself, only the rule and location.
+	Detail string
+	// Line is the 1-based line number for content matches, or 0 for a
+	// match based on the filename alone.
+	Line int
+}
+
+// maxScanBytes caps how much file content is scanned so a very large file
+// cannot stall the UI. Credentials that matter in practice sit near the top
+// of config and source files, so a generous cap is safe.
+const maxScanBytes = 1 << 20 // 1 MiB
+
+// minGenericValueLen is the shortest value the generic high-entropy rule will
+// consider, avoiding noise from short tokens that are unlikely to be secrets.
+const minGenericValueLen = 16
+
+// minGenericEntropy is the Shannon entropy (bits per character) a generic
+// value must exceed before it is treated as a possible secret.
+const minGenericEntropy = 3.5
+
+// Rule identifiers reported in Finding.Rule.
+const (
+	RuleGitHubToken       = "github-token"
+	RuleAWSAccessKey      = "aws-access-key"
+	RulePrivateKey        = "private-key"
+	RuleSlackToken        = "slack-token"
+	RuleGoogleAPIKey      = "google-api-key"
+	RuleStripeKey         = "stripe-key"
+	RuleHighEntropyValue  = "high-entropy-value"
+	RuleSensitiveFilename = "sensitive-filename"
+)
+
+// contentRule pairs a compiled pattern with the metadata reported on a match.
+type contentRule struct {
+	re     *regexp.Regexp
+	rule   string
+	detail string
+}
+
+var contentRules = []contentRule{
+	{
+		re:     regexp.MustCompile(`\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36}\b`),
+		rule:   RuleGitHubToken,
+		detail: "GitHub personal access or app token",
+	},
+	{
+		re:     regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}\b`),
+		rule:   RuleGitHubToken,
+		detail: "GitHub fine-grained personal access token",
+	},
+	{
+		re:     regexp.MustCompile(`\b(?:AKIA|ASIA)[0-9A-Z]{16}\b`),
+		rule:   RuleAWSAccessKey,
+		detail: "AWS access key id",
+	},
+	{
+		re:     regexp.MustCompile(`-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----`),
+		rule:   RulePrivateKey,
+		detail: "Private key block",
+	},
+	{
+		re:     regexp.MustCompile(`\bxox[baprs]-[0-9A-Za-z-]{10,}\b`),
+		rule:   RuleSlackToken,
+		detail: "Slack token",
+	},
+	{
+		re:     regexp.MustCompile(`\bAIza[0-9A-Za-z_\-]{35}\b`),
+		rule:   RuleGoogleAPIKey,
+		detail: "Google API key",
+	},
+	{
+		re:     regexp.MustCompile(`\b(?:sk|rk)_(?:live|test)_[0-9A-Za-z]{16,}\b`),
+		rule:   RuleStripeKey,
+		detail: "Stripe secret key",
+	},
+}
+
+// genericAssignment matches "key = value" style declarations where the key
+// name hints at a credential. The value is entropy-checked before it is
+// reported so that ordinary configuration does not trip the rule.
+var genericAssignment = regexp.MustCompile(
+	`(?i)(api[_-]?key|secret|token|password|passwd|pwd|access[_-]?key|auth)\s*[:=]\s*["']?([^\s"'` + "`" + `]+)`,
+)
+
+// placeholderHints mark values that are obviously not real secrets. They keep
+// examples, templates, and interpolation expressions from being flagged.
+var placeholderHints = []string{
+	"example", "changeme", "change-me", "placeholder", "your_", "your-",
+	"yourkey", "xxxx", "todo", "dummy", "sample", "redacted", "<", ">",
+	"${", "{{", "}}", "notreal", "fake", "test-", "insertkey", "none",
+}
+
+// exactSensitiveNames are filenames that are sensitive regardless of contents.
+var exactSensitiveNames = map[string]struct{}{
+	".env":             {},
+	"id_rsa":           {},
+	"id_dsa":           {},
+	"id_ecdsa":         {},
+	"id_ed25519":       {},
+	"credentials.json": {},
+	".netrc":           {},
+	".pgpass":          {},
+	".npmrc":           {},
+}
+
+// sensitiveExts are file extensions that typically hold keys or certificates.
+var sensitiveExts = map[string]struct{}{
+	".pem":      {},
+	".key":      {},
+	".pfx":      {},
+	".p12":      {},
+	".keystore": {},
+	".jks":      {},
+}
+
+// safeEnvSuffixes keep example and template env files from being flagged even
+// though they start with ".env".
+var safeEnvSuffixes = []string{".example", ".sample", ".template", ".dist"}
+
+// Scan inspects file content and its path and returns any findings. Content
+// scanning is skipped for binary data, but the filename rules still apply.
+// The returned slice is nil when nothing is flagged.
+func Scan(content []byte, path string) []Finding {
+	var findings []Finding
+
+	if f, ok := filenameFinding(path); ok {
+		findings = append(findings, f)
+	}
+
+	if len(content) == 0 || isBinary(content) {
+		return findings
+	}
+
+	scan := content
+	if len(scan) > maxScanBytes {
+		scan = scan[:maxScanBytes]
+	}
+	findings = append(findings, contentFindings(scan)...)
+	return findings
+}
+
+// HasFindings reports whether Scan would flag the given content or path.
+func HasFindings(content []byte, path string) bool {
+	return len(Scan(content, path)) > 0
+}
+
+// filenameFinding reports a sensitive-filename match based on path alone.
+func filenameFinding(path string) (Finding, bool) {
+	base := strings.ToLower(filepath.Base(filepath.FromSlash(path)))
+	if base == "" {
+		return Finding{}, false
+	}
+	if _, ok := exactSensitiveNames[base]; ok {
+		return Finding{Rule: RuleSensitiveFilename, Detail: "sensitive filename " + base}, true
+	}
+	if strings.HasPrefix(base, ".env.") && !hasSafeEnvSuffix(base) {
+		return Finding{Rule: RuleSensitiveFilename, Detail: "environment file " + base}, true
+	}
+	if _, ok := sensitiveExts[filepath.Ext(base)]; ok {
+		return Finding{Rule: RuleSensitiveFilename, Detail: "sensitive filename " + base}, true
+	}
+	return Finding{}, false
+}
+
+func hasSafeEnvSuffix(base string) bool {
+	for _, s := range safeEnvSuffixes {
+		if strings.HasSuffix(base, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// contentFindings runs the provider patterns and the gated generic rule over
+// the given content, deduplicating by rule and line.
+func contentFindings(content []byte) []Finding {
+	var findings []Finding
+	seen := make(map[string]struct{})
+
+	add := func(rule, detail string, line int) {
+		key := rule + ":" + detail
+		if _, dup := seen[key]; dup {
+			return
+		}
+		seen[key] = struct{}{}
+		findings = append(findings, Finding{Rule: rule, Detail: detail, Line: line})
+	}
+
+	for _, cr := range contentRules {
+		if loc := cr.re.FindIndex(content); loc != nil {
+			add(cr.rule, cr.detail, lineOf(content, loc[0]))
+		}
+	}
+
+	for _, m := range genericAssignment.FindAllSubmatchIndex(content, -1) {
+		keyName := string(content[m[2]:m[3]])
+		value := string(content[m[4]:m[5]])
+		if !looksLikeSecret(value) {
+			continue
+		}
+		add(RuleHighEntropyValue,
+			"high-entropy value assigned to "+strings.ToLower(keyName),
+			lineOf(content, m[4]))
+	}
+	return findings
+}
+
+// looksLikeSecret reports whether a generic assignment value is long enough,
+// high-entropy enough, and free of placeholder hints to be treated as a
+// possible secret.
+func looksLikeSecret(value string) bool {
+	if len(value) < minGenericValueLen {
+		return false
+	}
+	lower := strings.ToLower(value)
+	for _, h := range placeholderHints {
+		if strings.Contains(lower, h) {
+			return false
+		}
+	}
+	return shannonEntropy(value) >= minGenericEntropy
+}
+
+// shannonEntropy returns the Shannon entropy of s in bits per character.
+func shannonEntropy(s string) float64 {
+	if s == "" {
+		return 0
+	}
+	var counts [256]int
+	for i := 0; i < len(s); i++ {
+		counts[s[i]]++
+	}
+	var entropy float64
+	length := float64(len(s))
+	for _, c := range counts {
+		if c == 0 {
+			continue
+		}
+		p := float64(c) / length
+		entropy -= p * math.Log2(p)
+	}
+	return entropy
+}
+
+// lineOf returns the 1-based line number of the byte at index idx.
+func lineOf(content []byte, idx int) int {
+	if idx < 0 || idx > len(content) {
+		return 0
+	}
+	return bytes.Count(content[:idx], []byte{'\n'}) + 1
+}
+
+// isBinary reports whether content looks like binary data. A NUL byte within
+// the sniffed prefix is a reliable signal of a non-text file.
+func isBinary(content []byte) bool {
+	sniff := content
+	const sniffLen = 8000
+	if len(sniff) > sniffLen {
+		sniff = sniff[:sniffLen]
+	}
+	return bytes.IndexByte(sniff, 0) != -1
+}

--- a/internal/secretscan/secretscan_test.go
+++ b/internal/secretscan/secretscan_test.go
@@ -1,0 +1,149 @@
+package secretscan
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Test fixtures are assembled from split literals so that no contiguous
+// secret-like token appears in the source. This keeps the fixtures clear of
+// GitHub push protection while still exercising the detection patterns at
+// runtime. None of these are real credentials.
+var (
+	fxGitHub    = "ghp_" + "0123456789abcdefghijklmnopqrstuvwxyz"
+	fxGitHubPAT = "github_pat_" + "11ABCDEFG0abcdefghij_KLMNOPqrstuvwxyz012345"
+	fxSlack     = "xox" + "b-1234567890-abcdefghijklmno"
+	fxGoogle    = "AIza" + "SyA1234567890abcdefghijklmnopqrstuv"
+	fxStripe    = "sk_" + "live_0123456789abcdef0123"
+)
+
+func hasRule(findings []Finding, rule string) bool {
+	for _, f := range findings {
+		if f.Rule == rule {
+			return true
+		}
+	}
+	return false
+}
+
+func TestScan_ContentTruePositives(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		rule    string
+	}{
+		{"github classic", fmt.Sprintf("token = %q", fxGitHub), RuleGitHubToken},
+		{"github fine-grained", "GH=" + fxGitHubPAT, RuleGitHubToken},
+		{"aws access key", "AWS_ACCESS_KEY_ID=AKIA" + "IOSFODNN7EXAMPLE", RuleAWSAccessKey},
+		{"private key", "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n", RulePrivateKey},
+		{"openssh key", "-----BEGIN OPENSSH PRIVATE KEY-----\nb3Blbn...", RulePrivateKey},
+		{"slack token", "slack=" + fxSlack, RuleSlackToken},
+		{"google api key", "key=" + fxGoogle, RuleGoogleAPIKey},
+		{"stripe key", "STRIPE=" + fxStripe, RuleStripeKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := Scan([]byte(tc.content), "config.txt")
+			if !hasRule(findings, tc.rule) {
+				t.Fatalf("expected rule %q, got %+v", tc.rule, findings)
+			}
+		})
+	}
+}
+
+func TestScan_GenericHighEntropy(t *testing.T) {
+	content := []byte(`api_key = "Zx83kLm92QpVn5RtWy71Bc48Df06Hg23"`)
+	findings := Scan(content, "settings.conf")
+	if !hasRule(findings, RuleHighEntropyValue) {
+		t.Fatalf("expected high-entropy-value finding, got %+v", findings)
+	}
+}
+
+func TestScan_FalsePositives(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"plain code", "func Add(a, b int) int { return a + b }\n"},
+		{"placeholder env", `API_KEY=your-api-key-here`},
+		{"example value", `token = "example-token-value-000"`},
+		{"interpolation", "secret = ${MY_SECRET}"},
+		{"short value", `password = "short"`},
+		{"low entropy repeated", `api_key = "aaaaaaaaaaaaaaaaaaaa"`},
+		{"template mustache", `token = {{ vault_token }}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if findings := Scan([]byte(tc.content), "notes.txt"); len(findings) != 0 {
+				t.Fatalf("expected no findings, got %+v", findings)
+			}
+		})
+	}
+}
+
+func TestScan_SensitiveFilenames(t *testing.T) {
+	names := []string{
+		".env", ".env.local", ".env.production",
+		"server.pem", "tls.key", "id_rsa", "id_dsa",
+		"credentials.json", "keystore.p12", ".netrc",
+	}
+	for _, n := range names {
+		t.Run(n, func(t *testing.T) {
+			findings := Scan([]byte("nothing secret here\n"), n)
+			if !hasRule(findings, RuleSensitiveFilename) {
+				t.Fatalf("expected sensitive-filename for %q, got %+v", n, findings)
+			}
+		})
+	}
+}
+
+func TestScan_SafeEnvTemplatesNotFlagged(t *testing.T) {
+	for _, n := range []string{".env.example", ".env.sample", ".env.template", ".env.dist"} {
+		t.Run(n, func(t *testing.T) {
+			if findings := Scan([]byte("API_KEY=your-key\n"), n); len(findings) != 0 {
+				t.Fatalf("expected no findings for %q, got %+v", n, findings)
+			}
+		})
+	}
+}
+
+func TestScan_BinarySkipsContentButKeepsFilename(t *testing.T) {
+	// A NUL byte marks binary content; the embedded token must be ignored.
+	binary := append([]byte(fxGitHub), 0x00, 0x01, 0x02)
+	if findings := Scan(binary, "blob.bin"); len(findings) != 0 {
+		t.Fatalf("expected binary content to be skipped, got %+v", findings)
+	}
+	// Filename rules still apply to binary files.
+	if findings := Scan(binary, "server.pem"); !hasRule(findings, RuleSensitiveFilename) {
+		t.Fatalf("expected sensitive-filename for binary .pem, got %+v", findings)
+	}
+}
+
+func TestScan_LineNumbersReported(t *testing.T) {
+	content := []byte("line one\nline two\ntoken = " + fxGitHub + "\n")
+	findings := Scan(content, "x.txt")
+	if len(findings) == 0 || findings[0].Line != 3 {
+		t.Fatalf("expected finding on line 3, got %+v", findings)
+	}
+}
+
+func TestHasFindings(t *testing.T) {
+	if !HasFindings([]byte("k=AKIA"+"IOSFODNN7EXAMPLE"), "a.txt") {
+		t.Fatal("expected HasFindings true for AWS key")
+	}
+	if HasFindings([]byte("just some text"), "a.txt") {
+		t.Fatal("expected HasFindings false for plain text")
+	}
+}
+
+func TestShannonEntropy(t *testing.T) {
+	if got := shannonEntropy(""); got != 0 {
+		t.Fatalf("empty entropy = %v, want 0", got)
+	}
+	if got := shannonEntropy("aaaa"); got != 0 {
+		t.Fatalf("uniform entropy = %v, want 0", got)
+	}
+	if got := shannonEntropy("abcd"); got <= 0 {
+		t.Fatalf("varied entropy = %v, want > 0", got)
+	}
+}

--- a/magefile.go
+++ b/magefile.go
@@ -347,6 +347,10 @@ var deadcodeAllowlist = []string{
 	"MockClient.RevertContinue",
 	"MockClient.RevertAbort",
 	"MockClient.Reset",
+	"MockClient.WorktreeFile",
+
+	// secretscan — exported bool helper companion to Scan (public package API)
+	"HasFindings",
 }
 
 // Default target when running `mage` with no args.


### PR DESCRIPTION
## What this does

Adds a guard that scans a file for secrets before it is staged. When you stage a file (with `s`, `a`, section staging, or the right-click stage action), grut checks the working-tree content and the filename first. If it finds a likely credential or a sensitive filename, it either asks you to confirm or refuses the stage outright, depending on config. Files with no findings stage immediately with no extra prompt.

Closes #269

## How it works

```mermaid
flowchart TD
    A[Stage a file] --> B{Guard enabled?}
    B -- no --> S[git add]
    B -- yes --> C[Read working-tree content]
    C --> D[Scan content and filename]
    D --> E{Findings?}
    E -- none --> S
    E -- found --> F{Mode}
    F -- block --> G[Refuse and show error]
    F -- warn --> H{Confirm?}
    H -- yes --> S
    H -- no --> I[Cancel stage]
```

## Changes

- New package `internal/secretscan`: `Scan(content, path) []Finding`. High-confidence provider patterns (GitHub, AWS, private keys, Slack, Google, Stripe) and sensitive filenames (`.env`, `*.pem`, `*.key`, `id_rsa`, `id_dsa`, `credentials.json`, and more) always fire. A generic rule flags high-entropy values only when the key name looks sensitive, the value is long enough, its Shannon entropy is high, and it is not on the placeholder allowlist. Binary content is skipped for content scanning; filename rules still apply.
- `git.Client.WorktreeFile(ctx, path)` reads working-tree content for the scan. It validates the path, confirms the resolved path stays inside the repository, and caps the read size.
- Config: `git.secret_guard` (bool, default true) and `git.secret_guard_mode` (`warn` or `block`, default `warn`), with defaults and validation.
- Panel: full-file staging now routes through the guard. `warn` shows a confirmation listing the flagged files and rule names; `block` refuses with an error. Partial hunk and line staging, which you review interactively, are unaffected.
- The guard config is applied to the panel at construction through the existing panel registry.

## Testing

- `internal/secretscan`: true positives for each provider pattern, the generic high-entropy rule, sensitive filenames, safe env templates, binary skip, line numbers, and known false positives via the allowlist.
- `internal/git`: `WorktreeFile` happy path, traversal rejection, and missing file.
- `internal/panels/gitstatus`: guard disabled stages directly, no findings stage, warn prompts then stages on confirm, warn cancel does not stage, block refuses, scan error cancels the stage, sensitive filename prompts, empty paths are a no-op.
- `go build ./...`, `go vet ./...`, `golangci-lint`, and `gofumpt -l` all clean.

## Security notes

- The guard fails closed: a scan error cancels the stage rather than staging silently.
- `block` mode never stages a flagged file.
- Findings never echo the secret value, only the rule name and filename.
- `WorktreeFile` rejects absolute paths and directory traversal and confirms containment within the repository.