### PR TITLE
Add filtering to MCP tool inventory

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 
 	"github.com/jongio/grut/internal/config"
 	"github.com/jongio/grut/internal/git"
@@ -76,12 +77,13 @@ const mcpToolsUse = "tools"
 
 func newMCPToolsCmd() *cobra.Command {
 	var jsonOut bool
+	var filter string
 
 	cmd := &cobra.Command{
 		Use:   mcpToolsUse,
 		Short: "List grut MCP tools",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tools := grut_mcp.ToolInventory()
+			tools := filterMCPTools(grut_mcp.ToolInventory(), filter)
 			w := cmd.OutOrStdout()
 			if jsonOut {
 				enc := json.NewEncoder(w)
@@ -96,5 +98,23 @@ func newMCPToolsCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Print tools as JSON")
+	cmd.Flags().StringVar(&filter, "filter", "", "Only show tools matching this text")
 	return cmd
+}
+
+func filterMCPTools(tools []grut_mcp.ToolInfo, filter string) []grut_mcp.ToolInfo {
+	query := strings.TrimSpace(strings.ToLower(filter))
+	if query == "" {
+		return tools
+	}
+
+	out := []grut_mcp.ToolInfo{}
+	for _, tool := range tools {
+		if strings.Contains(strings.ToLower(tool.Name), query) ||
+			strings.Contains(strings.ToLower(tool.Category), query) ||
+			strings.Contains(strings.ToLower(tool.Description), query) {
+			out = append(out, tool)
+		}
+	}
+	return out
 }

--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	grut_mcp "github.com/jongio/grut/internal/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPToolsCommandFiltersTextOutput(t *testing.T) {
+	cmd := newMCPToolsCmd()
+	cmd.SetArgs([]string{"--filter", "read"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "file_read")
+	assert.NotContains(t, out.String(), "file_write")
+}
+
+func TestMCPToolsCommandFiltersJSONOutput(t *testing.T) {
+	cmd := newMCPToolsCmd()
+	cmd.SetArgs([]string{"--filter", "write", "--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	var tools []grut_mcp.ToolInfo
+	require.NoError(t, json.Unmarshal(out.Bytes(), &tools))
+	require.NotEmpty(t, tools)
+	for _, tool := range tools {
+		haystack := strings.ToLower(tool.Name + tool.Category + tool.Description)
+		assert.Contains(t, haystack, "write")
+	}
+}
+
+func TestMCPToolsCommandFilterNoMatches(t *testing.T) {
+	cmd := newMCPToolsCmd()
+	cmd.SetArgs([]string{"--filter", "no-such-tool", "--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	assert.Equal(t, "[]\n", out.String())
+}
+
+func TestRootRegistersMCPToolsCommand(t *testing.T) {
+	root, cleanup := newRootCommand()
+	defer cleanup()
+
+	toolsCmd, _, err := root.Find([]string{"mcp", mcpToolsUse})
+	require.NoError(t, err)
+	require.NotNil(t, toolsCmd)
+	assert.Equal(t, mcpToolsUse, toolsCmd.Name())
+}


### PR DESCRIPTION
Closes #365

Adds `grut mcp tools --filter <text>` so users can narrow the tool inventory by name, category, or description. The filter works with table and JSON output.

Validation:
- `go build ./...`
- `go test ./cmd -run MCP -count=1`
- `go test ./... -count=1`

Note: `mage preflight` was attempted. It is blocked by existing lint findings in `internal\panels\gitinfo\gitinfo_github.go` and `internal\panels\gitdiff\gitdiff.go`.