### PR TITLE
Add JSON output to config path

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -63,14 +64,31 @@ func newConfigCheckCmdWithKeymap(load configLoadFunc, path configPathFunc, loadK
 const configPathCommandName = "path"
 
 func newConfigPathCmd(path configPathFunc, dataPath dataPathFunc) *cobra.Command {
-	return &cobra.Command{
+	var asJSON bool
+	pathCmd := &cobra.Command{
 		Use:   configPathCommandName,
 		Short: "Print resolved grut config and data paths",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, err := fmt.Fprintf(cmd.OutOrStdout(), "Config: %s\nData:   %s\n", path(), dataPath())
+			paths := configPaths{
+				Config: path(),
+				Data:   dataPath(),
+			}
+			if asJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(paths)
+			}
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "Config: %s\nData:   %s\n", paths.Config, paths.Data)
 			return err
 		},
 	}
+	pathCmd.Flags().BoolVar(&asJSON, "json", false, "Print resolved paths as JSON")
+	return pathCmd
+}
+
+type configPaths struct {
+	Config string `json:"config"`
+	Data   string `json:"data"`
 }
 
 const defaultKeybindingScheme = "default"

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -113,6 +114,24 @@ func TestConfigPathPrintsResolvedPaths(t *testing.T) {
 	}
 }
 
+func TestConfigPathPrintsJSON(t *testing.T) {
+	cmd := newConfigPathCmd(
+		func() string { return windowsConfigPath },
+		func() string { return windowsDataPath },
+	)
+	cmd.SetArgs([]string{"--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	var paths configPaths
+	require.NoError(t, json.Unmarshal(out.Bytes(), &paths))
+	assert.Equal(t, windowsConfigPath, paths.Config)
+	assert.Equal(t, windowsDataPath, paths.Data)
+}
+
 func TestRootRegistersConfigCheck(t *testing.T) {
 	root, cleanup := newRootCommand()
 	defer cleanup()
@@ -136,6 +155,7 @@ func TestRootRegistersConfigPath(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pathCmd)
 	assert.Equal(t, configPathCommandName, pathCmd.Name())
+	require.NotNil(t, pathCmd.Flags().Lookup("json"), "--json flag should be registered")
 }
 
 func TestRootRegistersConfigGet(t *testing.T) {


### PR DESCRIPTION
Closes #366

Adds `grut config path --json` with resolved `config` and `data` paths for installers, shell integrations, and bug report tooling. The default text output stays unchanged.

Validation:
- `go build ./...`
- `go test ./cmd -run ConfigPath -count=1`
- `go test ./... -count=1`

Note: `mage preflight` was attempted. It is blocked by existing lint findings in `internal\panels\gitinfo\gitinfo_github.go` and `internal\panels\gitdiff\gitdiff.go`.