### PR TITLE
feat(panels): add status dashboard panel

### DIFF
--- a/internal/layout/plugins.go
+++ b/internal/layout/plugins.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/jongio/grut/internal/panels/preview"
 	_ "github.com/jongio/grut/internal/panels/review"
 	_ "github.com/jongio/grut/internal/panels/stash"
+	_ "github.com/jongio/grut/internal/panels/status"
 	_ "github.com/jongio/grut/internal/panels/terminal"
 	_ "github.com/jongio/grut/internal/panels/worktrees"
 )

--- a/internal/panels/status/register.go
+++ b/internal/panels/status/register.go
@@ -1,0 +1,21 @@
+package status
+
+import (
+	"context"
+
+	"github.com/jongio/grut/internal/panelreg"
+	"github.com/jongio/grut/internal/panels"
+)
+
+func init() {
+	panelreg.Register("status", func(deps panelreg.Deps) panels.Panel {
+		client, _, err := deps.NewGitClient()
+		if err != nil {
+			return New(nil, deps.Theme)
+		}
+		if ok, err := client.IsRepo(context.Background()); err != nil || !ok {
+			return New(nil, deps.Theme)
+		}
+		return New(client, deps.Theme)
+	})
+}

--- a/internal/panels/status/status.go
+++ b/internal/panels/status/status.go
@@ -1,0 +1,265 @@
+// Package status implements the compact repository status dashboard panel.
+package status
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/jongio/grut/internal/git"
+	"github.com/jongio/grut/internal/panels"
+	"github.com/jongio/grut/internal/theme"
+)
+
+type GitClient interface {
+	Status(ctx context.Context) ([]git.FileStatus, error)
+	CurrentBranch(ctx context.Context) (git.Branch, error)
+	IsRepo(ctx context.Context) (bool, error)
+}
+
+type loadResultMsg struct {
+	err    error
+	branch git.Branch
+	files  []git.FileStatus
+}
+
+type summary struct {
+	staged    int
+	unstaged  int
+	untracked int
+	conflicts int
+}
+
+type Panel struct {
+	git gitClientFactory
+	ctx context.Context
+	err error
+	panels.BasePanel
+	branch  git.Branch
+	summary summary
+	loading bool
+	dim     lipgloss.Style
+	ok      lipgloss.Style
+	warn    lipgloss.Style
+}
+
+type gitClientFactory interface {
+	GitClient
+}
+
+var _ panels.Panel = (*Panel)(nil)
+
+func New(client GitClient, th *theme.Theme) *Panel {
+	tc := themeColors(th)
+	return &Panel{
+		BasePanel: panels.BasePanel{PanelTitle: "status"},
+		git:       client,
+		dim:       lipgloss.NewStyle().Foreground(lipgloss.Color(tc.Dim)),
+		ok:        lipgloss.NewStyle().Foreground(lipgloss.Color(tc.Success)),
+		warn:      lipgloss.NewStyle().Foreground(lipgloss.Color(tc.Warning)),
+	}
+}
+
+func (p *Panel) Init(ctx context.Context) tea.Cmd {
+	p.ctx = ctx
+	if p.git == nil {
+		return nil
+	}
+	p.loading = true
+	return p.loadCmd()
+}
+
+func (p *Panel) Update(msg tea.Msg) (panels.Panel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case loadResultMsg:
+		p.loading = false
+		p.err = msg.err
+		p.branch = msg.branch
+		p.summary = summarize(msg.files)
+	case panels.RepoChangedMsg:
+		return p.handleRepoChanged(msg)
+	case tea.KeyPressMsg:
+		if msg.String() == "r" || msg.String() == "ctrl+r" {
+			return p, p.reload()
+		}
+	}
+	return p, nil
+}
+
+func (p *Panel) View(width, height int) string {
+	if width <= 0 || height <= 0 {
+		return ""
+	}
+	lines := p.lines()
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	for len(lines) < height {
+		lines = append(lines, "")
+	}
+	for i, line := range lines {
+		lines[i] = trimLine(line, width)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (p *Panel) KeyBindings() []panels.KeyBinding {
+	return []panels.KeyBinding{
+		{Key: "r", Description: "Refresh status", Action: "refresh"},
+	}
+}
+
+func (p *Panel) reload() tea.Cmd {
+	if p.git == nil {
+		return nil
+	}
+	p.loading = true
+	return p.loadCmd()
+}
+
+func (p *Panel) loadCmd() tea.Cmd {
+	client := p.git
+	ctx := p.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return func() tea.Msg {
+		ok, err := client.IsRepo(ctx)
+		if err != nil || !ok {
+			return loadResultMsg{err: fmt.Errorf("not a git repository")}
+		}
+		branch, branchErr := client.CurrentBranch(ctx)
+		files, statusErr := client.Status(ctx)
+		if statusErr != nil {
+			return loadResultMsg{err: statusErr}
+		}
+		if branchErr != nil {
+			branch = git.Branch{Name: "unknown", IsCurrent: true}
+		}
+		return loadResultMsg{branch: branch, files: files}
+	}
+}
+
+func (p *Panel) handleRepoChanged(msg panels.RepoChangedMsg) (panels.Panel, tea.Cmd) {
+	client, err := git.NewClient(msg.Path)
+	if err != nil {
+		p.git = nil
+		p.err = nil
+		p.branch = git.Branch{}
+		p.summary = summary{}
+		p.loading = false
+		return p, nil
+	}
+	ok, err := client.IsRepo(context.Background())
+	if err != nil || !ok {
+		p.git = nil
+		p.err = nil
+		p.branch = git.Branch{}
+		p.summary = summary{}
+		p.loading = false
+		return p, nil
+	}
+	p.git = client
+	return p, p.reload()
+}
+
+func (p *Panel) lines() []string {
+	if p.git == nil {
+		return []string{"No git repository", p.dim.Render("Open a repository to see status.")}
+	}
+	if p.loading {
+		return []string{"Loading status..."}
+	}
+	if p.err != nil {
+		return []string{"Status unavailable", p.warn.Render(p.err.Error())}
+	}
+
+	state := p.ok.Render("clean")
+	if p.summary.dirty() {
+		state = p.warn.Render("dirty")
+	}
+	branch := p.branch.Name
+	if branch == "" {
+		branch = "unknown"
+	}
+	sync := "up to date"
+	if p.branch.Ahead > 0 || p.branch.Behind > 0 {
+		sync = fmt.Sprintf("ahead %d, behind %d", p.branch.Ahead, p.branch.Behind)
+	}
+
+	return []string{
+		"Repository",
+		fmt.Sprintf("Branch:    %s", branch),
+		fmt.Sprintf("State:     %s", state),
+		fmt.Sprintf("Sync:      %s", sync),
+		"",
+		"Changes",
+		fmt.Sprintf("Staged:    %d", p.summary.staged),
+		fmt.Sprintf("Unstaged:  %d", p.summary.unstaged),
+		fmt.Sprintf("Untracked: %d", p.summary.untracked),
+		fmt.Sprintf("Conflicts: %d", p.summary.conflicts),
+	}
+}
+
+func summarize(files []git.FileStatus) summary {
+	var s summary
+	for _, file := range files {
+		if file.StagedStatus == git.StatusConflict || file.WorktreeStatus == git.StatusConflict {
+			s.conflicts++
+			continue
+		}
+		if file.StagedStatus == git.StatusUntracked || file.WorktreeStatus == git.StatusUntracked {
+			s.untracked++
+			continue
+		}
+		if isChanged(file.StagedStatus) {
+			s.staged++
+		}
+		if isChanged(file.WorktreeStatus) {
+			s.unstaged++
+		}
+	}
+	return s
+}
+
+func (s summary) dirty() bool {
+	return s.staged+s.unstaged+s.untracked+s.conflicts > 0
+}
+
+func isChanged(code git.StatusCode) bool {
+	if code == 0 {
+		return false
+	}
+	return code != git.StatusUnmodified && code != git.StatusIgnored && code != git.StatusUntracked
+}
+
+type colors struct {
+	Dim     string
+	Success string
+	Warning string
+}
+
+func themeColors(th *theme.Theme) colors {
+	if th == nil {
+		return colors{Dim: "#666666", Success: "#50FA7B", Warning: "#F1FA8C"}
+	}
+	return colors{
+		Dim:     panels.OrDefault(th.Colors.BrightBlack, "#666666"),
+		Success: panels.OrDefault(th.Colors.NotifySuccess, "#50FA7B"),
+		Warning: panels.OrDefault(th.Colors.NotifyWarn, "#F1FA8C"),
+	}
+}
+
+func trimLine(line string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	runes := []rune(line)
+	if len(runes) <= width {
+		return line
+	}
+	return string(runes[:width])
+}

--- a/internal/panels/status/status_test.go
+++ b/internal/panels/status/status_test.go
@@ -1,0 +1,112 @@
+package status
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jongio/grut/internal/git"
+	"github.com/jongio/grut/internal/panels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockClient struct {
+	status []git.FileStatus
+	branch git.Branch
+	err    error
+	isRepo bool
+}
+
+func (m mockClient) Status(context.Context) ([]git.FileStatus, error) {
+	return m.status, m.err
+}
+
+func (m mockClient) CurrentBranch(context.Context) (git.Branch, error) {
+	return m.branch, nil
+}
+
+func (m mockClient) IsRepo(context.Context) (bool, error) {
+	return m.isRepo, nil
+}
+
+func TestNew(t *testing.T) {
+	p := New(nil, nil)
+	assert.Equal(t, "status", p.Title())
+	assert.NotEmpty(t, p.KeyBindings())
+}
+
+func TestViewWithoutGitClient(t *testing.T) {
+	p := New(nil, nil)
+	out := p.View(80, 3)
+	assert.Contains(t, out, "No git repository")
+}
+
+func TestLoadShowsBranchAndCounts(t *testing.T) {
+	p := New(mockClient{
+		isRepo: true,
+		branch: git.Branch{
+			Name:   "main",
+			Ahead:  1,
+			Behind: 2,
+		},
+		status: []git.FileStatus{
+			{Path: "staged.go", StagedStatus: git.StatusModified},
+			{Path: "unstaged.go", WorktreeStatus: git.StatusModified},
+			{Path: "new.go", StagedStatus: git.StatusUntracked, WorktreeStatus: git.StatusUntracked},
+			{Path: "conflict.go", StagedStatus: git.StatusConflict, WorktreeStatus: git.StatusConflict},
+		},
+	}, nil)
+	cmd := p.Init(context.Background())
+	require.NotNil(t, cmd)
+	panel, next := p.Update(cmd())
+	require.Nil(t, next)
+	p = panel.(*Panel)
+
+	out := p.View(80, 12)
+	assert.Contains(t, out, "Branch:    main")
+	assert.Contains(t, out, "ahead 1, behind 2")
+	assert.Contains(t, out, "Staged:    1")
+	assert.Contains(t, out, "Unstaged:  1")
+	assert.Contains(t, out, "Untracked: 1")
+	assert.Contains(t, out, "Conflicts: 1")
+}
+
+func TestLoadError(t *testing.T) {
+	p := New(mockClient{isRepo: true, err: errors.New("boom")}, nil)
+	cmd := p.Init(context.Background())
+	require.NotNil(t, cmd)
+	p.Update(cmd())
+
+	out := p.View(80, 4)
+	assert.Contains(t, out, "Status unavailable")
+	assert.Contains(t, out, "boom")
+}
+
+func TestNonRepoLoad(t *testing.T) {
+	p := New(mockClient{isRepo: false}, nil)
+	cmd := p.Init(context.Background())
+	require.NotNil(t, cmd)
+	p.Update(cmd())
+
+	out := p.View(80, 4)
+	assert.Contains(t, out, "Status unavailable")
+	assert.Contains(t, out, "not a git repository")
+}
+
+func TestRepoChangedToNonGitClearsClient(t *testing.T) {
+	p := New(mockClient{isRepo: true}, nil)
+	panel, cmd := p.Update(panels.RepoChangedMsg{Path: filepath.Join(t.TempDir(), "missing")})
+	require.Nil(t, cmd)
+	p = panel.(*Panel)
+
+	out := p.View(80, 3)
+	assert.Contains(t, out, "No git repository")
+}
+
+func TestTrimLine(t *testing.T) {
+	out := New(nil, nil).View(5, 1)
+	assert.True(t, len([]rune(strings.Split(out, "\n")[0])) <= 5)
+}


### PR DESCRIPTION
Adds a real `status` panel for custom layouts. It shows branch, clean or dirty state, ahead and behind counts, and staged, unstaged, untracked, and conflict counts.

Closes #354

Validation:
- `go build ./...`
- `go test ./... -count=1`
- `go vet ./...`
- `go test ./internal/panels/status ./internal/layout -count=1`
- `mage testWSL`

Note: `mage preflight` was run, but the WSL pass hit an unrelated existing `/home/jong/.config/grut/grut-update.lock` during `internal/update` tests. A direct `mage testWSL` rerun passed.