### PR TITLE
Add JSON output to clean command

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -19,6 +20,21 @@ type dataDirFunc func() string
 type cleanTarget struct {
 	label string
 	path  string
+}
+
+type cleanTargetReport struct {
+	Label   string `json:"label"`
+	Path    string `json:"path"`
+	Exists  bool   `json:"exists"`
+	Bytes   int64  `json:"bytes"`
+	Removed bool   `json:"removed"`
+}
+
+type cleanReport struct {
+	Forced       bool                `json:"forced"`
+	TotalBytes   int64               `json:"total_bytes"`
+	PresentCount int                 `json:"present_count"`
+	Targets      []cleanTargetReport `json:"targets"`
 }
 
 // cleanTargets returns the transient directories clean manages, rooted at
@@ -54,50 +70,76 @@ clean never touches your config file, installed extensions, crash reports
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			force, _ := cmd.Flags().GetBool("force")
-			return runClean(cmd.OutOrStdout(), cleanTargets(dataDir()), force)
+			asJSON, _ := cmd.Flags().GetBool("json")
+			return runClean(cmd.OutOrStdout(), cleanTargets(dataDir()), force, asJSON)
 		},
 	}
 	cmd.Flags().Bool("force", false, "Delete the transient data (without this flag, clean only previews)")
+	cmd.Flags().Bool("json", false, "Print the clean report as JSON")
 	return cmd
 }
 
 // runClean scans each target, then either previews it or removes it. A
 // missing target is reported and skipped rather than treated as an error, so
 // running clean on a fresh machine is a no-op.
-func runClean(out io.Writer, targets []cleanTarget, force bool) error {
-	var total int64
-	present := 0
+func runClean(out io.Writer, targets []cleanTarget, force, asJSON bool) error {
+	report := cleanReport{
+		Forced:  force,
+		Targets: make([]cleanTargetReport, 0, len(targets)),
+	}
 	for _, t := range targets {
 		size, exists, err := dirSize(t.path)
 		if err != nil {
 			return fmt.Errorf("scanning %s: %w", t.label, err)
 		}
+		targetReport := cleanTargetReport{
+			Label:  t.label,
+			Path:   t.path,
+			Exists: exists,
+			Bytes:  size,
+		}
 		if !exists {
-			fmt.Fprintf(out, "  %-12s not present\n", t.label)
+			report.Targets = append(report.Targets, targetReport)
+			if !asJSON {
+				fmt.Fprintf(out, "  %-12s not present\n", t.label)
+			}
 			continue
 		}
-		present++
-		total += size
+		report.PresentCount++
+		report.TotalBytes += size
 		if force {
 			if err := os.RemoveAll(t.path); err != nil {
 				return fmt.Errorf("removing %s: %w", t.label, err)
 			}
-			fmt.Fprintf(out, "  %-12s removed  %s\n", t.label, humanizeBytes(size))
+			targetReport.Removed = true
+			report.Targets = append(report.Targets, targetReport)
+			if !asJSON {
+				fmt.Fprintf(out, "  %-12s removed  %s\n", t.label, humanizeBytes(size))
+			}
 			continue
 		}
-		fmt.Fprintf(out, "  %-12s %-10s %s\n", t.label, humanizeBytes(size), t.path)
+		report.Targets = append(report.Targets, targetReport)
+		if !asJSON {
+			fmt.Fprintf(out, "  %-12s %-10s %s\n", t.label, humanizeBytes(size), t.path)
+		}
+	}
+
+	if asJSON {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
 	}
 
 	fmt.Fprintln(out)
 	if force {
-		fmt.Fprintf(out, "Reclaimed %s.\n", humanizeBytes(total))
+		fmt.Fprintf(out, "Reclaimed %s.\n", humanizeBytes(report.TotalBytes))
 		return nil
 	}
-	if present == 0 {
+	if report.PresentCount == 0 {
 		fmt.Fprintln(out, "Nothing to clean.")
 		return nil
 	}
-	fmt.Fprintf(out, "%s across %d location(s). Run with --force to delete.\n", humanizeBytes(total), present)
+	fmt.Fprintf(out, "%s across %d location(s). Run with --force to delete.\n", humanizeBytes(report.TotalBytes), report.PresentCount)
 	return nil
 }
 

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -98,6 +99,57 @@ func TestCleanMissingDirsForce(t *testing.T) {
 	out := execClean(t, dataDir, "--force")
 
 	assert.Contains(t, out, "Reclaimed 0 B.")
+}
+
+func TestCleanJSONPreviewReportsTargetsWithoutDeleting(t *testing.T) {
+	dataDir := seedCleanData(t)
+
+	out := execClean(t, dataDir, "--json")
+
+	var report cleanReport
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.False(t, report.Forced)
+	assert.Equal(t, int64(len("session")+len("diag")), report.TotalBytes)
+	assert.Equal(t, 2, report.PresentCount)
+	require.Len(t, report.Targets, 2)
+	assert.Equal(t, "sessions", report.Targets[0].Label)
+	assert.True(t, report.Targets[0].Exists)
+	assert.False(t, report.Targets[0].Removed)
+	assert.DirExists(t, filepath.Join(dataDir, "sessions"))
+	assert.DirExists(t, filepath.Join(dataDir, "diagnostics"))
+}
+
+func TestCleanJSONForceReportsRemovedTargets(t *testing.T) {
+	dataDir := seedCleanData(t)
+
+	out := execClean(t, dataDir, "--force", "--json")
+
+	var report cleanReport
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.True(t, report.Forced)
+	assert.Equal(t, 2, report.PresentCount)
+	for _, target := range report.Targets {
+		assert.True(t, target.Exists)
+		assert.True(t, target.Removed)
+	}
+	assert.NoDirExists(t, filepath.Join(dataDir, "sessions"))
+	assert.NoDirExists(t, filepath.Join(dataDir, "diagnostics"))
+}
+
+func TestCleanJSONMissingDirs(t *testing.T) {
+	dataDir := t.TempDir()
+
+	out := execClean(t, dataDir, "--json")
+
+	var report cleanReport
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.Equal(t, int64(0), report.TotalBytes)
+	assert.Equal(t, 0, report.PresentCount)
+	require.Len(t, report.Targets, 2)
+	for _, target := range report.Targets {
+		assert.False(t, target.Exists)
+		assert.False(t, target.Removed)
+	}
 }
 
 func TestCleanRejectsArgs(t *testing.T) {


### PR DESCRIPTION
Adds `--json` to `grut clean` for scripts that need to inspect transient data cleanup.

Changes:
- Reports each clean target with path, existence, byte count, and removal status.
- Keeps text output unchanged by default.
- Covers preview, forced delete, and missing target cases with tests.

Validation:
- `go build ./...`
- `go test ./...`
- `mage preflight` failed on existing lint findings in `internal\panels\gitinfo\gitinfo_submodules.go` and `internal\panels\gitdiff\gitdiff.go`.

Closes https://github.com/jongio/grut/issues/371