### PR TITLE
feat(keys): add --sections index mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ grut is primarily a TUI, but it also exposes subcommands for scripting and setup
 | `grut status` | Print a summary of the working tree status |
 | `grut config` | Inspect configuration (`check`, `get <key>`, `defaults`) |
 | `grut theme` | Inspect themes (`theme list`) |
-| `grut keys` | Print keybindings (`--filter`, `--json`) |
+| `grut keys` | Print keybindings (`--filter`, `--section`, `--sections`, `--json`) |
 | `grut clean` | Remove transient session and diagnostic data |
 | `grut completion` | Generate shell completion scripts |
 | `grut run <shortcut>` | Execute an AI-powered git workflow shortcut |

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -11,9 +11,10 @@ import (
 
 func newKeysCmd() *cobra.Command {
 	var (
-		filter  string
-		section string
-		asJSON  bool
+		filter       string
+		section      string
+		sectionsOnly bool
+		asJSON       bool
 	)
 
 	keysCmd := &cobra.Command{
@@ -21,8 +22,22 @@ func newKeysCmd() *cobra.Command {
 		Short: "Print keybindings",
 		Long:  "Print the built-in keybinding reference without starting the TUI.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if sectionsOnly && strings.TrimSpace(section) != "" {
+				return fmt.Errorf("--section and --sections are mutually exclusive")
+			}
+
 			sections := filterKeybindingSectionsByID(keybindings.Sections(), section)
 			sections = filterKeybindingSections(sections, filter)
+			if sectionsOnly {
+				metadata := keybindingSectionMetadata(sections)
+				if asJSON {
+					enc := json.NewEncoder(cmd.OutOrStdout())
+					enc.SetIndent("", "  ")
+					return enc.Encode(metadata)
+				}
+				printKeybindingSectionIndex(cmd, metadata)
+				return nil
+			}
 			if asJSON {
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				enc.SetIndent("", "  ")
@@ -35,8 +50,25 @@ func newKeysCmd() *cobra.Command {
 
 	keysCmd.Flags().StringVar(&filter, "filter", "", "Only show sections, keys, or actions matching this text")
 	keysCmd.Flags().StringVar(&section, "section", "", "Only show the section with this id")
+	keysCmd.Flags().BoolVar(&sectionsOnly, "sections", false, "Print available keybinding section ids and titles")
 	keysCmd.Flags().BoolVar(&asJSON, "json", false, "Print keybindings as JSON")
 	return keysCmd
+}
+
+type keybindingSectionInfo struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
+func keybindingSectionMetadata(sections []keybindings.Section) []keybindingSectionInfo {
+	out := make([]keybindingSectionInfo, 0, len(sections))
+	for _, section := range sections {
+		out = append(out, keybindingSectionInfo{
+			ID:    section.ID,
+			Title: section.Title,
+		})
+	}
+	return out
 }
 
 func filterKeybindingSectionsByID(sections []keybindings.Section, section string) []keybindings.Section {
@@ -105,5 +137,12 @@ func printKeybindingSections(cmd *cobra.Command, sections []keybindings.Section,
 		for _, binding := range section.Bindings {
 			_, _ = fmt.Fprintf(w, "  %-14s %s\n", binding.Key, binding.Action)
 		}
+	}
+}
+
+func printKeybindingSectionIndex(cmd *cobra.Command, sections []keybindingSectionInfo) {
+	w := cmd.OutOrStdout()
+	for _, section := range sections {
+		_, _ = fmt.Fprintf(w, "%-14s %s\n", section.ID, section.Title)
 	}
 }

--- a/cmd/keys_test.go
+++ b/cmd/keys_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/jongio/grut/internal/keybindings"
@@ -90,6 +91,69 @@ func TestKeysCommandPrintsJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out.Bytes(), &sections))
 	require.Len(t, sections, 1)
 	assert.Equal(t, "Global", sections[0].Title)
+}
+
+func TestKeysCommandPrintsSectionIndex(t *testing.T) {
+	cmd := newKeysCmd()
+	cmd.SetArgs([]string{"--sections"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.NotEmpty(t, lines)
+	assert.Contains(t, lines[0], "global")
+	assert.Contains(t, lines[0], "Global")
+	assert.NotContains(t, out.String(), "ctrl+c")
+}
+
+func TestKeysCommandPrintsSectionIndexWithFilter(t *testing.T) {
+	cmd := newKeysCmd()
+	cmd.SetArgs([]string{"--sections", "--filter", "workflow"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "github")
+	assert.Contains(t, out.String(), "GitHub")
+	assert.NotContains(t, out.String(), "File Tree")
+	assert.NotContains(t, out.String(), "Dispatch workflow")
+}
+
+func TestKeysCommandPrintsSectionIndexJSON(t *testing.T) {
+	cmd := newKeysCmd()
+	cmd.SetArgs([]string{"--sections", "--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	var sections []map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &sections))
+	require.NotEmpty(t, sections)
+	assert.Equal(t, "global", sections[0]["id"])
+	assert.Equal(t, "Global", sections[0]["title"])
+	assert.NotContains(t, sections[0], "bindings")
+	assert.NotContains(t, sections[0], "key")
+	assert.NotContains(t, sections[0], "action")
+}
+
+func TestKeysCommandRejectsSectionAndSectionsTogether(t *testing.T) {
+	cmd := newKeysCmd()
+	cmd.SetArgs([]string{"--section", "global", "--sections"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+	assert.NotContains(t, out.String(), "ctrl+c")
 }
 
 func TestRootRegistersKeysCommand(t *testing.T) {

--- a/web/src/pages/docs/cli.astro
+++ b/web/src/pages/docs/cli.astro
@@ -81,9 +81,12 @@ grut theme list</code></pre>
   <p>Print keybindings from the command line.</p>
   <pre><code>grut keys
 grut keys --filter commit
+grut keys --sections
 grut keys --json</code></pre>
   <KeybindingTable bindings={[
     { key: '--filter <text>', action: 'Only show sections, keys, or actions matching the text' },
+    { key: '--section <id>', action: 'Only show the section with this id' },
+    { key: '--sections', action: 'Print available keybinding section ids and titles' },
     { key: '--json', action: 'Print keybindings as JSON' },
   ]} />
 


### PR DESCRIPTION
Closes #390

## What

Adds `--sections` to `grut keys` so users can discover section ids instead of guessing them for `--section`.

## Behavior

- `grut keys --sections` prints one section per line with id and title.
- Honors `--filter`, reusing the existing matching logic in the command.
- `--sections --json` returns section metadata only, with no binding details.
- `--sections` and `--section` are mutually exclusive and return a clear error together.

## Tests

`cmd/keys_test.go` covers the section index output, `--sections --filter`, `--sections --json` metadata shape, and the mutual exclusion error.

## Note

This touches `cmd/keys.go`, which is also refactored by the `--filter` extraction in the PR for #382. Suggest merging this one first so that refactor absorbs these changes.