### PR TITLE
feat(theme): add --filter flag to theme list

### DIFF
--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/jongio/grut/internal/theme"
 	"github.com/spf13/cobra"
@@ -22,12 +23,13 @@ func newThemeCmd() *cobra.Command {
 
 func newThemeListCmd(list themeListFunc) *cobra.Command {
 	var asJSON bool
+	var filter string
 
 	listCmd := &cobra.Command{
 		Use:   cmdList,
 		Short: "List available themes",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			themes := list()
+			themes := filterThemeNames(list(), filter)
 			if asJSON {
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				enc.SetIndent("", "  ")
@@ -40,7 +42,23 @@ func newThemeListCmd(list themeListFunc) *cobra.Command {
 		},
 	}
 	listCmd.Flags().BoolVar(&asJSON, "json", false, "Print theme names as JSON")
+	listCmd.Flags().StringVar(&filter, "filter", "", "Only show themes matching this text")
 	return listCmd
+}
+
+func filterThemeNames(themes []string, filter string) []string {
+	query := strings.TrimSpace(strings.ToLower(filter))
+	if query == "" {
+		return themes
+	}
+
+	out := []string{}
+	for _, name := range themes {
+		if strings.Contains(strings.ToLower(name), query) {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 type themeLoadFunc func(string) (*theme.Theme, error)

--- a/cmd/theme_test.go
+++ b/cmd/theme_test.go
@@ -36,6 +36,68 @@ func TestThemeListCommandPrintsJSON(t *testing.T) {
 	assert.Equal(t, []string{"default", "gruvbox"}, names)
 }
 
+func TestThemeListCommandFiltersNames(t *testing.T) {
+	cmd := newThemeListCmd(func() []string { return []string{"catppuccin", "custom", "Catwalk"} })
+	cmd.SetArgs([]string{"--filter", "cat"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	assert.Equal(t, "catppuccin\nCatwalk\n", out.String())
+}
+
+func TestThemeListCommandFiltersJSON(t *testing.T) {
+	cmd := newThemeListCmd(func() []string { return []string{"default", "Catppuccin", "gruvbox"} })
+	cmd.SetArgs([]string{"--filter", "CAT", "--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	var names []string
+	require.NoError(t, json.Unmarshal(out.Bytes(), &names))
+	assert.Equal(t, []string{"Catppuccin"}, names)
+}
+
+func TestThemeListCommandEmptyFilterPreservesNames(t *testing.T) {
+	cmd := newThemeListCmd(func() []string { return []string{"default", "gruvbox"} })
+	cmd.SetArgs([]string{"--filter", ""})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	assert.Equal(t, "default\ngruvbox\n", out.String())
+}
+
+func TestThemeListCommandFilterNoMatchesText(t *testing.T) {
+	cmd := newThemeListCmd(func() []string { return []string{"default", "gruvbox"} })
+	cmd.SetArgs([]string{"--filter", "cat"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	assert.Empty(t, out.String())
+}
+
+func TestThemeListCommandFilterNoMatchesJSON(t *testing.T) {
+	cmd := newThemeListCmd(func() []string { return []string{"default", "gruvbox"} })
+	cmd.SetArgs([]string{"--filter", "cat", "--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	assert.Equal(t, "[]\n", out.String())
+}
+
 func TestThemeShowCommandPrintsText(t *testing.T) {
 	cmd := newThemeShowCmd(func(string) (*theme.Theme, error) {
 		return &theme.Theme{Name: "default", Variant: "dark", Mode: theme.ModeColor, Colors: theme.Colors{Background: "#000000"}}, nil


### PR DESCRIPTION
Closes #389

## What

Adds `--filter` to `grut theme list` so setup scripts can narrow output instead of parsing every theme name.

## Behavior

- `grut theme list --filter cat` prints only names matching case-insensitively.
- `--json` returns the filtered list.
- An empty filter preserves the existing output exactly.

Matching semantics follow the existing `--filter` flags on `grut keys` and `grut mcp` (case-insensitive substring).

## Tests

`cmd/theme_test.go` covers filtered text output, filtered JSON, empty filter passthrough, and the no-match case in both text and JSON.