### PR TITLE
Show resolved theme details from the CLI

### DIFF
--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -16,6 +16,7 @@ func newThemeCmd() *cobra.Command {
 		Short: "Inspect grut themes",
 	}
 	themeCmd.AddCommand(newThemeListCmd(theme.ListThemes))
+	themeCmd.AddCommand(newThemeShowCmd(theme.Load))
 	return themeCmd
 }
 
@@ -40,4 +41,58 @@ func newThemeListCmd(list themeListFunc) *cobra.Command {
 	}
 	listCmd.Flags().BoolVar(&asJSON, "json", false, "Print theme names as JSON")
 	return listCmd
+}
+
+type themeLoadFunc func(string) (*theme.Theme, error)
+
+type themeShowReport struct {
+	Name    string       `json:"name"`
+	Variant string       `json:"variant"`
+	Mode    string       `json:"mode"`
+	Colors  theme.Colors `json:"colors"`
+}
+
+func newThemeShowCmd(load themeLoadFunc) *cobra.Command {
+	var asJSON bool
+	showCmd := &cobra.Command{
+		Use:   "show <name>",
+		Short: "Show resolved theme details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := load(args[0])
+			if err != nil {
+				return err
+			}
+			report := themeShowReport{
+				Name:    resolved.Name,
+				Variant: resolved.Variant,
+				Mode:    string(resolved.Mode),
+				Colors:  resolved.Colors,
+			}
+			if asJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(report)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Name:    %s\n", report.Name)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Variant: %s\n", report.Variant)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Mode:    %s\n", report.Mode)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Colors:  %d slots\n", themeColorSlotCount(report.Colors))
+			return nil
+		},
+	}
+	showCmd.Flags().BoolVar(&asJSON, "json", false, "Print resolved theme details as JSON")
+	return showCmd
+}
+
+func themeColorSlotCount(colors theme.Colors) int {
+	data, err := json.Marshal(colors)
+	if err != nil {
+		return 0
+	}
+	var slots map[string]string
+	if err := json.Unmarshal(data, &slots); err != nil {
+		return 0
+	}
+	return len(slots)
 }

--- a/cmd/theme_test.go
+++ b/cmd/theme_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/jongio/grut/internal/theme"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,6 +34,41 @@ func TestThemeListCommandPrintsJSON(t *testing.T) {
 	var names []string
 	require.NoError(t, json.Unmarshal(out.Bytes(), &names))
 	assert.Equal(t, []string{"default", "gruvbox"}, names)
+}
+
+func TestThemeShowCommandPrintsText(t *testing.T) {
+	cmd := newThemeShowCmd(func(string) (*theme.Theme, error) {
+		return &theme.Theme{Name: "default", Variant: "dark", Mode: theme.ModeColor, Colors: theme.Colors{Background: "#000000"}}, nil
+	})
+	cmd.SetArgs([]string{"default"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Name:    default")
+	assert.Contains(t, out.String(), "Variant: dark")
+	assert.Contains(t, out.String(), "Mode:    color")
+}
+
+func TestThemeShowCommandPrintsJSON(t *testing.T) {
+	cmd := newThemeShowCmd(func(string) (*theme.Theme, error) {
+		return &theme.Theme{Name: "gruvbox", Variant: "dark", Mode: theme.ModeColor, Colors: theme.Colors{Background: "#282828"}}, nil
+	})
+	cmd.SetArgs([]string{"gruvbox", "--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	var report themeShowReport
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	assert.Equal(t, "gruvbox", report.Name)
+	assert.Equal(t, "dark", report.Variant)
+	assert.Equal(t, "color", report.Mode)
+	assert.Equal(t, "#282828", report.Colors.Background)
 }
 
 func TestRootRegistersThemeListCommand(t *testing.T) {


### PR DESCRIPTION
Closes #379

Adds `grut theme show <name>` with JSON output for theme tooling and docs scripts.

Changes:
- Adds a `theme show` subcommand.
- Prints resolved theme name, variant, mode, and color slots as JSON.
- Keeps `theme list` unchanged.

Validation:
- `go build ./...`
- `go test ./cmd -run Theme -count=1`
- `go test ./... -count=1`
- `mage preflight` was attempted. It is blocked by WSL tests where `git` is not available in the WSL PATH.