### PR TITLE
feat(doctor): add --check flag for quiet health gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ grut is primarily a TUI, but it also exposes subcommands for scripting and setup
 | `grut [path]` | Launch the TUI in the current or given directory |
 | `grut version` | Print the version of grut |
 | `grut update` | Update grut to the latest release |
-| `grut doctor` | Check environment health (`--json` for issue reports/CI logs) |
+| `grut doctor` | Check environment health (`--json` for reports, `--check` for quiet gates) |
 | `grut status` | Print a summary of the working tree status |
 | `grut config` | Inspect configuration (`check`, `get <key>`, `defaults`) |
 | `grut theme` | Inspect themes (`theme list`) |

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -86,24 +86,28 @@ func newDoctorCmdWithDeps(deps doctorCommandDeps) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			report := runDoctor(cmd.Context(), deps)
+			check, _ := cmd.Flags().GetBool("check")
 			var err error
 			if asJSON {
 				err = writeDoctorJSON(cmd.OutOrStdout(), report)
-			} else {
+			} else if !check {
 				writeDoctorText(cmd.OutOrStdout(), report)
 			}
 			if err != nil {
 				return err
 			}
 			if !report.OK {
-				return errors.New("doctor found failed required checks")
+				return errDoctorRequiredChecksFailed
 			}
 			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output the doctor report as JSON")
+	cmd.Flags().Bool("check", false, "Exit with an error when required doctor checks fail")
 	return cmd
 }
+
+var errDoctorRequiredChecksFailed = errors.New("doctor found failed required checks")
 
 func defaultDoctorDeps() doctorCommandDeps {
 	return doctorCommandDeps{

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -26,6 +26,14 @@ func TestDoctorPassingConfig(t *testing.T) {
 	assert.Contains(t, out, "All required checks passed.")
 }
 
+func TestNewDoctorCmd_Wiring(t *testing.T) {
+	cmd := newDoctorCmd()
+	assert.Equal(t, "doctor", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	require.NotNil(t, cmd.Flags().Lookup("json"), "--json flag should be registered")
+	require.NotNil(t, cmd.Flags().Lookup("check"), "--check flag should be registered")
+}
+
 func TestDoctorInvalidConfigFailsRequiredCheck(t *testing.T) {
 	deps := doctorTestDeps(nil)
 	deps.loadConfig = func() (*config.Config, error) {
@@ -88,6 +96,47 @@ func TestDoctorRequiredFailureExitsNonZero(t *testing.T) {
 	assert.Contains(t, out, "Git")
 	assert.Contains(t, out, "FAIL")
 	assert.Contains(t, out, "One or more required checks failed.")
+}
+
+func TestDoctorCheckPassingRequiredChecksPrintsNothing(t *testing.T) {
+	out, err := runDoctorTest(t, doctorTestDeps(&config.Config{
+		Theme: config.ThemeConfig{Name: "default"},
+		AI:    config.AIConfig{Enabled: false, Provider: "none"},
+	}), []string{"--check"})
+
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestDoctorCheckRequiredFailureExitsNonZeroAndPrintsNothing(t *testing.T) {
+	deps := doctorTestDeps(&config.Config{
+		Theme: config.ThemeConfig{Name: "default"},
+		AI:    config.AIConfig{Enabled: false, Provider: "none"},
+	})
+	deps.runCommand = func(_ context.Context, name string, args ...string) (string, string, error) {
+		if name == "git" && len(args) == 1 && args[0] == "--version" {
+			return "", "git missing", errors.New("not found")
+		}
+		return fakeDoctorCommand(name, args...)
+	}
+
+	out, err := runDoctorTest(t, deps, []string{"--check"})
+
+	require.ErrorIs(t, err, errDoctorRequiredChecksFailed)
+	assert.Empty(t, out)
+}
+
+func TestDoctorCheckJSONStillPrintsJSON(t *testing.T) {
+	out, err := runDoctorTest(t, doctorTestDeps(&config.Config{
+		Theme: config.ThemeConfig{Name: "default"},
+		AI:    config.AIConfig{Enabled: false, Provider: "none"},
+	}), []string{"--check", "--json"})
+
+	require.NoError(t, err)
+	var report doctorReport
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.True(t, report.OK)
+	assert.NotEmpty(t, report.Checks)
 }
 
 func TestDoctorJSONStableFields(t *testing.T) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ Config: C:\Users\me\AppData\Roaming\grut\config.toml
 Data:   C:\Users\me\AppData\Local\grut
 ```
 
-Run `grut doctor` to validate the active config, selected theme, terminal compatibility, Git/GitHub auth, AI provider readiness, and config/data directory writability. Use `grut doctor --json` to attach a stable machine-readable report to bug reports or CI logs.
+Run `grut doctor` to validate the active config, selected theme, terminal compatibility, Git/GitHub auth, AI provider readiness, and config/data directory writability. Use `grut doctor --json` to attach a stable machine-readable report to bug reports or CI logs. Use `grut doctor --check` for quiet shell gates that only need an exit code.
 
 ---
 


### PR DESCRIPTION
Closes #381

## What

Adds `--check` to `grut doctor` so shell prompts and install scripts can gate on health without printing a report.

## Behavior

- `grut doctor --check` exits 0 when all required checks pass.
- Exits non-zero when any required check fails.
- Suppresses the text report.
- `--check --json` still prints JSON for callers that ask for it.

Follows the `--check` convention already established by `grut status --check`.

## Tests

`cmd/doctor_test.go` covers the pass and fail exit codes, suppressed text output, and the `--check --json` combination.

Docs updated in `README.md` and `docs/configuration.md`.