### PR TITLE
Add dirty-worktree check to status

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -56,6 +57,7 @@ tools can parse.`,
 		RunE: runStatus,
 	}
 	cmd.Flags().Bool("json", false, "Output the status as JSON")
+	cmd.Flags().Bool("check", false, "Exit with an error when the working tree is not clean")
 	return cmd
 }
 
@@ -87,11 +89,21 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 
 	asJSON, _ := cmd.Flags().GetBool("json")
 	if asJSON {
-		return writeStatusJSON(cmd.OutOrStdout(), report)
+		if err := writeStatusJSON(cmd.OutOrStdout(), report); err != nil {
+			return err
+		}
+	} else {
+		writeStatusText(cmd.OutOrStdout(), report)
 	}
-	writeStatusText(cmd.OutOrStdout(), report)
+
+	check, _ := cmd.Flags().GetBool("check")
+	if check && !report.Clean {
+		return errStatusDirty
+	}
 	return nil
 }
+
+var errStatusDirty = errors.New("working tree has changes")
 
 // buildStatusReport classifies file entries into staged, unstaged, untracked,
 // and conflicted buckets. A file may be both staged and unstaged (for example

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -19,6 +19,7 @@ func TestNewStatusCmd_Wiring(t *testing.T) {
 	assert.Equal(t, "status", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
 	require.NotNil(t, cmd.Flags().Lookup("json"), "--json flag should be registered")
+	require.NotNil(t, cmd.Flags().Lookup("check"), "--check flag should be registered")
 }
 
 func TestBuildStatusReport_Clean(t *testing.T) {
@@ -122,6 +123,47 @@ func TestWriteStatusJSON_RoundTrip(t *testing.T) {
 	require.Len(t, decoded.Staged, 1)
 	assert.Equal(t, "a.go", decoded.Staged[0].Path)
 	assert.Equal(t, "A", decoded.Staged[0].Status)
+}
+
+func TestRunStatus_CheckCleanRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("hi"), 0o644))
+	runGit(t, dir, "add", "tracked.txt")
+	runGit(t, dir, "commit", "-m", "initial")
+
+	t.Chdir(dir)
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	require.NoError(t, cmd.Flags().Set("check", "true"))
+
+	require.NoError(t, runStatus(cmd, nil))
+	assert.Contains(t, out.String(), "Working tree clean")
+}
+
+func TestRunStatus_CheckDirtyRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "loose.txt"), []byte("hi"), 0o644))
+
+	t.Chdir(dir)
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	require.NoError(t, cmd.Flags().Set("check", "true"))
+
+	err := runStatus(cmd, nil)
+	require.ErrorIs(t, err, errStatusDirty)
+	assert.Contains(t, out.String(), "Untracked (1):")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #364

Adds `grut status --check` so scripts can fail when the working tree has staged, unstaged, untracked, or conflicted changes.

Validation:
- `go build ./...`
- `go test ./cmd -run Status -count=1`
- `go test ./... -count=1`

Note: `mage preflight` was attempted. It is blocked by existing lint findings in `internal\panels\gitinfo\gitinfo_github.go` and `internal\panels\gitdiff\gitdiff.go`.