### PR TITLE
feat(report): add --limit flag to crash report listing

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -19,7 +19,8 @@ const (
 	issueURL   = "https://github.com/" + githubRepo + "/issues/new"
 	maxURLLen  = 4000
 
-	reportJSONFlag = "json"
+	reportJSONFlag  = "json"
+	reportLimitFlag = "limit"
 )
 
 type crashReportSummary struct {
@@ -54,6 +55,7 @@ all stored reports, --show to inspect one, or --clear to remove them all.`,
 	cmd.Flags().Bool("clear", false, "Clear all crash reports")
 	cmd.Flags().Bool("no-browser", false, "Print the GitHub issue URL instead of opening the browser")
 	cmd.Flags().Bool(reportJSONFlag, false, "Print list output as JSON")
+	cmd.Flags().Int(reportLimitFlag, 0, "Limit list output to the newest N crash reports (0 for all)")
 
 	return cmd
 }
@@ -94,9 +96,17 @@ func runReportClear() error {
 }
 
 func runReportList(cmd *cobra.Command, jsonOutput bool) error {
+	limit, _ := cmd.Flags().GetInt(reportLimitFlag)
+	if limit < 0 {
+		return fmt.Errorf("--limit must be 0 or greater")
+	}
+
 	reports, err := crashlog.List()
 	if err != nil {
 		return fmt.Errorf("listing crash reports: %w", err)
+	}
+	if limit > 0 && len(reports) > limit {
+		reports = reports[:limit]
 	}
 	if jsonOutput {
 		return writeCrashReportListJSON(cmd.OutOrStdout(), reports)

--- a/cmd/report_test.go
+++ b/cmd/report_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adrg/xdg"
 	"github.com/jongio/grut/internal/crashlog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -150,6 +151,7 @@ func TestNewReportCmd_FlagsRegistered(t *testing.T) {
 		{"clear", "bool"},
 		{"no-browser", "bool"},
 		{"json", "bool"},
+		{"limit", "int"},
 	}
 
 	for _, tt := range tests {
@@ -251,6 +253,60 @@ func TestRunReport_JSONWithoutListReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "--json can only be used with --list")
 }
 
+func TestRunReportList_LimitTextNewestReports(t *testing.T) {
+	setReportTestDataHome(t)
+	writeReportFixture(t, "oldest-id", "oldest panic", time.Date(2026, 7, 9, 0, 0, 0, 0, time.UTC))
+	writeReportFixture(t, "middle-id", "middle panic", time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC))
+	writeReportFixture(t, "newest-id", "newest panic", time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC))
+	var out bytes.Buffer
+	cmd := newReportCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--list", "--limit", "2"})
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	got := out.String()
+	assert.Contains(t, got, "Crash Reports (2 found)")
+	assert.Contains(t, got, "newest panic")
+	assert.Contains(t, got, "middle panic")
+	assert.NotContains(t, got, "oldest panic")
+	assert.Less(t, strings.Index(got, "newest panic"), strings.Index(got, "middle panic"))
+}
+
+func TestRunReportList_LimitZeroTextUnlimited(t *testing.T) {
+	setReportTestDataHome(t)
+	writeReportFixture(t, "oldest-id", "oldest panic", time.Date(2026, 7, 9, 0, 0, 0, 0, time.UTC))
+	writeReportFixture(t, "middle-id", "middle panic", time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC))
+	writeReportFixture(t, "newest-id", "newest panic", time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC))
+	var out bytes.Buffer
+	cmd := newReportCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--list", "--limit", "0"})
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	got := out.String()
+	assert.Contains(t, got, "Crash Reports (3 found)")
+	assert.Contains(t, got, "newest panic")
+	assert.Contains(t, got, "middle panic")
+	assert.Contains(t, got, "oldest panic")
+}
+
+func TestRunReportList_NegativeLimitTextReturnsError(t *testing.T) {
+	setReportTestDataHome(t)
+	var out bytes.Buffer
+	cmd := newReportCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--list", "--limit", "-1"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--limit must be 0 or greater")
+}
+
 func TestWriteCrashReportListJSON_Empty(t *testing.T) {
 	var out bytes.Buffer
 
@@ -288,6 +344,60 @@ func TestWriteCrashReportListJSON_SummaryFields(t *testing.T) {
 	assert.Equal(t, "preview render", got[0].Context)
 }
 
+func TestRunReportList_LimitJSONNewestReports(t *testing.T) {
+	setReportTestDataHome(t)
+	writeReportFixture(t, "oldest-id", "oldest panic", time.Date(2026, 7, 9, 0, 0, 0, 0, time.UTC))
+	writeReportFixture(t, "middle-id", "middle panic", time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC))
+	writeReportFixture(t, "newest-id", "newest panic", time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC))
+	var out bytes.Buffer
+	cmd := newReportCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--list", "--json", "--limit", "2"})
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	var got []crashReportSummary
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Len(t, got, 2)
+	assert.Equal(t, "newest-id", got[0].ID)
+	assert.Equal(t, "middle-id", got[1].ID)
+}
+
+func TestRunReportList_LimitZeroJSONUnlimited(t *testing.T) {
+	setReportTestDataHome(t)
+	writeReportFixture(t, "oldest-id", "oldest panic", time.Date(2026, 7, 9, 0, 0, 0, 0, time.UTC))
+	writeReportFixture(t, "middle-id", "middle panic", time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC))
+	writeReportFixture(t, "newest-id", "newest panic", time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC))
+	var out bytes.Buffer
+	cmd := newReportCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--list", "--json", "--limit", "0"})
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	var got []crashReportSummary
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Len(t, got, 3)
+	assert.Equal(t, "newest-id", got[0].ID)
+	assert.Equal(t, "middle-id", got[1].ID)
+	assert.Equal(t, "oldest-id", got[2].ID)
+}
+
+func TestRunReportList_NegativeLimitJSONReturnsError(t *testing.T) {
+	setReportTestDataHome(t)
+	var out bytes.Buffer
+	cmd := newReportCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--list", "--json", "--limit", "-1"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--limit must be 0 or greater")
+}
+
 func TestRunReport_LatestDefault_NoReports(t *testing.T) {
 	// Default behavior (no flags) when no crash reports exist should
 	// print "No crash reports found." and succeed.
@@ -295,6 +405,26 @@ func TestRunReport_LatestDefault_NoReports(t *testing.T) {
 	cmd.SetArgs([]string{})
 	err := cmd.Execute()
 	assert.NoError(t, err)
+}
+
+func setReportTestDataHome(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	orig := xdg.DataHome
+	xdg.DataHome = tmp
+	t.Cleanup(func() { xdg.DataHome = orig })
+}
+
+func writeReportFixture(t *testing.T, id, panicValue string, timestamp time.Time) {
+	t.Helper()
+	_, err := crashlog.Write(&crashlog.CrashReport{
+		ID:         id,
+		Timestamp:  timestamp,
+		Version:    "test-version",
+		PanicValue: panicValue,
+		Context:    "test context",
+	})
+	require.NoError(t, err)
 }
 
 func TestRunReport_LatestWithNoBrowser_NoReports(t *testing.T) {

--- a/docs/report-json.md
+++ b/docs/report-json.md
@@ -6,4 +6,4 @@ Use JSON output when scripts need to inspect stored crash reports:
 grut report --list --json
 ```
 
-The command prints an array of summaries. Use `grut report --show <id>` to print one full report.
+The command prints an array of summaries. Use `--limit N` to encode only the newest N reports, or `--limit 0` to keep the default unlimited output. Use `grut report --show <id>` to print one full report.

--- a/web/src/pages/docs/cli.astro
+++ b/web/src/pages/docs/cli.astro
@@ -109,6 +109,7 @@ grut completion powershell</code></pre>
   <p>View crash reports and file GitHub issues for them.</p>
   <pre><code># List all crash reports
 grut report --list
+grut report --list --limit 5
 
 # Show a specific report by ID
 grut report --show &lt;id&gt;
@@ -125,6 +126,7 @@ grut report --clear</code></pre>
     { key: '--clear', action: 'Clear all crash reports' },
     { key: '--no-browser', action: 'Print the issue URL instead of opening the browser' },
     { key: '--json', action: 'Print list output as JSON' },
+    { key: '--limit N', action: 'Limit list output to the newest N crash reports' },
   ]} />
 
   <h3>mcp</h3>


### PR DESCRIPTION
Closes #388

## What

Adds `--limit` to `grut report --list` so scripts can pull just the newest crash reports.

## Behavior

- `grut report --list --limit N` prints at most N reports.
- `grut report --list --json --limit N` encodes at most N reports.
- `--limit 0` keeps the existing unlimited behavior.
- Negative limits return a clear error.

`internal/crashlog.List()` returns newest-first, so limiting trims from the front and yields the N most recent reports.

## Tests

`cmd/report_test.go` covers the text and JSON limit paths, the unlimited `--limit 0` case, and the negative-limit error.