### PR TITLE
Filter keybindings by section id

### DIFF
--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -11,8 +11,9 @@ import (
 
 func newKeysCmd() *cobra.Command {
 	var (
-		filter string
-		asJSON bool
+		filter  string
+		section string
+		asJSON  bool
 	)
 
 	keysCmd := &cobra.Command{
@@ -20,7 +21,8 @@ func newKeysCmd() *cobra.Command {
 		Short: "Print keybindings",
 		Long:  "Print the built-in keybinding reference without starting the TUI.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sections := filterKeybindingSections(keybindings.Sections(), filter)
+			sections := filterKeybindingSectionsByID(keybindings.Sections(), section)
+			sections = filterKeybindingSections(sections, filter)
 			if asJSON {
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				enc.SetIndent("", "  ")
@@ -32,8 +34,22 @@ func newKeysCmd() *cobra.Command {
 	}
 
 	keysCmd.Flags().StringVar(&filter, "filter", "", "Only show sections, keys, or actions matching this text")
+	keysCmd.Flags().StringVar(&section, "section", "", "Only show the section with this id")
 	keysCmd.Flags().BoolVar(&asJSON, "json", false, "Print keybindings as JSON")
 	return keysCmd
+}
+
+func filterKeybindingSectionsByID(sections []keybindings.Section, section string) []keybindings.Section {
+	query := strings.TrimSpace(strings.ToLower(section))
+	if query == "" {
+		return sections
+	}
+	for _, item := range sections {
+		if strings.ToLower(item.ID) == query {
+			return []keybindings.Section{item}
+		}
+	}
+	return []keybindings.Section{}
 }
 
 func filterKeybindingSections(sections []keybindings.Section, filter string) []keybindings.Section {

--- a/cmd/keys_test.go
+++ b/cmd/keys_test.go
@@ -35,6 +35,48 @@ func TestKeysCommandFiltersBindings(t *testing.T) {
 	assert.NotContains(t, out.String(), "File Tree\n")
 }
 
+func TestKeysCommandFiltersBySection(t *testing.T) {
+	cmd := newKeysCmd()
+	cmd.SetArgs([]string{"--section", "filetree"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "File Tree")
+	assert.NotContains(t, out.String(), "Global\n")
+}
+
+func TestKeysCommandFiltersBySectionJSON(t *testing.T) {
+	cmd := newKeysCmd()
+	cmd.SetArgs([]string{"--section", "global", "--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	var sections []keybindings.Section
+	require.NoError(t, json.Unmarshal(out.Bytes(), &sections))
+	require.Len(t, sections, 1)
+	assert.Equal(t, "global", sections[0].ID)
+}
+
+func TestKeysCommandUnknownSectionReturnsEmptyJSON(t *testing.T) {
+	cmd := newKeysCmd()
+	cmd.SetArgs([]string{"--section", "missing", "--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	var sections []keybindings.Section
+	require.NoError(t, json.Unmarshal(out.Bytes(), &sections))
+	assert.Empty(t, sections)
+}
+
 func TestKeysCommandPrintsJSON(t *testing.T) {
 	cmd := newKeysCmd()
 	cmd.SetArgs([]string{"--filter", "global", "--json"})


### PR DESCRIPTION
Closes #380

Adds `grut keys --section <id>` for docs tooling and scripts that need a stable keybinding group.

Changes:
- Filters keybindings by exact section id.
- Supports `--section` with text and JSON output.
- Returns an empty result for unknown section ids.

Validation:
- `go build ./...`
- `go test ./cmd -run Keys -count=1`
- `go test ./... -count=1`
- `mage preflight` was attempted. It is blocked by WSL tests where `git` is not available in the WSL PATH.