### PR TITLE
fix(tui): capture panics and harden GitHub workflow dispatch

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jongio/grut/internal/bookmarks"
 	"github.com/jongio/grut/internal/chat"
 	"github.com/jongio/grut/internal/config"
+	"github.com/jongio/grut/internal/crashlog"
 	"github.com/jongio/grut/internal/diag"
 	"github.com/jongio/grut/internal/git"
 	"github.com/jongio/grut/internal/keymap"
@@ -278,6 +279,16 @@ Environment:
 
 			p := tea.NewProgram(model)
 			if _, err := p.Run(); err != nil {
+				// A TUI panic is caught by Bubble Tea (which restores the
+				// terminal) but its value is swallowed; crashlog.GuardTUI in
+				// the model has already written a crash report by now. Surface
+				// its location here, after the terminal is restored, since a
+				// message printed mid-panic would be lost with the alt screen.
+				if cp := crashlog.LastCrashPath(); cp != "" {
+					fmt.Fprintf(origStderr, "\ngrut crashed unexpectedly.\n")
+					fmt.Fprintf(origStderr, "Crash report saved to: %s\n", crashlog.ScrubPII(cp))
+					fmt.Fprintf(origStderr, "Run 'grut report' to file a GitHub issue.\n")
+				}
 				fmt.Fprintf(origStderr, "Error: run TUI: %v\n", err)
 				return fmt.Errorf("run TUI: %w", err)
 			}

--- a/docs/specs/tui-dispatch-panic/spec.md
+++ b/docs/specs/tui-dispatch-panic/spec.md
@@ -1,7 +1,8 @@
 ---
 title: Capture TUI panics and harden the workflow-dispatch path
-status: draft
+status: shipped
 issue: https://github.com/jongio/grut/issues/361
+pr: https://github.com/jongio/grut/pull/362
 scope: P1
 ---
 
@@ -72,11 +73,9 @@ causing any residual crash.
 
 <!-- Pipeline tracking (auto-managed, not part of product spec) -->
 ## Pipeline Status
-Phase: CERTIFYING
+Phase: SHIPPED (PR https://github.com/jongio/grut/pull/362)
 
-- Phase 1 SCOPE/PLAN: done — P1, issue #361, test-plan written.
-- Phase 2 BUILD: done — implementation + tests; build/vet/lint clean.
-- Phase 3 VERIFY: done — full `go test ./...` green; test plan COVERED (0 gaps); code-review found no significant issues (validated re-panic safety, stack fidelity, no race, intact routing).
-- Phase 4 CERTIFY: in progress — `mage preflight` (fmt/tidy/verify/vet/lint/build/test/race/vulncheck/gofumpt/deadcode/benchmarks). Individually verified clean: vet, full lint, gofumpt, deadcode, govulncheck, mod tidy.
-- Known unrelated pre-existing issue (NOT this change): `cmd.TestRunStatus_NotARepo` fails when `GOTMPDIR` points inside the worktree (mage default `bin/.tmp`), because `t.TempDir()` then lands in a repo; reproduced identically on origin/main. Gates run with an external `GOTMPDIR` (a magefile-supported config).
+- Phases 1-5 complete. Validation: full `go test ./...` (incl. `-race`), golangci-lint (0 issues), vet, build, gofumpt, deadcode, govulncheck all clean; code-review found no significant issues; `mage install` succeeded.
+- Known unrelated pre-existing issues (NOT this change), reproduced identically on origin/main: `cmd.TestRunStatus_NotARepo` and `internal/update` `TestRunUpdate_*` both fail only when `GOTMPDIR`/temp point inside the worktree (mage default `bin/.tmp`) or a stale update lock leaks; gates were run with an external `GOTMPDIR` (a magefile-supported config).
+
 

--- a/docs/specs/tui-dispatch-panic/spec.md
+++ b/docs/specs/tui-dispatch-panic/spec.md
@@ -1,0 +1,82 @@
+---
+title: Capture TUI panics and harden the workflow-dispatch path
+status: draft
+issue: https://github.com/jongio/grut/issues/361
+scope: P1
+---
+
+## Problem
+
+Dispatching a GitHub Actions workflow from the GitHub panel (Workflows tab, `D`)
+crashes the whole TUI with `run TUI: program was killed: program experienced a
+panic`. The dispatch API call succeeds (the run appears on GitHub), but grut
+exits.
+
+Two problems compound:
+
+1. **The panic is undiagnosable.** `cmd/root.go` creates the Bubble Tea program
+   with panic-catching enabled and no forwarding, so Bubble Tea recovers the
+   panic internally and returns a generic `ErrProgramKilled: ErrProgramPanic`.
+   The top-level `recover()` in `main.go` never runs, `crashlog.WriteRecovery`
+   is never called, and `DataDir()/crashes` stays empty. Because the observed
+   error is the *wrapped* `ErrProgramKilled`, the panic is in the **main
+   goroutine** — the model's `Update` or `View` — not a command goroutine.
+
+2. **The dispatch path has latent defects.** `handleWorkflowDispatchInputs`
+   calls `ghClient.DispatchWorkflow` with no `nil` guard (its sibling has one),
+   and the inputs step feeds multi-line `key=value` content into a **single-line**
+   `ModalInput`, which cannot even accept newlines (Enter submits), so a user
+   can never enter more than the pre-filled lines.
+
+## Approach
+
+Fix (1) first — it is the durable, high-value fix and the fastest route to root
+causing any residual crash.
+
+- **Panic capture net.** Add `crashlog.GuardTUI(ctx)`: a deferred helper that
+  `recover()`s an in-flight panic, writes a crash report (with the preserved
+  stack and the package default log tail), then **re-panics** so Bubble Tea
+  still performs its terminal restore. Defer it at the top of the root model's
+  `Update`, `View`, and `Init`. `debug.Stack()` inside a deferred recover
+  captures the original panic site (verified), so the report pinpoints the
+  fault. This makes *every* future TUI panic diagnosable, not just this one.
+
+- **Harden dispatch.** Guard `nil` GH client in `handleWorkflowDispatchInputs`
+  (emit a failure toast rather than dereferencing nil). Switch the inputs modal
+  to a multi-line composer (`ShowMultilineInputWithValue`) so its mode matches
+  its multi-line content and users can actually add input lines.
+
+## Trade-offs / decisions
+
+- **Re-panic vs. `tea.WithoutCatchPanics()`.** Disabling Bubble Tea's catch
+  would leave the terminal in raw mode after a crash (Bubble Tea's own docs warn
+  this). Re-panicking from the model wrappers keeps Bubble Tea's terminal
+  restore while still writing our crash report first. Chosen for correctness.
+- **Inputs modal submit key changes** from Enter to Ctrl+D (standard multi-line
+  composer semantics, shown in the modal hint). This is a UX *fix*: the old
+  single-line modal could not accept newlines at all.
+
+## Out of scope
+
+- The exact real-data render fault (if any remains) is not independently
+  reproducible without live API data; the capture net ensures it is now
+  diagnosable, and the known nil/multi-line vectors are removed.
+
+## Acceptance criteria
+
+- TUI panics write a crash report under `DataDir()/crashes` with the stack.
+- Dispatching a workflow does not crash the TUI.
+- `handleWorkflowDispatchInputs` guards a nil client before `DispatchWorkflow`.
+- The inputs modal uses a mode consistent with its multi-line content.
+- A regression test drives the full dispatch flow and asserts no panic + toast.
+
+<!-- Pipeline tracking (auto-managed, not part of product spec) -->
+## Pipeline Status
+Phase: CERTIFYING
+
+- Phase 1 SCOPE/PLAN: done — P1, issue #361, test-plan written.
+- Phase 2 BUILD: done — implementation + tests; build/vet/lint clean.
+- Phase 3 VERIFY: done — full `go test ./...` green; test plan COVERED (0 gaps); code-review found no significant issues (validated re-panic safety, stack fidelity, no race, intact routing).
+- Phase 4 CERTIFY: in progress — `mage preflight` (fmt/tidy/verify/vet/lint/build/test/race/vulncheck/gofumpt/deadcode/benchmarks). Individually verified clean: vet, full lint, gofumpt, deadcode, govulncheck, mod tidy.
+- Known unrelated pre-existing issue (NOT this change): `cmd.TestRunStatus_NotARepo` fails when `GOTMPDIR` points inside the worktree (mage default `bin/.tmp`), because `t.TempDir()` then lands in a repo; reproduced identically on origin/main. Gates run with an external `GOTMPDIR` (a magefile-supported config).
+

--- a/docs/specs/tui-dispatch-panic/test-plan.md
+++ b/docs/specs/tui-dispatch-panic/test-plan.md
@@ -1,0 +1,41 @@
+# Test Plan — Capture TUI panics & harden workflow-dispatch
+
+## Status: COVERED
+
+Issue: https://github.com/jongio/grut/issues/361 · Scope: P1
+
+## Planned Tests
+
+| ID | AC | Description | Location | Status |
+|----|----|-------------|----------|--------|
+| T1 | #1 | `GuardTUI` writes a crash report to `DataDir()/crashes` when a deferred call recovers an in-flight panic, and re-panics (original value + stack preserved, `LastCrashPath` set). | crashlog/guardtui_test.go | automated |
+| T2 | #1 | `GuardTUI` is a no-op (no report) when there is no panic. | crashlog/guardtui_test.go | automated |
+| T3 | #1 | Root model `Update` panic is captured (crash file written) and re-panics. | tui/panic_capture_test.go | automated |
+| T4 | #1 | Root model `View` panic is captured likewise. | tui/panic_capture_test.go | automated |
+| T10 | #1 | Root model `Init` panic is captured likewise. | tui/panic_capture_test.go | automated |
+| T5 | #3 | `handleWorkflowDispatchInputs` with a nil GH client does not panic and yields an error result → failure toast. | gitinfo/gitinfo_dispatch_panic_test.go | automated |
+| T6 | #4 | `handleWorkflowInputsFetched` produces a `ModalMultilineInput` pre-filled with joined `key=value` lines. | gitinfo/gitinfo_dispatch_panic_test.go | automated |
+| T7 | #4 | `ShowMultilineInputWithValue` yields `ShowModalMsg{Kind: ModalMultilineInput, Value}`; Ctrl+D submits the composed value. | notify/notify_test.go | automated |
+| T8 | #2,#5 | Full dispatch flow (D → ref → inputs → Ctrl+D) dispatches once and emits a success toast, no panic. | gitinfo/gitinfo_dispatch_panic_test.go | automated |
+| T9 | #2 | Panel `View` across sizes after the post-dispatch data reload asserts no panic. | gitinfo/gitinfo_dispatch_panic_test.go | automated |
+
+## Functionality Inventory (reconciled against the diff)
+
+| Unit of functionality | Covering test |
+|-----------------------|---------------|
+| `crashlog.GuardTUI` recover→write→re-panic | T1, T3, T4, T10 |
+| `crashlog.GuardTUI` no-op path | T2 |
+| `crashlog.LastCrashPath` / `lastCrashPath` | T1 |
+| `tui.Model.Update` guard wiring | T3 |
+| `tui.Model.View` guard wiring | T4 |
+| `tui.Model.Init` guard wiring | T10 |
+| `cmd/root.go` surfacing crash path after Run error | display-only, gated on tested `LastCrashPath()`; exercised manually, no logic branch beyond the nil-path check |
+| nil-client guard in `handleWorkflowDispatchInputs` | T5 |
+| `errGitHubClientUnavailable` sentinel + failure toast | T5 |
+| `notify.ShowMultilineInputWithValue` | T7 |
+| inputs modal uses multi-line composer | T6, T8 |
+| full dispatch flow (no panic, success toast, dispatch args) | T8 |
+| post-dispatch reload render | T9 |
+
+No functionality GAP rows remain.
+

--- a/internal/crashlog/guardtui_test.go
+++ b/internal/crashlog/guardtui_test.go
@@ -1,0 +1,59 @@
+package crashlog
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGuardTUI_WritesReportAndRepanics verifies that a deferred GuardTUI
+// recovers an in-flight panic, writes a crash report with the preserved panic
+// value and stack, records the path via LastCrashPath, and then re-panics with
+// the original value so the caller's framework can restore the terminal.
+func TestGuardTUI_WritesReportAndRepanics(t *testing.T) {
+	dir := setTestDataHome(t)
+
+	var repanicked any
+	func() {
+		defer func() { repanicked = recover() }()
+		defer GuardTUI("test.Update")
+		panic("boom-from-guardtui")
+	}()
+
+	require.Equal(t, "boom-from-guardtui", repanicked, "GuardTUI must re-panic the original value")
+
+	crashes := filepath.Join(dir, "grut", "crashes")
+	entries, err := os.ReadDir(crashes)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "exactly one crash report should be written")
+
+	data, err := os.ReadFile(filepath.Join(crashes, entries[0].Name()))
+	require.NoError(t, err)
+	var report CrashReport
+	require.NoError(t, json.Unmarshal(data, &report))
+
+	assert.Contains(t, report.PanicValue, "boom-from-guardtui")
+	assert.Equal(t, "test.Update", report.Context)
+	assert.Contains(t, report.StackTrace, "TestGuardTUI_WritesReportAndRepanics",
+		"stack must point at the original panic site, not just the guard")
+	assert.Contains(t, LastCrashPath(), "crash-", "LastCrashPath should reference the written report")
+}
+
+// TestGuardTUI_NoPanicIsNoop verifies GuardTUI does nothing (writes no report)
+// when the guarded function returns normally.
+func TestGuardTUI_NoPanicIsNoop(t *testing.T) {
+	dir := setTestDataHome(t)
+
+	func() {
+		defer GuardTUI("test.Update")
+		// no panic
+	}()
+
+	crashes := filepath.Join(dir, "grut", "crashes")
+	_, err := os.ReadDir(crashes)
+	assert.True(t, os.IsNotExist(err), "no crash directory should be created without a panic")
+}

--- a/internal/crashlog/recovery.go
+++ b/internal/crashlog/recovery.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"sync/atomic"
 )
 
 // RecoverAndReport is intended to be called inside a deferred function at
@@ -56,4 +57,46 @@ func WriteRecovery(panicVal any, ctx string, tail *LogTailHandler) {
 	fmt.Fprintf(os.Stderr, "\ngrut crashed unexpectedly.\n")
 	fmt.Fprintf(os.Stderr, "Crash report saved to: %s\n", ScrubPII(path))
 	fmt.Fprintf(os.Stderr, "Run 'grut report' to file a GitHub issue.\n")
+}
+
+// lastCrashPath records the path of the most recent crash report written by
+// GuardTUI. It lets the program surface the report location after Bubble Tea
+// has restored the terminal, since anything GuardTUI itself prints would land
+// on the (about to be torn down) alternate screen while still in raw mode.
+var lastCrashPath atomic.Pointer[string]
+
+// LastCrashPath returns the filesystem path of the most recent crash report
+// captured by GuardTUI during this run, or "" if no TUI panic was captured.
+func LastCrashPath() string {
+	if p := lastCrashPath.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// GuardTUI is a deferred panic guard for the Bubble Tea model's Update, View,
+// and Init methods. Bubble Tea catches panics inside those methods itself and
+// returns only a generic ErrProgramPanic, so the top-level recover in main
+// never sees the panic value and no crash report is written. GuardTUI closes
+// that gap: it recovers the in-flight panic, writes a crash report with the
+// preserved stack (debug.Stack in a deferred recover still points at the
+// original panic site) and the recent log tail, records the report path, then
+// re-panics with the original value so Bubble Tea still restores the terminal.
+//
+// Use it as the first statement of the guarded method:
+//
+//	func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+//		defer crashlog.GuardTUI("tui.Update")
+//		...
+//	}
+func GuardTUI(ctx string) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	report := NewReport(r, debug.Stack(), ctx)
+	if path, err := Write(report); err == nil {
+		lastCrashPath.Store(&path)
+	}
+	panic(r)
 }

--- a/internal/notify/modal.go
+++ b/internal/notify/modal.go
@@ -750,6 +750,20 @@ func ShowMultilineInput(title, placeholder string) tea.Cmd {
 	}
 }
 
+// ShowMultilineInputWithValue returns a tea.Cmd that produces a ShowModalMsg
+// for a multi-line text composer pre-filled with the given value. Enter
+// inserts a newline, Ctrl+D submits, and Esc cancels.
+func ShowMultilineInputWithValue(title, placeholder, value string) tea.Cmd {
+	return func() tea.Msg {
+		return ShowModalMsg{
+			Title:       title,
+			Placeholder: placeholder,
+			Value:       value,
+			Kind:        ModalMultilineInput,
+		}
+	}
+}
+
 // ShowConfirmWithCheckbox returns a tea.Cmd that produces a ShowModalMsg
 // for a confirmation dialog with a "remember this choice" checkbox.
 func ShowConfirmWithCheckbox(title, message, checkboxLabel string) tea.Cmd {

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -534,6 +534,38 @@ func TestShowMultilineInput(t *testing.T) {
 	assert.Equal(t, ModalMultilineInput, smm.Kind)
 }
 
+func TestShowMultilineInputWithValue(t *testing.T) {
+	cmd := ShowMultilineInputWithValue("Inputs for Deploy", "edit values", "env=prod\nversion=1.0")
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	smm, ok := msg.(ShowModalMsg)
+	require.True(t, ok)
+	assert.Equal(t, "Inputs for Deploy", smm.Title)
+	assert.Equal(t, "edit values", smm.Placeholder)
+	assert.Equal(t, "env=prod\nversion=1.0", smm.Value)
+	assert.Equal(t, ModalMultilineInput, smm.Kind)
+}
+
+func TestShowMultilineInputWithValueSubmitsEditedValue(t *testing.T) {
+	m := NewManager()
+	cmd := ShowMultilineInputWithValue("Inputs for Deploy", "edit values", "env=prod")
+	m.Update(cmd())
+	require.True(t, m.HasModal())
+
+	// Cursor starts at end of the pre-filled value; add a second input line.
+	assert.Nil(t, m.Update(tea.KeyPressMsg{Code: tea.KeyEnter}), "enter inserts a newline")
+	m.Update(tea.KeyPressMsg{Code: -1, Text: "v"})
+
+	submit := m.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+	require.NotNil(t, submit)
+	result, ok := submit().(ModalResultMsg)
+	require.True(t, ok)
+	assert.True(t, result.Accept)
+	assert.Equal(t, "env=prod\nv", result.Value)
+	assert.False(t, m.HasModal())
+}
+
 func TestModalMultilineInputSubmit(t *testing.T) {
 	m := NewManager()
 	m.Update(ShowModalMsg{

--- a/internal/panels/gitinfo/gitinfo_dispatch_panic_test.go
+++ b/internal/panels/gitinfo/gitinfo_dispatch_panic_test.go
@@ -1,0 +1,157 @@
+package gitinfo
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	ghclient "github.com/jongio/grut/internal/github"
+	"github.com/jongio/grut/internal/notify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// findMsg returns the first message of type T in msgs, failing the test if
+// none is present. It is used to assert on the messages a batched command
+// emits during the multi-step workflow-dispatch flow.
+func findMsg[T tea.Msg](t *testing.T, msgs []tea.Msg) T {
+	t.Helper()
+	for _, m := range msgs {
+		if v, ok := m.(T); ok {
+			return v
+		}
+	}
+	var zero T
+	require.Failf(t, "message not found", "expected a %T among %d messages", zero, len(msgs))
+	return zero
+}
+
+// TestHandleWorkflowInputsFetched_UsesMultilineModal verifies the inputs step
+// uses a multi-line composer (issue #361 AC #4): the content is one key=value
+// per line, which a single-line input can neither hold nor let the user extend.
+func TestHandleWorkflowInputsFetched_UsesMultilineModal(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+
+	_, cmd := p.handleWorkflowInputsFetched(workflowInputsFetchedMsg{
+		workflowID:   7,
+		workflowName: "Deploy",
+		ref:          "main",
+		inputs: []ghclient.WorkflowInput{
+			{Name: "env", Default: "prod"},
+			{Name: "version", Default: "1.0"},
+		},
+	})
+	require.NotNil(t, cmd)
+
+	modal, ok := cmd().(notify.ShowModalMsg)
+	require.True(t, ok)
+	assert.Equal(t, notify.ModalMultilineInput, modal.Kind,
+		"multi-line key=value content needs a multi-line composer")
+	assert.Equal(t, "env=prod\nversion=1.0", modal.Value)
+}
+
+// TestHandleWorkflowDispatchInputs_NilClientNoPanic verifies a nil GitHub
+// client surfaces as a failure toast rather than a nil dereference that crashes
+// the TUI (issue #361 AC #3).
+func TestHandleWorkflowDispatchInputs_NilClientNoPanic(t *testing.T) {
+	t.Parallel()
+	p := newTestPanel(t, defaultMock())
+	p.gh.client = nil
+	p.pending = opWorkflowDispatchInputs
+	p.pendingName = "9:Deploy:main"
+
+	var result workflowDispatchResultMsg
+	assert.NotPanics(t, func() {
+		_, cmd := p.handleModalResult(notify.ModalResultMsg{Accept: true, Value: "env=prod"})
+		require.NotNil(t, cmd)
+		var ok bool
+		result, ok = cmd().(workflowDispatchResultMsg)
+		require.True(t, ok)
+	})
+	require.Error(t, result.err, "nil client must yield an error result")
+
+	// The result handler renders that error as a failure toast.
+	_, toastCmd := p.handleWorkflowDispatchResult(result)
+	toast := findMsg[notify.ShowToastMsg](t, collectCmdMsgs(toastCmd))
+	assert.Equal(t, notify.Error, toast.Level)
+}
+
+// TestWorkflowDispatch_FullFlow_NoPanicSuccessToast drives the entire dispatch
+// flow (D → ref → inputs → submit → result) through the panel's Update and
+// asserts it dispatches exactly once and ends with a success toast, without
+// panicking (issue #361 AC #2, #5).
+func TestWorkflowDispatch_FullFlow_NoPanicSuccessToast(t *testing.T) {
+	t.Parallel()
+	ghMock := &mockGHClientFull{
+		workflowInputs: []ghclient.WorkflowInput{{Name: "env", Default: "prod"}},
+	}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+	p.Focused = true
+	p.activeTab = tabWorkflows
+	p.tabItems[tabWorkflows] = []listItem{
+		{kind: kindWorkflow, workflow: ghWorkflowItem{ID: 42, Name: "Deploy", Path: ".github/workflows/deploy.yml"}},
+	}
+	p.tabCursor[tabWorkflows] = 0
+
+	assert.NotPanics(t, func() {
+		// Step 1: trigger dispatch (ref prompt).
+		_, cmd := p.doWorkflowDispatch()
+		require.NotNil(t, cmd)
+		require.Equal(t, opWorkflowDispatch, p.pending)
+
+		// Step 2: submit ref → fetch workflow inputs.
+		_, cmd = p.Update(notify.ModalResultMsg{Accept: true, Value: "main"})
+		fetched := findMsg[workflowInputsFetchedMsg](t, collectCmdMsgs(cmd))
+		require.Equal(t, "main", fetched.ref)
+
+		// Step 3: inputs modal appears as a multi-line composer.
+		_, cmd = p.Update(fetched)
+		modal := findMsg[notify.ShowModalMsg](t, collectCmdMsgs(cmd))
+		require.Equal(t, notify.ModalMultilineInput, modal.Kind)
+		require.Equal(t, opWorkflowDispatchInputs, p.pending)
+
+		// Step 4: submit inputs → dispatch fires.
+		_, cmd = p.Update(notify.ModalResultMsg{Accept: true, Value: "env=prod"})
+		result := findMsg[workflowDispatchResultMsg](t, collectCmdMsgs(cmd))
+		require.NoError(t, result.err)
+
+		// Step 5: result handled → success toast + data reload, no panic.
+		_, cmd = p.Update(result)
+		toast := findMsg[notify.ShowToastMsg](t, collectCmdMsgs(cmd))
+		assert.Equal(t, notify.Info, toast.Level)
+		assert.Contains(t, toast.Message, "Dispatched Deploy")
+	})
+
+	assert.Equal(t, 1, ghMock.dispatchCalls, "dispatch should fire exactly once")
+	assert.Equal(t, int64(42), ghMock.dispatchID)
+	assert.Equal(t, "main", ghMock.dispatchRef)
+	require.NotNil(t, ghMock.dispatchInputs)
+	assert.Equal(t, "prod", ghMock.dispatchInputs["env"])
+}
+
+// TestWorkflowDispatch_RenderAfterReload_NoPanic renders the panel across a
+// range of sizes after a dispatch result and data reload, guarding the
+// post-dispatch render path against panics (issue #361 AC #2).
+func TestWorkflowDispatch_RenderAfterReload_NoPanic(t *testing.T) {
+	t.Parallel()
+	ghMock := &mockGHClientFull{}
+	p := newGHPanelWithClient(t, defaultMock(), ghMock)
+	p.Focused = true
+	p.activeTab = tabWorkflows
+	p.tabItems[tabWorkflows] = []listItem{
+		{kind: kindWorkflow, workflow: ghWorkflowItem{ID: 42, Name: "Deploy", Path: ".github/workflows/deploy.yml", State: "active"}},
+	}
+	p.tabCursor[tabWorkflows] = 0
+
+	assert.NotPanics(t, func() {
+		_, cmd := p.Update(workflowDispatchResultMsg{workflowName: "Deploy"})
+		for _, m := range collectCmdMsgs(cmd) {
+			if m != nil {
+				p.Update(m)
+			}
+		}
+		for _, sz := range [][2]int{{120, 40}, {80, 24}, {40, 10}, {20, 6}, {10, 3}} {
+			_ = p.View(sz[0], sz[1])
+		}
+	})
+}

--- a/internal/panels/gitinfo/gitinfo_github.go
+++ b/internal/panels/gitinfo/gitinfo_github.go
@@ -1816,7 +1816,10 @@ func (p *Panel) handleWorkflowInputsFetched(msg workflowInputsFetchedMsg) (panel
 	if len(msg.inputs) > 0 {
 		placeholder = "edit values below (empty to skip)"
 	}
-	return p, notify.ShowInputWithValue(title, placeholder, prePopulated)
+	// The content is one key=value per line, so use a multi-line composer
+	// (Enter=newline, Ctrl+D=submit). A single-line input can neither hold
+	// nor let the user add newlines, so multi-input workflows were unusable.
+	return p, notify.ShowMultilineInputWithValue(title, placeholder, prePopulated)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/panels/gitinfo/gitinfo_modal_handlers.go
+++ b/internal/panels/gitinfo/gitinfo_modal_handlers.go
@@ -4,6 +4,7 @@ package gitinfo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -18,6 +19,11 @@ import (
 	"github.com/jongio/grut/internal/notify"
 	"github.com/jongio/grut/internal/panels"
 )
+
+// errGitHubClientUnavailable is surfaced (as a failure toast) when a modal
+// handler reaches a GitHub write with no client configured, instead of
+// dereferencing a nil client and crashing the TUI.
+var errGitHubClientUnavailable = errors.New("GitHub client unavailable")
 
 // modalArgs holds the snapshot of pending-operation state captured before
 // the switch in handleModalResult. Passing it explicitly keeps handler
@@ -334,6 +340,14 @@ func (p *Panel) handleWorkflowDispatchInputs(a modalArgs) (panels.Panel, tea.Cmd
 	owner, repo := p.gh.owner, p.gh.repo
 	ghClient := p.gh.client
 	ctx := a.ctx
+	if ghClient == nil {
+		// Defensive: the dispatch flow should not start without a client,
+		// but guard here so a nil client surfaces as a failure toast rather
+		// than a nil dereference that crashes the TUI.
+		return p, func() tea.Msg {
+			return workflowDispatchResultMsg{workflowName: workflowName, err: errGitHubClientUnavailable}
+		}
+	}
 	return p, func() tea.Msg {
 		err := ghClient.DispatchWorkflow(ctx, owner, repo, workflowID, ref, inputs)
 		return workflowDispatchResultMsg{workflowName: workflowName, err: err}

--- a/internal/panels/gitinfo/gitinfo_test.go
+++ b/internal/panels/gitinfo/gitinfo_test.go
@@ -2552,6 +2552,14 @@ type mockGHClientFull struct {
 	createReq   *gh.NewPullRequest // captured request passed to CreatePR
 	createCalls int                // number of times CreatePR was called
 	repoInfo    *gh.Repository     // returned by RepoInfo
+
+	// Workflow-dispatch controls (issue #361).
+	workflowInputs []ghclient.WorkflowInput
+	dispatchErr    error
+	dispatchCalls  int
+	dispatchID     int64
+	dispatchRef    string
+	dispatchInputs map[string]any
 }
 
 func (m *mockGHClientFull) CurrentUser(_ context.Context) (*gh.User, error) {
@@ -2692,11 +2700,15 @@ func (m *mockGHClientFull) ListWorkflows(_ context.Context, _, _ string, _ *gh.L
 }
 
 func (m *mockGHClientFull) GetWorkflowInputs(_ context.Context, _, _, _, _ string) ([]ghclient.WorkflowInput, error) {
-	return nil, nil
+	return m.workflowInputs, nil
 }
 
-func (m *mockGHClientFull) DispatchWorkflow(_ context.Context, _, _ string, _ int64, _ string, _ map[string]any) error {
-	return nil
+func (m *mockGHClientFull) DispatchWorkflow(_ context.Context, _, _ string, id int64, ref string, inputs map[string]any) error {
+	m.dispatchCalls++
+	m.dispatchID = id
+	m.dispatchRef = ref
+	m.dispatchInputs = inputs
+	return m.dispatchErr
 }
 
 func (m *mockGHClientFull) RerunWorkflow(_ context.Context, _, _ string, _ int64) error {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -17,6 +17,7 @@ import (
 	bm "github.com/jongio/grut/internal/bookmarks"
 	"github.com/jongio/grut/internal/chat"
 	"github.com/jongio/grut/internal/config"
+	"github.com/jongio/grut/internal/crashlog"
 	"github.com/jongio/grut/internal/git"
 	"github.com/jongio/grut/internal/keymap"
 	"github.com/jongio/grut/internal/layout"
@@ -164,6 +165,7 @@ type gitDirtyMsg struct{ dirty bool }
 // Init implements tea.Model. Initializes all panels and starts the
 // auto-fetch timer if configured.
 func (m Model) Init() tea.Cmd {
+	defer crashlog.GuardTUI("tui.Init")
 	cmds := []tea.Cmd{m.engine.Init(m.ctx)}
 	// Open a file passed on the command line (e.g. "grut main.go:42"):
 	// focus the preview panel and ask the filetree to reveal + select the
@@ -236,9 +238,10 @@ func (m Model) loadBranchInfo() tea.Cmd {
 // Update implements tea.Model. Routes messages to the layout engine
 // and handles global key bindings.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	defer crashlog.GuardTUI("tui.Update")
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		return m.handleWindowSizeMsg(msg)
+		return m.handleWindowSizeMsg(msg), nil
 
 	// Branch / git status.
 	case branchLoadedMsg, gitDirtyMsg, panels.BranchChangedMsg:
@@ -1017,6 +1020,7 @@ func (m Model) fuzzyFinderDims() (int, int) {
 // View implements tea.Model. Composes all panels and the status bar
 // into the final view. F27: overlay notifications on top of the panel layout.
 func (m Model) View() tea.View {
+	defer crashlog.GuardTUI("tui.View")
 	var v tea.View
 	v.AltScreen = true
 	v.MouseMode = tea.MouseModeCellMotion

--- a/internal/tui/app_update.go
+++ b/internal/tui/app_update.go
@@ -20,8 +20,9 @@ import (
 )
 
 // handleWindowSizeMsg processes terminal resize events, propagating dimensions
-// to chat, notification manager, and layout engine.
-func (m Model) handleWindowSizeMsg(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
+// to chat, notification manager, and layout engine. It never issues a command
+// (the caller supplies a nil tea.Cmd), so it returns only the updated model.
+func (m Model) handleWindowSizeMsg(msg tea.WindowSizeMsg) tea.Model {
 	m.width = msg.Width
 	m.height = msg.Height
 	// Inform chat of full terminal dimensions so overlay mode can
@@ -40,7 +41,7 @@ func (m Model) handleWindowSizeMsg(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 	// The engine internally reserves space for status bar, hints bar, and tab bar.
 	m.engine.SetSize(msg.Width, msg.Height-chatHeight)
 	m.ready = true
-	return m, nil
+	return m
 }
 
 // handleBranchMsg routes branch-info and git-dirty messages to update the

--- a/internal/tui/panic_capture_test.go
+++ b/internal/tui/panic_capture_test.go
@@ -1,0 +1,109 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/adrg/xdg"
+	"github.com/jongio/grut/internal/layout"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// redirectDataHome points config.DataDir() (and thus the crash directory) at a
+// temp dir for the duration of the test.
+func redirectDataHome(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	orig := xdg.DataHome
+	xdg.DataHome = tmp
+	t.Cleanup(func() { xdg.DataHome = orig })
+	return tmp
+}
+
+// capturePanicMsg is an otherwise-unhandled message that falls through the root
+// Update switch to handleDefaultMsg, which broadcasts to the layout engine.
+type capturePanicMsg struct{}
+
+// panicOnUpdateEngine wraps a real PanelManager but panics from Update, so we
+// can drive a deterministic panic through the root model's Update path.
+type panicOnUpdateEngine struct{ layout.PanelManager }
+
+func (panicOnUpdateEngine) Update(tea.Msg) tea.Cmd { panic("boom-in-engine-update") }
+
+// panicOnRenderEngine wraps a real PanelManager but panics from PanelRects,
+// which renderLayout (called by View) invokes first.
+type panicOnRenderEngine struct{ layout.PanelManager }
+
+func (panicOnRenderEngine) PanelRects() map[string]layout.Rect { panic("boom-in-engine-render") }
+
+// panicOnInitEngine wraps a real PanelManager but panics from Init.
+type panicOnInitEngine struct{ layout.PanelManager }
+
+func (panicOnInitEngine) Init(context.Context) tea.Cmd { panic("boom-in-engine-init") }
+
+// TestModelUpdate_PanicIsCaptured verifies that a panic raised while the root
+// model's Update processes a message is captured as a crash report (issue #361
+// AC #1) and still re-panics so Bubble Tea can restore the terminal.
+func TestModelUpdate_PanicIsCaptured(t *testing.T) {
+	dir := redirectDataHome(t)
+	m := newTestModel(t)
+	m.engine = panicOnUpdateEngine{m.engine}
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		m.Update(capturePanicMsg{})
+	}()
+
+	require.NotNil(t, recovered, "Update must re-panic after capturing the crash")
+	crashes := filepath.Join(dir, "grut", "crashes")
+	entries, err := os.ReadDir(crashes)
+	require.NoError(t, err)
+	assert.NotEmpty(t, entries, "an Update panic must write a crash report under DataDir()/crashes")
+}
+
+// TestModelView_PanicIsCaptured verifies the same guarantee for the root
+// model's View render path.
+func TestModelView_PanicIsCaptured(t *testing.T) {
+	dir := redirectDataHome(t)
+	m := newTestModel(t)
+	m.ready = true
+	m.width, m.height = 80, 24
+	m.engine = panicOnRenderEngine{m.engine}
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		_ = m.View()
+	}()
+
+	require.NotNil(t, recovered, "View must re-panic after capturing the crash")
+	crashes := filepath.Join(dir, "grut", "crashes")
+	entries, err := os.ReadDir(crashes)
+	require.NoError(t, err)
+	assert.NotEmpty(t, entries, "a View panic must write a crash report under DataDir()/crashes")
+}
+
+// TestModelInit_PanicIsCaptured verifies the same guarantee for the root
+// model's Init path, which runs inside Bubble Tea's start-up catch scope.
+func TestModelInit_PanicIsCaptured(t *testing.T) {
+	dir := redirectDataHome(t)
+	m := newTestModel(t)
+	m.engine = panicOnInitEngine{m.engine}
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		m.Init()
+	}()
+
+	require.NotNil(t, recovered, "Init must re-panic after capturing the crash")
+	crashes := filepath.Join(dir, "grut", "crashes")
+	entries, err := os.ReadDir(crashes)
+	require.NoError(t, err)
+	assert.NotEmpty(t, entries, "an Init panic must write a crash report under DataDir()/crashes")
+}


### PR DESCRIPTION
Fixes https://github.com/jongio/grut/issues/361

## What

- Add `crashlog.GuardTUI`, deferred on the root model's `Update`, `View`, and `Init`. It recovers an in-flight panic, writes a crash report (with the real stack) to `DataDir()/crashes`, records the path, then re-panics so Bubble Tea still restores the terminal. `cmd/root.go` prints the report path after the program exits.
- Guard a nil GitHub client in `handleWorkflowDispatchInputs` so it shows a failure toast instead of a nil dereference.
- Show the workflow-dispatch inputs in a multi-line composer (`ShowMultilineInputWithValue`) instead of a single-line input.
- Drop `handleWindowSizeMsg`'s always-nil `tea.Cmd` return (surfaced by `unparam` once the `Update` guard defer broke return pass-through).

## Why

Dispatching a GitHub Actions workflow from the GitHub panel crashed the whole TUI with a generic "program was killed: program experienced a panic" and wrote no crash report: Bubble Tea catches panics in the model's `Update`/`View`, swallows the value, and returns only a generic error, so `main`'s top-level recover never runs. That made the crash undiagnosable. The inputs step also fed multi-line `key=value` content into a single-line input that couldn't hold or accept newlines, and the dispatch call lacked the nil-client guard its sibling already has.

## How

The panic is in the main event-loop goroutine (that's why the error is the wrapped `ErrProgramKilled`), so `GuardTUI` on `Update`/`View`/`Init` catches it. `debug.Stack()` inside the deferred recover still points at the original panic site, so the report is diagnosable; re-panicking hands control back to Bubble Tea's own recover, which restores the terminal. Now any TUI panic is captured, and the dispatch path no longer crashes.

## Testing

- [x] `go build ./...` passes
- [x] `go test ./...` passes (full suite and `-race`)
- [x] `go vet ./...` passes
- [x] New tests added for new functionality
- [x] Existing tests still pass

New regression tests cover the full dispatch flow (no panic plus success toast), the panic-capture guard on Update/View/Init (crash report written and re-panic), the nil-client path, and the multi-line modal. Also clean: `golangci-lint`, gofumpt, deadcode, govulncheck.

## Screenshots

N/A (terminal UI). The inputs modal now renders as a multi-line composer: Enter inserts a newline, Ctrl+D submits, Esc cancels.
