### PR TITLE
fix: kill git/gh/shell process trees to stop Windows resource leaks

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -20,6 +21,7 @@ import (
 	"github.com/jongio/grut/internal/bookmarks"
 	"github.com/jongio/grut/internal/chat"
 	"github.com/jongio/grut/internal/config"
+	"github.com/jongio/grut/internal/diag"
 	"github.com/jongio/grut/internal/git"
 	"github.com/jongio/grut/internal/keymap"
 	"github.com/jongio/grut/internal/layout"
@@ -238,6 +240,15 @@ Environment:
 			if chatModel != nil {
 				model = model.WithChat(chatModel)
 			}
+
+			// Start the always-on resource watchdog for the lifetime of the
+			// TUI. It samples goroutine and heap usage on an interval and
+			// records a diagnostic (with a goroutine stack dump) to the data
+			// directory if either grows abnormally, so runaway resource use is
+			// captured even without GRUT_LOG enabled.
+			watchdogCtx, stopWatchdog := context.WithCancel(context.Background())
+			go diag.New().Run(watchdogCtx)
+			defer stopWatchdog()
 
 			p := tea.NewProgram(model)
 			if _, err := p.Run(); err != nil {

--- a/internal/diag/sink.go
+++ b/internal/diag/sink.go
@@ -1,0 +1,55 @@
+package diag
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/jongio/grut/internal/config"
+)
+
+// maxDiagLogBytes caps the watchdog diagnostics log before it is rotated. One
+// previous generation is kept (watchdog.log.1), bounding disk use to ~4 MiB.
+const maxDiagLogBytes = 2 << 20 // 2 MiB
+
+// diagWriteMu serialises rotation-plus-append so concurrent reporters cannot
+// interleave a rotation with a write.
+var diagWriteMu sync.Mutex
+
+// diagLogPath returns the path to the watchdog diagnostics log. It is a
+// package variable so tests can redirect writes to a temporary location.
+var diagLogPath = func() string {
+	return filepath.Join(config.DataDir(), "diagnostics", "watchdog.log")
+}
+
+// writeDiag appends a diagnostic record to the durable watchdog log, rotating
+// the file first if it has grown past the size cap. Failures are logged and
+// otherwise ignored: diagnostics must never take down the app.
+func writeDiag(record string) {
+	diagWriteMu.Lock()
+	defer diagWriteMu.Unlock()
+
+	path := diagLogPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		slog.Warn("watchdog: cannot create diagnostics dir", "error", err)
+		return
+	}
+
+	if fi, err := os.Stat(path); err == nil && fi.Size() >= maxDiagLogBytes {
+		// Keep a single previous generation; ignore rename errors (the
+		// subsequent append still succeeds).
+		_ = os.Rename(path, path+".1")
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		slog.Warn("watchdog: cannot open diagnostics log", "error", err)
+		return
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(record + "\n\n"); err != nil {
+		slog.Warn("watchdog: cannot write diagnostics log", "error", err)
+	}
+}

--- a/internal/diag/watchdog.go
+++ b/internal/diag/watchdog.go
@@ -1,0 +1,254 @@
+// Package diag provides a lightweight, always-on runtime watchdog that samples
+// process resource metrics (goroutine count, heap usage) on an interval and
+// records a diagnostic when a threshold is crossed. It exists to catch runaway
+// resource growth — leaked goroutines or unbounded memory — early, and to leave
+// a durable, actionable artifact (including a full goroutine stack dump) even
+// when structured logging via GRUT_LOG is not enabled.
+//
+// The watchdog is cheap: one runtime.ReadMemStats and runtime.NumGoroutine per
+// interval (default 60s), so it is safe to run for the entire session.
+package diag
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync"
+	"time"
+)
+
+// Defaults for the watchdog thresholds and cadence. They are deliberately
+// conservative so the watchdog only fires on genuinely abnormal growth.
+const (
+	defaultInterval        = 60 * time.Second
+	defaultGoroutineFloor  = 800             // absolute count that always warns
+	defaultGoroutineGrowth = 6.0             // warn at growth * startup baseline
+	defaultGoroutineMin    = 250             // growth alert requires at least this many
+	defaultHeapInuseBytes  = 1 << 30         // 1 GiB resident heap
+	defaultCooldown        = 5 * time.Minute // per-signal minimum spacing
+)
+
+// Thresholds configures when the watchdog reports.
+type Thresholds struct {
+	// GoroutineFloor is an absolute goroutine count that always triggers an
+	// alert regardless of the startup baseline.
+	GoroutineFloor int
+	// GoroutineGrowth triggers an alert when the live goroutine count exceeds
+	// GoroutineGrowth * baseline (and is at least GoroutineGrowthMin).
+	GoroutineGrowth float64
+	// GoroutineGrowthMin guards the growth check so a tiny baseline cannot
+	// produce alerts at harmless goroutine counts.
+	GoroutineGrowthMin int
+	// HeapInuseBytes triggers an alert when heap-in-use exceeds this many bytes.
+	HeapInuseBytes uint64
+	// Cooldown is the minimum time between alerts of the same kind.
+	Cooldown time.Duration
+}
+
+// DefaultThresholds returns the built-in threshold configuration.
+func DefaultThresholds() Thresholds {
+	return Thresholds{
+		GoroutineFloor:     defaultGoroutineFloor,
+		GoroutineGrowth:    defaultGoroutineGrowth,
+		GoroutineGrowthMin: defaultGoroutineMin,
+		HeapInuseBytes:     defaultHeapInuseBytes,
+		Cooldown:           defaultCooldown,
+	}
+}
+
+// sample is a single point-in-time reading of runtime resource usage.
+type sample struct {
+	goroutines int
+	heapInuse  uint64
+	numGC      uint32
+}
+
+// Alert kinds.
+const (
+	kindGoroutines = "goroutines"
+	kindHeap       = "heap"
+)
+
+// Alert describes a threshold breach detected by the watchdog.
+type Alert struct {
+	Timestamp      time.Time
+	Kind           string // kindGoroutines or kindHeap
+	Message        string
+	Goroutines     int
+	Baseline       int
+	HeapInuseBytes uint64
+	NumGC          uint32
+}
+
+// Watchdog samples runtime metrics and reports threshold breaches.
+type Watchdog struct {
+	now       func() time.Time
+	sampleFn  func() sample
+	reportFn  func(Alert)
+	lastAlert map[string]time.Time
+	cfg       Thresholds
+	interval  time.Duration
+	baseline  int
+	mu        sync.Mutex
+}
+
+// New creates a Watchdog with default cadence, thresholds, and reporter. The
+// default reporter logs via slog and appends a durable diagnostic record (with
+// a goroutine stack dump for goroutine alerts) under the app data directory.
+func New() *Watchdog {
+	return &Watchdog{
+		interval:  defaultInterval,
+		cfg:       DefaultThresholds(),
+		now:       time.Now,
+		sampleFn:  readSample,
+		reportFn:  reportAlert,
+		lastAlert: make(map[string]time.Time),
+	}
+}
+
+// readSample reads the current runtime metrics.
+func readSample() sample {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return sample{
+		goroutines: runtime.NumGoroutine(),
+		heapInuse:  ms.HeapInuse,
+		numGC:      ms.NumGC,
+	}
+}
+
+// Run samples on the configured interval until ctx is cancelled. It takes an
+// immediate baseline sample so the growth check has a reference point, then
+// reports any breaches through the configured reporter.
+func (w *Watchdog) Run(ctx context.Context) {
+	// Establish the baseline right away rather than waiting a full interval.
+	w.mu.Lock()
+	if w.baseline == 0 {
+		w.baseline = w.sampleFn().goroutines
+	}
+	w.mu.Unlock()
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			for _, a := range w.checkOnce() {
+				w.reportFn(a)
+			}
+		}
+	}
+}
+
+// checkOnce takes one sample and returns any alerts that fire, honoring the
+// per-kind cooldown. It is separated from Run so it can be unit-tested without
+// real timers or goroutines.
+func (w *Watchdog) checkOnce() []Alert {
+	s := w.sampleFn()
+	now := w.now()
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.baseline == 0 {
+		w.baseline = s.goroutines
+	}
+
+	var alerts []Alert
+
+	if w.goroutineBreached(s) && w.allowAlertLocked(kindGoroutines, now) {
+		alerts = append(alerts, Alert{
+			Timestamp:      now,
+			Kind:           kindGoroutines,
+			Message:        fmt.Sprintf("goroutine count %d exceeds threshold (baseline %d)", s.goroutines, w.baseline),
+			Goroutines:     s.goroutines,
+			Baseline:       w.baseline,
+			HeapInuseBytes: s.heapInuse,
+			NumGC:          s.numGC,
+		})
+	}
+
+	if s.heapInuse >= w.cfg.HeapInuseBytes && w.allowAlertLocked(kindHeap, now) {
+		alerts = append(alerts, Alert{
+			Timestamp:      now,
+			Kind:           kindHeap,
+			Message:        fmt.Sprintf("heap in use %.0f MiB exceeds threshold %.0f MiB", float64(s.heapInuse)/(1<<20), float64(w.cfg.HeapInuseBytes)/(1<<20)),
+			Goroutines:     s.goroutines,
+			Baseline:       w.baseline,
+			HeapInuseBytes: s.heapInuse,
+			NumGC:          s.numGC,
+		})
+	}
+
+	return alerts
+}
+
+// goroutineBreached reports whether the goroutine count crosses either the
+// absolute floor or the growth-relative-to-baseline threshold.
+func (w *Watchdog) goroutineBreached(s sample) bool {
+	if s.goroutines >= w.cfg.GoroutineFloor {
+		return true
+	}
+	if w.baseline > 0 && w.cfg.GoroutineGrowth > 0 {
+		growthLimit := int(float64(w.baseline) * w.cfg.GoroutineGrowth)
+		if s.goroutines >= growthLimit && s.goroutines >= w.cfg.GoroutineGrowthMin {
+			return true
+		}
+	}
+	return false
+}
+
+// allowAlertLocked reports whether an alert of the given kind may fire now,
+// recording the time when it may. Caller must hold w.mu.
+func (w *Watchdog) allowAlertLocked(kind string, now time.Time) bool {
+	if last, ok := w.lastAlert[kind]; ok && now.Sub(last) < w.cfg.Cooldown {
+		return false
+	}
+	w.lastAlert[kind] = now
+	return true
+}
+
+// reportAlert is the default reporter: it logs the breach via slog and writes a
+// durable diagnostic record. For goroutine breaches it also captures a full
+// goroutine stack dump so the leaking call site can be identified.
+func reportAlert(a Alert) {
+	slog.Warn(
+		"resource watchdog: "+a.Message,
+		"kind", a.Kind,
+		"goroutines", a.Goroutines,
+		"baseline", a.Baseline,
+		"heap_inuse_mb", fmt.Sprintf("%.1f", float64(a.HeapInuseBytes)/(1<<20)),
+		"gc_cycles", a.NumGC,
+	)
+
+	record := formatRecord(a)
+	if a.Kind == kindGoroutines {
+		record += "\n\n" + goroutineDump()
+	}
+	writeDiag(record)
+}
+
+// goroutineDump returns a snapshot of all goroutine stacks, capped in size.
+func goroutineDump() string {
+	const maxDump = 1 << 20 // 1 MiB
+	buf := make([]byte, maxDump)
+	n := runtime.Stack(buf, true)
+	return string(buf[:n])
+}
+
+// formatRecord renders a human-readable header for a diagnostic record.
+func formatRecord(a Alert) string {
+	return fmt.Sprintf(
+		"[%s] watchdog %s alert: %s (goroutines=%d baseline=%d heap_inuse_mb=%.1f gc=%d)",
+		a.Timestamp.UTC().Format(time.RFC3339),
+		a.Kind,
+		a.Message,
+		a.Goroutines,
+		a.Baseline,
+		float64(a.HeapInuseBytes)/(1<<20),
+		a.NumGC,
+	)
+}

--- a/internal/diag/watchdog_test.go
+++ b/internal/diag/watchdog_test.go
@@ -1,0 +1,202 @@
+package diag
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestWatchdog builds a Watchdog with injectable sampling and clock and a
+// no-op reporter, suitable for deterministic unit tests.
+func newTestWatchdog(cfg Thresholds, samples ...sample) *Watchdog {
+	i := 0
+	return &Watchdog{
+		interval: time.Millisecond,
+		cfg:      cfg,
+		now:      func() time.Time { return time.Unix(0, 0) },
+		sampleFn: func() sample {
+			s := samples[i]
+			if i < len(samples)-1 {
+				i++
+			}
+			return s
+		},
+		reportFn:  func(Alert) {},
+		lastAlert: make(map[string]time.Time),
+	}
+}
+
+func TestCheckOnce_GoroutineFloorAlert(t *testing.T) {
+	cfg := DefaultThresholds()
+	w := newTestWatchdog(cfg, sample{goroutines: cfg.GoroutineFloor + 1})
+	alerts := w.checkOnce()
+	if len(alerts) != 1 || alerts[0].Kind != "goroutines" {
+		t.Fatalf("expected one goroutine alert, got %+v", alerts)
+	}
+}
+
+func TestCheckOnce_GoroutineGrowthAlert(t *testing.T) {
+	cfg := DefaultThresholds()
+	w := newTestWatchdog(
+		cfg,
+		sample{goroutines: 50}, // baseline
+		sample{goroutines: 400},
+	)
+	// First sample establishes baseline 50; below floor and growth → no alert.
+	if got := w.checkOnce(); len(got) != 0 {
+		t.Fatalf("expected no alert on baseline sample, got %+v", got)
+	}
+	// 400 > 6*50=300 and >= GoroutineGrowthMin(250) → growth alert.
+	alerts := w.checkOnce()
+	if len(alerts) != 1 || alerts[0].Kind != "goroutines" {
+		t.Fatalf("expected goroutine growth alert, got %+v", alerts)
+	}
+}
+
+func TestCheckOnce_GrowthBelowMinDoesNotAlert(t *testing.T) {
+	cfg := DefaultThresholds()
+	// baseline 20 → 6x = 120, but 120 < GoroutineGrowthMin(250) so no alert
+	// despite exceeding the growth multiple.
+	w := newTestWatchdog(
+		cfg,
+		sample{goroutines: 20},
+		sample{goroutines: 130},
+	)
+	_ = w.checkOnce()
+	if got := w.checkOnce(); len(got) != 0 {
+		t.Fatalf("expected no alert when below growth minimum, got %+v", got)
+	}
+}
+
+func TestCheckOnce_HeapAlert(t *testing.T) {
+	cfg := DefaultThresholds()
+	w := newTestWatchdog(cfg, sample{goroutines: 10, heapInuse: cfg.HeapInuseBytes})
+	alerts := w.checkOnce()
+	if len(alerts) != 1 || alerts[0].Kind != "heap" {
+		t.Fatalf("expected one heap alert, got %+v", alerts)
+	}
+}
+
+func TestCheckOnce_NoAlertBelowThresholds(t *testing.T) {
+	cfg := DefaultThresholds()
+	w := newTestWatchdog(cfg, sample{goroutines: 40, heapInuse: 10 << 20})
+	if got := w.checkOnce(); len(got) != 0 {
+		t.Fatalf("expected no alerts, got %+v", got)
+	}
+}
+
+func TestCheckOnce_CooldownSuppressesRepeat(t *testing.T) {
+	cfg := DefaultThresholds()
+	now := time.Unix(1000, 0)
+	w := newTestWatchdog(cfg, sample{goroutines: cfg.GoroutineFloor + 5})
+	w.now = func() time.Time { return now }
+
+	if got := w.checkOnce(); len(got) != 1 {
+		t.Fatalf("expected first alert to fire, got %+v", got)
+	}
+	// Within cooldown: suppressed.
+	now = now.Add(cfg.Cooldown - time.Second)
+	if got := w.checkOnce(); len(got) != 0 {
+		t.Fatalf("expected alert suppressed within cooldown, got %+v", got)
+	}
+	// After cooldown: fires again.
+	now = now.Add(2 * time.Second)
+	if got := w.checkOnce(); len(got) != 1 {
+		t.Fatalf("expected alert to fire again after cooldown, got %+v", got)
+	}
+}
+
+func TestRun_StopsOnContextCancel(t *testing.T) {
+	cfg := DefaultThresholds()
+	fired := make(chan Alert, 4)
+	w := &Watchdog{
+		interval: time.Millisecond,
+		cfg:      cfg,
+		now:      time.Now,
+		sampleFn: func() sample { return sample{goroutines: cfg.GoroutineFloor + 1} },
+		reportFn: func(a Alert) {
+			select {
+			case fired <- a:
+			default:
+			}
+		},
+		lastAlert: make(map[string]time.Time),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { w.Run(ctx); close(done) }()
+
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("watchdog did not report within timeout")
+	}
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not stop after context cancel")
+	}
+}
+
+func TestWriteDiag_AppendsAndRotates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "watchdog.log")
+	orig := diagLogPath
+	diagLogPath = func() string { return path }
+	t.Cleanup(func() { diagLogPath = orig })
+
+	// Write enough to exceed the rotation cap, then write once more to trigger
+	// rotation into watchdog.log.1.
+	big := strings.Repeat("x", maxDiagLogBytes)
+	writeDiag(big)
+	writeDiag("after-rotation")
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected current log to exist: %v", err)
+	}
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Fatalf("expected rotated log to exist: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read current log: %v", err)
+	}
+	if !strings.Contains(string(data), "after-rotation") {
+		t.Fatal("current log should contain the post-rotation record")
+	}
+}
+
+func TestReportAlert_WritesGoroutineDump(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "watchdog.log")
+	orig := diagLogPath
+	diagLogPath = func() string { return path }
+	t.Cleanup(func() { diagLogPath = orig })
+
+	reportAlert(Alert{
+		Timestamp:  time.Unix(0, 0),
+		Kind:       "goroutines",
+		Message:    "test breach",
+		Goroutines: 1234,
+		Baseline:   50,
+	})
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "goroutines alert") {
+		t.Fatalf("record missing header: %q", content)
+	}
+	if !strings.Contains(content, "goroutine ") {
+		t.Fatal("goroutine alert record should include a stack dump")
+	}
+}

--- a/internal/extension/runtime/mcp_procattr_unix.go
+++ b/internal/extension/runtime/mcp_procattr_unix.go
@@ -4,24 +4,21 @@ package runtime
 
 import (
 	"os/exec"
-	"syscall"
+
+	"github.com/jongio/grut/internal/proctree"
 )
 
-// setProcGroup places the subprocess in its own process group so the
-// entire tree can be killed together, preventing orphaned children from
-// persisting after the parent is terminated (CWE-269).
-func setProcGroup(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-}
+// The process-tree containment logic lives in the shared internal/proctree
+// package. These thin wrappers preserve the runtime's existing call sites while
+// avoiding a duplicate implementation (CWE-269).
+
+// setProcGroup places the subprocess in its own process group before start so
+// the entire tree can be killed together.
+func setProcGroup(cmd *exec.Cmd) { proctree.Configure(cmd) }
 
 // killProcGroup sends SIGKILL to the entire process group rooted at cmd.
-func killProcGroup(cmd *exec.Cmd) {
-	if cmd.Process != nil {
-		// Negative PID targets the process group.
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	}
-}
+func killProcGroup(cmd *exec.Cmd) { proctree.Kill(cmd) }
 
-// postStartProcGroup is a no-op on Unix; process group membership is
-// configured before start via setProcGroup / SysProcAttr.Setpgid.
-func postStartProcGroup(_ *exec.Cmd) {}
+// postStartProcGroup is a no-op on Unix; process-group membership is configured
+// before start via setProcGroup.
+func postStartProcGroup(cmd *exec.Cmd) { proctree.AfterStart(cmd) }

--- a/internal/extension/runtime/mcp_procattr_windows.go
+++ b/internal/extension/runtime/mcp_procattr_windows.go
@@ -3,102 +3,22 @@
 package runtime
 
 import (
-	"log/slog"
 	"os/exec"
-	"sync"
-	"unsafe"
 
-	"golang.org/x/sys/windows"
+	"github.com/jongio/grut/internal/proctree"
 )
 
-// jobHandles maps running exec.Cmd pointers to the Windows Job Object handle
-// that contains their process tree. The handle is stored after process start
-// (postStartProcGroup) and removed on kill (killProcGroup).
-var jobHandles sync.Map // map[*exec.Cmd]windows.Handle
+// The process-tree containment logic lives in the shared internal/proctree
+// package. These thin wrappers preserve the runtime's existing call sites while
+// avoiding a duplicate implementation (CWE-269).
 
-// setProcGroup is a no-op on Windows; process-group containment is handled
-// via Job Objects in postStartProcGroup after the process has started.
-func setProcGroup(_ *exec.Cmd) {}
+// setProcGroup configures the subprocess for whole-tree termination before
+// start. On Windows this is a no-op; containment is established after start.
+func setProcGroup(cmd *exec.Cmd) { proctree.Configure(cmd) }
 
-// postStartProcGroup creates a Windows Job Object configured with
-// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, then assigns the newly started
-// process to it. When the Job Object handle is closed (in killProcGroup),
-// Windows terminates every process in the job — the direct child and all
-// its descendants — preventing orphaned process trees (CWE-269).
-//
-// Must be called after cmd.Start() succeeds.
-func postStartProcGroup(cmd *exec.Cmd) {
-	if cmd.Process == nil {
-		return
-	}
+// postStartProcGroup assigns the started process to a Job Object so the whole
+// tree is terminated together. Must be called after cmd.Start succeeds.
+func postStartProcGroup(cmd *exec.Cmd) { proctree.AfterStart(cmd) }
 
-	job, err := windows.CreateJobObject(nil, nil)
-	if err != nil {
-		slog.Warn("mcp runtime: CreateJobObject failed, child processes may orphan",
-			"pid", cmd.Process.Pid, "error", err)
-		return
-	}
-
-	// Configure the job to kill all contained processes when the last
-	// handle is closed.
-	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
-		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
-			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-		},
-	}
-	if _, err := windows.SetInformationJobObject(
-		job,
-		windows.JobObjectExtendedLimitInformation,
-		uintptr(unsafe.Pointer(&info)),
-		uint32(unsafe.Sizeof(info)),
-	); err != nil {
-		slog.Warn("mcp runtime: SetInformationJobObject failed",
-			"pid", cmd.Process.Pid, "error", err)
-		_ = windows.CloseHandle(job)
-		return
-	}
-
-	// Open the process handle with ASSIGN rights and assign to the job.
-	proc, err := windows.OpenProcess(
-		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE,
-		false,
-		uint32(cmd.Process.Pid),
-	)
-	if err != nil {
-		slog.Warn("mcp runtime: OpenProcess failed",
-			"pid", cmd.Process.Pid, "error", err)
-		_ = windows.CloseHandle(job)
-		return
-	}
-
-	if err := windows.AssignProcessToJobObject(job, proc); err != nil {
-		slog.Warn("mcp runtime: AssignProcessToJobObject failed",
-			"pid", cmd.Process.Pid, "error", err)
-		_ = windows.CloseHandle(proc)
-		_ = windows.CloseHandle(job)
-		return
-	}
-
-	_ = windows.CloseHandle(proc)
-	jobHandles.Store(cmd, job)
-
-	slog.Debug("mcp runtime: process assigned to job object",
-		"pid", cmd.Process.Pid)
-}
-
-// killProcGroup closes the Windows Job Object handle for the given command,
-// which causes Windows to terminate every process in the job tree.
-func killProcGroup(cmd *exec.Cmd) {
-	v, ok := jobHandles.LoadAndDelete(cmd)
-	if !ok {
-		return
-	}
-	job, ok := v.(windows.Handle)
-	if !ok {
-		return
-	}
-	if err := windows.CloseHandle(job); err != nil {
-		slog.Warn("mcp runtime: CloseHandle(job) failed",
-			"pid", cmd.Process.Pid, "error", err)
-	}
-}
+// killProcGroup terminates the entire process tree rooted at cmd.
+func killProcGroup(cmd *exec.Cmd) { proctree.Kill(cmd) }

--- a/internal/extension/runtime/mcp_procattr_windows_test.go
+++ b/internal/extension/runtime/mcp_procattr_windows_test.go
@@ -5,85 +5,44 @@ package runtime
 import (
 	"os/exec"
 	"testing"
-
-	"golang.org/x/sys/windows"
 )
 
-func TestPostStartProcGroup_AssignsJobObject(t *testing.T) {
-	// Start a long-running process (ping -t loops indefinitely on Windows).
-	cmd := exec.Command("cmd.exe", "/C", "ping -n 60 127.0.0.1 > NUL")
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	defer func() {
-		killProcGroup(cmd)
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
-	}()
+// These tests exercise the runtime's thin wrappers over internal/proctree. The
+// job-object internals (handle storage, tree termination) are covered directly
+// in the proctree package tests.
 
-	postStartProcGroup(cmd)
+func TestSetProcGroup_NoOp(t *testing.T) {
+	cmd := &exec.Cmd{}
+	// On Windows setProcGroup must not modify SysProcAttr; containment is
+	// established after start via postStartProcGroup.
+	setProcGroup(cmd)
+	if cmd.SysProcAttr != nil {
+		t.Fatal("setProcGroup should not modify SysProcAttr on Windows")
+	}
+}
 
-	// Verify a Job Object handle was stored for this cmd.
-	v, ok := jobHandles.Load(cmd)
-	if !ok {
-		t.Fatal("expected job handle to be stored after postStartProcGroup")
-	}
-	job := v.(windows.Handle)
-	if job == 0 {
-		t.Fatal("stored job handle is zero")
-	}
+func TestKillProcGroup_NoHandle(t *testing.T) {
+	cmd := &exec.Cmd{}
+	// Should not panic when no containment handle is stored.
+	killProcGroup(cmd)
 }
 
 func TestPostStartProcGroup_NilProcess(t *testing.T) {
 	cmd := &exec.Cmd{}
 	// Should not panic when Process is nil.
 	postStartProcGroup(cmd)
-
-	if _, ok := jobHandles.Load(cmd); ok {
-		t.Fatal("expected no job handle for cmd with nil Process")
-	}
 }
 
-func TestKillProcGroup_TerminatesJobTree(t *testing.T) {
-	// Start a process that spawns a child (cmd /C start /B ping).
+func TestProcGroupWrappers_KillTree(t *testing.T) {
 	cmd := exec.Command("cmd.exe", "/C", "ping -n 60 127.0.0.1 > NUL")
+	setProcGroup(cmd)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-
 	postStartProcGroup(cmd)
 
-	// Verify handle exists.
-	if _, ok := jobHandles.Load(cmd); !ok {
-		t.Fatal("expected job handle")
-	}
-
-	// Kill via job object.
+	// Kill the tree via the wrapper, then ensure Wait returns.
 	killProcGroup(cmd)
-
-	// Handle should be cleaned up.
-	if _, ok := jobHandles.Load(cmd); ok {
-		t.Fatal("expected job handle to be removed after killProcGroup")
-	}
-
-	// Process should be dead (Wait should return quickly).
-	err := cmd.Wait()
-	if err == nil {
-		t.Log("process exited cleanly (may have been killed by job close)")
-	}
-}
-
-func TestKillProcGroup_NoHandle(t *testing.T) {
-	cmd := &exec.Cmd{}
-	// Should not panic when no handle is stored.
-	killProcGroup(cmd)
-}
-
-func TestSetProcGroup_NoOp(t *testing.T) {
-	cmd := &exec.Cmd{}
-	// Should not panic or modify cmd.
-	setProcGroup(cmd)
-	if cmd.SysProcAttr != nil {
-		t.Fatal("setProcGroup should not modify SysProcAttr on Windows")
-	}
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
 }

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/jongio/grut/internal/proctree"
 )
 
 // Client wraps the git CLI and implements GitClient.
@@ -116,7 +117,12 @@ func (c *Client) runWithEnv(ctx context.Context, extraEnv []string, args ...stri
 	if err := validateArgs(normalized); err != nil {
 		return "", fmt.Errorf("invalid git argument: %w", err)
 	}
-	cmd := exec.CommandContext(ctx, "git", normalized...)
+	// proctree.Command wires the git process into a containment group (Job
+	// Object on Windows, process group on Unix) and sets a bounded WaitDelay,
+	// so cancelling ctx kills the whole tree — including children like
+	// git-remote-https, ssh, and credential helpers — and a descendant that
+	// inherits the output pipes cannot block Wait forever (CWE-269, CWE-400).
+	cmd := proctree.Command(ctx, "git", normalized...)
 	cmd.Dir = c.repoDir
 	if len(extraEnv) > 0 {
 		cmd.Env = append(os.Environ(), extraEnv...)
@@ -126,7 +132,7 @@ func (c *Client) runWithEnv(ctx context.Context, extraEnv []string, args ...stri
 	cmd.Stdout = stdout
 	cmd.Stderr = &stderr
 	slog.Debug("git exec", "args", normalized, "dir", c.repoDir)
-	if err := cmd.Run(); err != nil {
+	if err := proctree.Run(cmd); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
 		if errMsg == "" {
 			return "", fmt.Errorf("git %s: %w", normalized[0], err)

--- a/internal/git/stage_patch.go
+++ b/internal/git/stage_patch.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os/exec"
 	stdpath "path"
 	"path/filepath"
 	"strings"
+
+	"github.com/jongio/grut/internal/proctree"
 )
 
 // StageHunk stages a single hunk from an unstaged file by building a patch
@@ -218,7 +219,7 @@ func (c *Client) runWithStdin(ctx context.Context, stdin []byte, args ...string)
 		return fmt.Errorf("invalid git argument: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := proctree.Command(ctx, "git", args...)
 	cmd.Dir = c.repoDir
 	cmd.Stdin = bytes.NewReader(stdin)
 
@@ -228,7 +229,7 @@ func (c *Client) runWithStdin(ctx context.Context, stdin []byte, args ...string)
 
 	slog.Debug("git exec (stdin)", "args", args, "dir", c.repoDir, "stdinLen", len(stdin))
 
-	if err := cmd.Run(); err != nil {
+	if err := proctree.Run(cmd); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
 		if errMsg == "" {
 			return fmt.Errorf("git %s: %w", args[0], err)

--- a/internal/github/exec.go
+++ b/internal/github/exec.go
@@ -4,18 +4,24 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
+
+	"github.com/jongio/grut/internal/proctree"
 )
 
 // ghExec runs a `gh` CLI command and returns its trimmed stdout.
 // This is an escape hatch for operations not supported by the go-github SDK.
+//
+// The command runs through proctree so that cancelling ctx terminates the whole
+// `gh` process tree (gh spawns git and network helpers) rather than orphaning
+// its children, and a descendant that inherits the output pipes cannot block
+// Wait forever (CWE-269, CWE-400).
 func ghExec(ctx context.Context, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd := proctree.Command(ctx, "gh", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
+	if err := proctree.Run(cmd); err != nil {
 		return "", fmt.Errorf("gh %s: %w: %s", strings.Join(args, " "), err, stderr.String())
 	}
 	return strings.TrimSpace(stdout.String()), nil

--- a/internal/panels/gitstatus/coalesce_test.go
+++ b/internal/panels/gitstatus/coalesce_test.go
@@ -1,0 +1,70 @@
+package gitstatus
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/jongio/grut/internal/panels"
+)
+
+// errCoalesceTest is a sentinel error used to exercise the error-result path.
+var errCoalesceTest = errors.New("status load failed")
+
+// TestRefreshGitStatus_CoalescesWhileLoading verifies that a refresh arriving
+// while a status load is in flight is coalesced into a single pending reload
+// rather than spawning another overlapping `git status`.
+func TestRefreshGitStatus_CoalescesWhileLoading(t *testing.T) {
+	mock := &mockGitClient{}
+	p := newTestPanel(t, mock)
+
+	// Simulate an in-flight load.
+	p.loading = true
+	p.reloadPending = false
+
+	_, cmd := p.Update(panels.RefreshGitStatusMsg{})
+	require.Nil(t, cmd, "refresh while loading must not spawn a new load")
+	require.True(t, p.reloadPending, "refresh while loading must mark a pending reload")
+
+	// A second refresh while still loading stays coalesced.
+	_, cmd = p.Update(panels.RefreshGitStatusMsg{})
+	require.Nil(t, cmd, "second refresh while loading must not spawn a new load")
+	require.True(t, p.reloadPending)
+
+	// Completing the in-flight load drains the pending reload exactly once.
+	_, cmd = p.Update(statusLoadedMsg{files: nil, err: nil, generation: p.statusGen})
+	require.False(t, p.reloadPending, "pending reload must be cleared after draining")
+	require.True(t, p.loading, "draining a pending reload must start a new load")
+	require.NotNil(t, cmd, "draining a pending reload must return a load command")
+}
+
+// TestRefreshGitStatus_SpawnsWhenIdle verifies that a refresh with no load in
+// flight starts a load immediately.
+func TestRefreshGitStatus_SpawnsWhenIdle(t *testing.T) {
+	mock := &mockGitClient{}
+	p := newTestPanel(t, mock)
+	p.loading = false
+
+	_, cmd := p.Update(panels.RefreshGitStatusMsg{})
+	require.True(t, p.loading, "refresh while idle must start a load")
+	require.NotNil(t, cmd, "refresh while idle must return a load command")
+	require.False(t, p.reloadPending)
+}
+
+// TestRefreshGitStatus_DrainsPendingOnErrorResult verifies that a pending
+// reload is still drained when the in-flight load returns an error, so a
+// coalesced refresh is never lost.
+func TestRefreshGitStatus_DrainsPendingOnErrorResult(t *testing.T) {
+	mock := &mockGitClient{}
+	p := newTestPanel(t, mock)
+
+	p.loading = true
+	_, _ = p.Update(panels.RefreshGitStatusMsg{})
+	require.True(t, p.reloadPending)
+
+	_, cmd := p.Update(statusLoadedMsg{files: nil, err: errCoalesceTest, generation: p.statusGen})
+	require.False(t, p.reloadPending, "pending reload must be drained even on error")
+	require.True(t, p.loading, "draining after an error must start a new load")
+	require.NotNil(t, cmd)
+}

--- a/internal/panels/gitstatus/gitstatus.go
+++ b/internal/panels/gitstatus/gitstatus.go
@@ -169,12 +169,13 @@ type GitStatus struct {
 	hunkCursor int      // active hunk index within expanded file
 	lineCursor int      // active line index within active hunk
 	// Generation counters to discard stale async results (CWE-362).
-	statusGen uint64 // incremented on each status load request
-	diffGen   uint64 // incremented on each diff load request
-	loading   bool   // true while an async status load is in flight
-	rowsDirty bool   // true when rows need rebuilding before next render
-	theme     *theme.Theme
-	colors    panelColors
+	statusGen     uint64 // incremented on each status load request
+	diffGen       uint64 // incremented on each diff load request
+	loading       bool   // true while an async status load is in flight
+	reloadPending bool   // a refresh arrived while loading; coalesce into one reload
+	rowsDirty     bool   // true when rows need rebuilding before next render
+	theme         *theme.Theme
+	colors        panelColors
 	// Cached lipgloss styles for hot-path rendering (avoid per-row allocations).
 	styleSectionHeader lipgloss.Style
 	styleHunkHeader    lipgloss.Style
@@ -287,14 +288,23 @@ func (p *GitStatus) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 			return p, nil
 		}
 		p.loading = false
+		var cmd tea.Cmd
 		if msg.err != nil {
 			p.err = msg.err
-			return p, nil
+		} else {
+			p.files = msg.files
+			p.rebuildRows()
+			p.rowsDirty = false
+			cmd = p.emitStatusChanged()
 		}
-		p.files = msg.files
-		p.rebuildRows()
-		p.rowsDirty = false
-		return p, p.emitStatusChanged()
+		// A refresh that arrived while this load was in flight was coalesced;
+		// run exactly one more load now so the view reflects the latest state.
+		if p.reloadPending {
+			p.reloadPending = false
+			p.loading = true
+			return p, tea.Batch(cmd, p.loadStatusCmd())
+		}
+		return p, cmd
 	case diffLoadedMsg:
 		// Discard stale diff results.
 		if msg.generation != p.diffGen {
@@ -342,6 +352,14 @@ func (p *GitStatus) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
 	case cleanResultMsg:
 		return p.handleCleanResult(msg)
 	case panels.RefreshGitStatusMsg:
+		// Coalesce refreshes that arrive while a load is already in flight so
+		// bursts of filesystem events cannot fan out into many overlapping
+		// `git status` subprocesses. The pending reload runs when the current
+		// load completes (see statusLoadedMsg).
+		if p.loading {
+			p.reloadPending = true
+			return p, nil
+		}
 		p.loading = true
 		return p, p.loadStatusCmd()
 	case panels.RepoChangedMsg:

--- a/internal/proctree/proctree.go
+++ b/internal/proctree/proctree.go
@@ -1,0 +1,71 @@
+// Package proctree runs child processes as a contained process tree so the
+// entire tree (the direct child and every descendant) can be terminated
+// together.
+//
+// On Unix the child is placed in its own process group (Setpgid) and the group
+// is signalled with SIGKILL. On Windows the child is assigned to a Job Object
+// configured with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, so closing the job handle
+// terminates the whole tree. This prevents orphaned grandchild processes — for
+// example git spawning git-remote-https, ssh, or a credential helper — that
+// would otherwise leak when a command's context is cancelled or the application
+// exits. Leaked children hold memory, file descriptors, and network
+// connections, which is a resource-exhaustion risk over a long session
+// (CWE-269, CWE-400).
+//
+// The platform-specific primitives Configure, AfterStart, and Kill live in
+// proctree_unix.go and proctree_windows.go. Most callers should use the Command
+// and Run helpers, which wire those primitives together with a bounded
+// WaitDelay so a descendant that inherits an stdout/stderr pipe cannot block
+// Wait forever.
+package proctree
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+// DefaultWaitDelay bounds how long Wait blocks after the process exits, or
+// after its context is cancelled, waiting for inherited stdout/stderr pipes to
+// close. Without it a descendant that inherits a pipe can block Wait — leaking
+// the process, its output-copy goroutine, and file descriptors — indefinitely.
+const DefaultWaitDelay = 5 * time.Second
+
+// Command creates an *exec.Cmd bound to ctx that is configured for whole-tree
+// termination. Cancelling ctx (or the ctx timing out) kills the entire process
+// tree, not just the direct child. Callers set Stdout/Stderr/Dir/Env as usual,
+// then either run it to completion with Run (for buffered commands) or manage
+// the lifecycle themselves via Start/AfterStart/Kill (for streaming commands).
+func Command(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, args...)
+	Configure(cmd)
+	cmd.WaitDelay = DefaultWaitDelay
+	// Replace the default cancel (which only kills the direct child) with a
+	// whole-tree kill. The Process.Kill fallback covers the small window
+	// between Start and AfterStart before the containment group exists.
+	cmd.Cancel = func() error {
+		Kill(cmd)
+		if cmd.Process != nil {
+			return cmd.Process.Kill()
+		}
+		return nil
+	}
+	return cmd
+}
+
+// Run starts cmd, assigns it to its containment group, waits for it to exit,
+// and guarantees the process tree and any OS handle are released — including on
+// the normal-exit path. Use it for buffered, run-to-completion commands whose
+// Stdout/Stderr are set to in-memory buffers. For streaming commands that need
+// pipes, call Start, AfterStart, and Kill directly.
+func Run(cmd *exec.Cmd) error {
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	AfterStart(cmd)
+	err := cmd.Wait()
+	// Idempotent: tears down the group and releases the OS handle even when
+	// the process exited on its own (no context cancellation).
+	Kill(cmd)
+	return err
+}

--- a/internal/proctree/proctree_test.go
+++ b/internal/proctree/proctree_test.go
@@ -1,0 +1,121 @@
+package proctree
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// exitZeroCmd returns a platform-appropriate command that exits 0 immediately.
+func exitZeroCmd() (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd.exe", []string{"/c", "exit", "0"}
+	}
+	return "sh", []string{"-c", "exit 0"}
+}
+
+// exitOneCmd returns a platform-appropriate command that exits 1 immediately.
+func exitOneCmd() (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd.exe", []string{"/c", "exit", "1"}
+	}
+	return "sh", []string{"-c", "exit 1"}
+}
+
+// sleepCmd returns a platform-appropriate command that runs for ~30 seconds.
+func sleepCmd() (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd.exe", []string{"/c", "ping -n 30 127.0.0.1 > NUL"}
+	}
+	return "sh", []string{"-c", "sleep 30"}
+}
+
+func TestCommand_ConfiguresWaitDelayAndCancel(t *testing.T) {
+	name, args := exitZeroCmd()
+	cmd := Command(context.Background(), name, args...)
+	if cmd.WaitDelay != DefaultWaitDelay {
+		t.Fatalf("WaitDelay = %v, want %v", cmd.WaitDelay, DefaultWaitDelay)
+	}
+	if cmd.Cancel == nil {
+		t.Fatal("Command must set a Cancel function for whole-tree termination")
+	}
+}
+
+func TestRun_Success(t *testing.T) {
+	name, args := exitZeroCmd()
+	cmd := Command(context.Background(), name, args...)
+	if err := Run(cmd); err != nil {
+		t.Fatalf("Run: unexpected error: %v", err)
+	}
+}
+
+func TestRun_NonZeroExitPropagates(t *testing.T) {
+	name, args := exitOneCmd()
+	cmd := Command(context.Background(), name, args...)
+	err := Run(cmd)
+	if err == nil {
+		t.Fatal("Run: expected non-nil error for non-zero exit")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("Run: expected *exec.ExitError, got %T: %v", err, err)
+	}
+}
+
+func TestRun_ContextCancelTerminatesPromptly(t *testing.T) {
+	name, args := sleepCmd()
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := Command(ctx, name, args...)
+
+	// Cancel shortly after start; Run must return well before the command's
+	// natural ~30s runtime, proving the whole tree was terminated.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := Run(cmd)
+	elapsed := time.Since(start)
+	cancel()
+
+	if err == nil {
+		t.Fatal("Run: expected non-nil error after context cancellation")
+	}
+	// Allow generous slack for CI, but far below the 30s natural runtime.
+	if elapsed > 20*time.Second {
+		t.Fatalf("Run: took %v after cancel; process tree may not have been killed", elapsed)
+	}
+}
+
+func TestRun_AlreadyCancelledContext(t *testing.T) {
+	name, args := exitZeroCmd()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd := Command(ctx, name, args...)
+	if err := Run(cmd); err == nil {
+		t.Fatal("Run: expected error when context is already cancelled")
+	}
+}
+
+func TestKill_NilProcessNoPanic(t *testing.T) {
+	// Kill must be safe on a command that was never started.
+	Kill(&exec.Cmd{})
+}
+
+func TestKill_Idempotent(t *testing.T) {
+	name, args := sleepCmd()
+	cmd := Command(context.Background(), name, args...)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	AfterStart(cmd)
+	// Multiple Kill calls must not panic.
+	Kill(cmd)
+	Kill(cmd)
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+}

--- a/internal/proctree/proctree_unix.go
+++ b/internal/proctree/proctree_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package proctree
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// Configure places the subprocess in its own process group so the entire tree
+// can be killed together, preventing orphaned children from persisting after
+// the parent is terminated (CWE-269). It is called before cmd.Start.
+func Configure(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// AfterStart is a no-op on Unix; process-group membership is configured before
+// start via Configure (SysProcAttr.Setpgid).
+func AfterStart(_ *exec.Cmd) {}
+
+// Kill sends SIGKILL to the entire process group rooted at cmd. It is safe to
+// call multiple times and on a process that has already exited.
+func Kill(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		// A negative PID targets the whole process group.
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/internal/proctree/proctree_unix_test.go
+++ b/internal/proctree/proctree_unix_test.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package proctree
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+func TestConfigure_SetsSetpgid(t *testing.T) {
+	cmd := &exec.Cmd{}
+	Configure(cmd)
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+		t.Fatal("Configure must set SysProcAttr.Setpgid on Unix")
+	}
+}
+
+func TestConfigure_PreservesExistingSysProcAttr(t *testing.T) {
+	cmd := &exec.Cmd{}
+	// Simulate a caller that already set an attribute; Configure must not
+	// clobber it, only add Setpgid.
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	Configure(cmd)
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+		t.Fatal("Configure must set Setpgid while preserving the existing struct")
+	}
+}

--- a/internal/proctree/proctree_windows.go
+++ b/internal/proctree/proctree_windows.go
@@ -1,0 +1,101 @@
+//go:build windows
+
+package proctree
+
+import (
+	"log/slog"
+	"os/exec"
+	"sync"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// jobHandles maps a running *exec.Cmd to the Windows Job Object handle that
+// contains its process tree. The handle is stored after the process starts
+// (AfterStart) and removed when the tree is killed (Kill).
+var jobHandles sync.Map // map[*exec.Cmd]windows.Handle
+
+// Configure is a no-op on Windows; process-tree containment is established
+// after start via a Job Object in AfterStart.
+func Configure(_ *exec.Cmd) {}
+
+// AfterStart creates a Windows Job Object configured with
+// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE and assigns the newly started process to
+// it. When the job handle is later closed (in Kill), Windows terminates every
+// process in the job — the direct child and all its descendants — preventing
+// orphaned process trees (CWE-269). It must be called after cmd.Start succeeds.
+func AfterStart(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		slog.Warn("proctree: CreateJobObject failed, child processes may orphan",
+			"pid", cmd.Process.Pid, "error", err)
+		return
+	}
+
+	// Configure the job to kill all contained processes when the last handle
+	// is closed.
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		slog.Warn("proctree: SetInformationJobObject failed",
+			"pid", cmd.Process.Pid, "error", err)
+		_ = windows.CloseHandle(job)
+		return
+	}
+
+	// Open the process handle with the rights needed to assign it to the job.
+	proc, err := windows.OpenProcess(
+		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE,
+		false,
+		uint32(cmd.Process.Pid),
+	)
+	if err != nil {
+		slog.Warn("proctree: OpenProcess failed",
+			"pid", cmd.Process.Pid, "error", err)
+		_ = windows.CloseHandle(job)
+		return
+	}
+
+	if err := windows.AssignProcessToJobObject(job, proc); err != nil {
+		slog.Warn("proctree: AssignProcessToJobObject failed",
+			"pid", cmd.Process.Pid, "error", err)
+		_ = windows.CloseHandle(proc)
+		_ = windows.CloseHandle(job)
+		return
+	}
+
+	_ = windows.CloseHandle(proc)
+	jobHandles.Store(cmd, job)
+
+	slog.Debug("proctree: process assigned to job object", "pid", cmd.Process.Pid)
+}
+
+// Kill closes the Windows Job Object handle for cmd, which causes Windows to
+// terminate every process in the job tree. It is safe to call multiple times
+// and on a process that has already exited (subsequent calls are no-ops).
+func Kill(cmd *exec.Cmd) {
+	v, ok := jobHandles.LoadAndDelete(cmd)
+	if !ok {
+		return
+	}
+	job, ok := v.(windows.Handle)
+	if !ok {
+		return
+	}
+	if err := windows.CloseHandle(job); err != nil {
+		slog.Warn("proctree: CloseHandle(job) failed", "error", err)
+	}
+}

--- a/internal/proctree/proctree_windows_test.go
+++ b/internal/proctree/proctree_windows_test.go
@@ -1,0 +1,70 @@
+//go:build windows
+
+package proctree
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestConfigure_NoOpOnWindows(t *testing.T) {
+	cmd := &exec.Cmd{}
+	Configure(cmd)
+	if cmd.SysProcAttr != nil {
+		t.Fatal("Configure must not set SysProcAttr on Windows")
+	}
+}
+
+func TestAfterStart_AssignsJobObject(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/C", "ping -n 60 127.0.0.1 > NUL")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		Kill(cmd)
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	AfterStart(cmd)
+
+	v, ok := jobHandles.Load(cmd)
+	if !ok {
+		t.Fatal("expected job handle to be stored after AfterStart")
+	}
+	job, ok := v.(windows.Handle)
+	if !ok || job == 0 {
+		t.Fatalf("stored job handle invalid: %v", v)
+	}
+}
+
+func TestAfterStart_NilProcessStoresNothing(t *testing.T) {
+	cmd := &exec.Cmd{}
+	AfterStart(cmd)
+	if _, ok := jobHandles.Load(cmd); ok {
+		t.Fatal("expected no job handle for cmd with nil Process")
+	}
+}
+
+func TestKill_TerminatesJobTreeAndCleansHandle(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/C", "ping -n 60 127.0.0.1 > NUL")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	AfterStart(cmd)
+
+	if _, ok := jobHandles.Load(cmd); !ok {
+		t.Fatal("expected job handle before Kill")
+	}
+
+	Kill(cmd)
+
+	if _, ok := jobHandles.Load(cmd); ok {
+		t.Fatal("expected job handle to be removed after Kill")
+	}
+
+	// Job close with KILL_ON_JOB_CLOSE terminates the tree; Wait returns.
+	_ = cmd.Wait()
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -13,6 +13,8 @@ import (
 	"os/exec"
 	"runtime"
 	"sync"
+
+	"github.com/jongio/grut/internal/proctree"
 )
 
 // maxLineBytes caps the length of a single output line to prevent memory
@@ -75,7 +77,12 @@ func New(ctx context.Context, shell string, maxLines int) (*Terminal, error) {
 	if maxLines <= 0 {
 		maxLines = 10000
 	}
-	cmd := exec.CommandContext(ctx, shell)
+	// proctree.Command places the shell in a containment group (Job Object on
+	// Windows, process group on Unix) and sets a bounded WaitDelay, so the
+	// entire shell subtree is terminated on ctx cancellation or Close and a
+	// long-running child cannot keep the output pipes (and reader goroutines)
+	// alive forever (CWE-269).
+	cmd := proctree.Command(ctx, shell)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, fmt.Errorf("creating stdin pipe: %w", err)
@@ -96,6 +103,9 @@ func New(ctx context.Context, shell string, maxLines int) (*Terminal, error) {
 		_ = stderr.Close()
 		return nil, fmt.Errorf("starting shell %q: %w", shell, err)
 	}
+	// Assign the started shell to its containment group so descendants are
+	// terminated together with it (no-op on Unix; Job Object on Windows).
+	proctree.AfterStart(cmd)
 	t := &Terminal{
 		cmd:      cmd,
 		stdin:    stdin,
@@ -160,13 +170,16 @@ func (t *Terminal) LinesWindow(offsetFromBottom, height int) ([]string, int) {
 	return cp, total
 }
 
-// Close closes stdin, kills the process if still running, and waits for
+// Close closes stdin, kills the process tree if still running, and waits for
 // the done channel to be closed.
 func (t *Terminal) Close() error {
 	// Close stdin first to signal the shell to exit.
 	_ = t.stdin.Close()
-	// Kill the process if it's still running.
+	// Kill the whole shell subtree if it's still running. Killing the tree
+	// (not just the direct child) closes the output pipes held by any
+	// descendant, which unblocks the reader goroutines so <-t.done can return.
 	if t.cmd.Process != nil {
+		proctree.Kill(t.cmd)
 		_ = t.cmd.Process.Kill()
 	}
 	// Wait for the process to finish and goroutines to clean up.


### PR DESCRIPTION
## What

Stops grut from leaking git (and gh, and shell) child processes on Windows over long sessions, and adds an always-on resource watchdog so runaway growth is captured even without `GRUT_LOG`.

- New `internal/proctree`: cross-platform process-tree containment. Windows Job Objects (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`), Unix process groups (`Setpgid` + group `SIGKILL`), and a bounded `WaitDelay`. `Command`/`Run` wire context cancellation to a whole-tree kill.
- Routed **git** (`client.go`, `stage_patch.go`), **gh** (`github/exec.go`), and the **terminal shell** through `proctree`.
- `internal/extension/runtime` now delegates to `proctree` instead of keeping a second copy of the job-object logic.
- New `internal/diag`: an always-on watchdog started for the TUI lifetime that records goroutine/heap breaches (with a full goroutine stack dump) to `DataDir/diagnostics/watchdog.log`.
- Coalesced `gitstatus` refreshes so filesystem-event bursts cannot fan out into many overlapping `git status` subprocesses.
- Bumped `go.mod` to 1.26.5 to clear the `crypto/tls` advisory GO-2026-5856.

## Why

grut shelled out with `exec.CommandContext`, which on Windows terminates **only the direct child** on cancellation. `git fetch/pull/push` (and `gh`, and the embedded shell) spawn helpers like `git-remote-https`, `ssh`, and credential managers that were orphaned on cancel or exit. A descendant that inherited the output pipes could also block `Wait` forever, leaking the process, its output-copy goroutine, and file descriptors. Over a long session these piled up and drove the machine to high CPU and memory. The existing pprof/memstats tooling only runs behind `--pprof`, so there was no durable signal when this happened in normal use.

## How

`proctree.Command` builds an `*exec.Cmd` whose `Cancel` kills the whole tree (Unix: `SIGKILL` to the process group; Windows: close the Job Object handle, which terminates every process in the job) and sets `WaitDelay` so a pipe-inheriting descendant cannot block `Wait` indefinitely. `proctree.Run` starts the command, assigns it to the containment group, waits, and releases the group/handle on every path including normal exit. Streaming callers (the terminal) use `Command` + `AfterStart` + `Kill` directly. The job-object/process-group primitives that previously lived only in `extension/runtime` were extracted here so there is a single implementation.

The `diag` watchdog samples `runtime.NumGoroutine` and heap-in-use on an interval (default 60s) and, on a breach of the goroutine floor / growth-over-baseline / heap thresholds, appends a record plus a full goroutine stack dump to a size-rotated log under the app data dir, with a per-signal cooldown.

The `gitstatus` coalescing adds a `reloadPending` flag: a refresh that arrives while a load is in flight is folded into a single follow-up load rather than spawning another `git status`.

Design notes:
- `exec.CommandContext` calls that are intentionally **not** routed through `proctree`: `internal/panels/open.go` (fire-and-forget detached editors/browsers that must outlive grut), one-shot leaf commands (clipboard, token/config checks), and build tooling in `magefile.go`.
- A CERTIFY multi-model review raised three low/medium points (Windows `os.Rename` rotation, a microsecond `Start`→`AfterStart` window, a benign already-exited job handle); each was verified against Go stdlib behavior and the actual code paths and dismissed as non-issues.

## Testing

- [x] `go build ./...` passes
- [x] `go test ./...` passes (full suite green; race detector clean on every package; WSL Linux run green)
- [x] `go vet ./...` passes (plus `golangci-lint`, `gofumpt`, `mage deadcode`, `govulncheck` all clean)
- [x] New tests added for new functionality (`proctree` tree-kill + cancel/WaitDelay across Windows/Unix, `diag` thresholds/cooldown/rotation/stack-dump, `gitstatus` refresh coalescing)
- [x] Existing tests still pass

## Screenshots

No UI changes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>