### PR TITLE
docs: add zoom keybinding to help index

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -18,6 +18,7 @@ Always active regardless of focused panel.
 | Key | Action |
 |-----|--------|
 | `1-5` | Focus panel by number |
+| `ctrl+b z` | Zoom focused panel |
 | `R` | Refresh all data + preview |
 | `P` | Push to remote |
 | `F` | Fetch all remotes |

--- a/internal/keybindings/keybindings.json
+++ b/internal/keybindings/keybindings.json
@@ -8,6 +8,7 @@
       "description": "Always active regardless of focused panel.",
       "bindings": [
         { "key": "1-5", "action": "Focus panel by number" },
+        { "key": "ctrl+b z", "action": "Zoom focused panel" },
         { "key": "R", "action": "Refresh all data + preview" },
         { "key": "P", "action": "Push to remote" },
         { "key": "F", "action": "Fetch all remotes" },


### PR DESCRIPTION
## What

Adds the zoom keybinding (`ctrl+b z`) to `internal/keybindings/keybindings.json` (global section) and regenerates `docs/keybindings.md`.

## Why

`zoom_toggle` is already implemented and bound to `ctrl+b z` in all three keymap schemes (classic, default, vim), with tests. It was just missing from the keybindings feature index, so it never appeared in the help overlay or the generated docs. This closes that gap, which is the last acceptance criterion on #244.

## Verification

- `go run ./internal/keybindings/cmd/genmd` regenerated the doc
- `go build ./...` clean
- `go test ./...` all 54 packages pass (including the keybindings doc-sync test)

Closes #244