### PR TITLE
feat(status): add --short compact output mode

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -45,23 +45,31 @@ type statusReport struct {
 // current repository state for humans or, with --json, for scripts.
 func newStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "status",
-		Short: "Print a summary of the working tree status",
+		Use:          "status",
+		Short:        "Print a summary of the working tree status",
+		SilenceUsage: true,
 		Long: `Print a summary of the current repository: branch, tracking
 information (ahead/behind), and the staged, unstaged, untracked, and
 conflicted files.
 
 Use --json for a stable, machine-readable document that scripts and other
-tools can parse.`,
+tools can parse. Use --short for compact branch and file status lines.`,
 		Args: cobra.NoArgs,
 		RunE: runStatus,
 	}
 	cmd.Flags().Bool("json", false, "Output the status as JSON")
 	cmd.Flags().Bool("check", false, "Exit with an error when the working tree is not clean")
+	cmd.Flags().Bool("short", false, "Output compact branch and file status lines")
 	return cmd
 }
 
 func runStatus(cmd *cobra.Command, _ []string) error {
+	asJSON, _ := cmd.Flags().GetBool("json")
+	asShort, _ := cmd.Flags().GetBool("short")
+	if asJSON && asShort {
+		return fmt.Errorf("--short cannot be combined with --json")
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("get working directory: %w", err)
@@ -87,11 +95,12 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 
 	report := buildStatusReport(branch, files)
 
-	asJSON, _ := cmd.Flags().GetBool("json")
 	if asJSON {
 		if err := writeStatusJSON(cmd.OutOrStdout(), report); err != nil {
 			return err
 		}
+	} else if asShort {
+		writeStatusShort(cmd.OutOrStdout(), branch, files, report.Clean)
 	} else {
 		writeStatusText(cmd.OutOrStdout(), report)
 	}
@@ -210,6 +219,62 @@ func writeStatusText(w io.Writer, report statusReport) {
 			fmt.Fprintf(w, "  ? %s\n", p)
 		}
 	}
+}
+
+func writeStatusShort(w io.Writer, branch git.StatusBranch, files []git.FileStatus, clean bool) {
+	fmt.Fprint(w, shortBranchLine(branch))
+	if clean {
+		fmt.Fprint(w, " clean\n")
+		return
+	}
+	fmt.Fprintln(w)
+
+	for _, f := range files {
+		fmt.Fprintf(w, "%s %s\n", shortStatusCode(f), shortStatusPath(f))
+	}
+}
+
+func shortBranchLine(branch git.StatusBranch) string {
+	head := branch.Head
+	if head == "" || head == detachedHead {
+		head = "HEAD (detached)"
+	}
+
+	line := "## " + head
+	if branch.Upstream != "" {
+		line += "..." + branch.Upstream
+	}
+
+	switch {
+	case branch.Ahead > 0 && branch.Behind > 0:
+		line += fmt.Sprintf(" [ahead %d, behind %d]", branch.Ahead, branch.Behind)
+	case branch.Ahead > 0:
+		line += fmt.Sprintf(" [ahead %d]", branch.Ahead)
+	case branch.Behind > 0:
+		line += fmt.Sprintf(" [behind %d]", branch.Behind)
+	}
+
+	return line
+}
+
+func shortStatusCode(f git.FileStatus) string {
+	if f.StagedStatus == git.StatusUntracked && f.WorktreeStatus == git.StatusUntracked {
+		return "??"
+	}
+	if f.StagedStatus == git.StatusConflict || f.WorktreeStatus == git.StatusConflict {
+		return "UU"
+	}
+	if f.StagedStatus == git.StatusIgnored && f.WorktreeStatus == git.StatusIgnored {
+		return "!!"
+	}
+	return f.StagedStatus.String() + f.WorktreeStatus.String()
+}
+
+func shortStatusPath(f git.FileStatus) string {
+	if f.OrigPath != "" && (f.StagedStatus == git.StatusRenamed || f.StagedStatus == git.StatusCopied) {
+		return f.OrigPath + " -> " + f.Path
+	}
+	return f.Path
 }
 
 func writeStatusSection(w io.Writer, label string, entries []statusEntry) {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -20,6 +20,7 @@ func TestNewStatusCmd_Wiring(t *testing.T) {
 	assert.NotEmpty(t, cmd.Short)
 	require.NotNil(t, cmd.Flags().Lookup("json"), "--json flag should be registered")
 	require.NotNil(t, cmd.Flags().Lookup("check"), "--check flag should be registered")
+	require.NotNil(t, cmd.Flags().Lookup("short"), "--short flag should be registered")
 }
 
 func TestBuildStatusReport_Clean(t *testing.T) {
@@ -106,6 +107,37 @@ func TestWriteStatusText_DetachedHead(t *testing.T) {
 	assert.Contains(t, buf.String(), "HEAD detached")
 }
 
+func TestWriteStatusShort_Clean(t *testing.T) {
+	var buf bytes.Buffer
+	writeStatusShort(&buf, git.StatusBranch{Head: "main", Upstream: "origin/main", Ahead: 2}, nil, true)
+	assert.Equal(t, "## main...origin/main [ahead 2] clean\n", buf.String())
+}
+
+func TestWriteStatusShort_CompactFiles(t *testing.T) {
+	files := []git.FileStatus{
+		{Path: "staged.go", StagedStatus: git.StatusModified, WorktreeStatus: git.StatusUnmodified},
+		{Path: "unstaged.go", StagedStatus: git.StatusUnmodified, WorktreeStatus: git.StatusModified},
+		{Path: "both.go", StagedStatus: git.StatusModified, WorktreeStatus: git.StatusModified},
+		{Path: "new.txt", StagedStatus: git.StatusUntracked, WorktreeStatus: git.StatusUntracked},
+		{Path: "conflict.txt", StagedStatus: git.StatusConflict, WorktreeStatus: git.StatusConflict},
+		{Path: "new-name.go", OrigPath: "old-name.go", StagedStatus: git.StatusRenamed, WorktreeStatus: git.StatusUnmodified},
+	}
+
+	var buf bytes.Buffer
+	writeStatusShort(&buf, git.StatusBranch{Head: "main"}, files, false)
+
+	assert.Equal(t, strings.Join([]string{
+		"## main",
+		"M  staged.go",
+		" M unstaged.go",
+		"MM both.go",
+		"?? new.txt",
+		"UU conflict.txt",
+		"R  old-name.go -> new-name.go",
+		"",
+	}, "\n"), buf.String())
+}
+
 func TestWriteStatusJSON_RoundTrip(t *testing.T) {
 	files := []git.FileStatus{
 		{Path: "a.go", StagedStatus: git.StatusAdded, WorktreeStatus: git.StatusUnmodified},
@@ -164,6 +196,58 @@ func TestRunStatus_CheckDirtyRepo(t *testing.T) {
 	err := runStatus(cmd, nil)
 	require.ErrorIs(t, err, errStatusDirty)
 	assert.Contains(t, out.String(), "Untracked (1):")
+}
+
+func TestRunStatus_ShortCleanRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("hi"), 0o644))
+	runGit(t, dir, "add", "tracked.txt")
+	runGit(t, dir, "commit", "-m", "initial")
+
+	t.Chdir(dir)
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--short"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "## main clean\n", out.String())
+}
+
+func TestRunStatus_ShortCheckDirtyRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "loose.txt"), []byte("hi"), 0o644))
+
+	t.Chdir(dir)
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--short", "--check"})
+
+	err := cmd.Execute()
+	require.ErrorIs(t, err, errStatusDirty)
+	assert.Equal(t, "## main\n?? loose.txt\n", out.String())
+}
+
+func TestRunStatus_ShortJSONMutualExclusion(t *testing.T) {
+	cmd := newStatusCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--short", "--json"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--short cannot be combined with --json")
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/pages/docs/cli.astro
+++ b/web/src/pages/docs/cli.astro
@@ -52,9 +52,10 @@ grut</code></pre>
   <pre><code>grut update</code></pre>
 
   <h3>status</h3>
-  <p>Print a summary of the working tree status. Add <code>--json</code> for scriptable output.</p>
+  <p>Print a summary of the working tree status. Add <code>--json</code> for scriptable output or <code>--short</code> for compact lines.</p>
   <pre><code>grut status
-grut status --json</code></pre>
+grut status --json
+grut status --short</code></pre>
 
   <h3>config</h3>
   <p>Inspect grüt configuration.</p>


### PR DESCRIPTION
Closes #391

## What

Adds `--short` to `grut status` for compact output suited to prompt scripts and quick terminal checks.

## Behavior

- `grut status --short` prints branch information followed by compact file lines.
- Clean repositories print a single clean line.
- `--check` still returns an error when the report is dirty.
- `--short` cannot be combined with `--json` and returns a clear error.

## Tests

`cmd/status_test.go` covers the compact dirty output, the clean single-line case, `--short --check` on a dirty tree, and the `--short --json` mutual exclusion error.