### PR TITLE
feat(run): add --filter flag to shortcut listing

### DIFF
--- a/cmd/filter.go
+++ b/cmd/filter.go
@@ -1,0 +1,16 @@
+package cmd
+
+import "strings"
+
+func textFilterMatches(filter string, fields ...string) bool {
+	query := strings.TrimSpace(strings.ToLower(filter))
+	if query == "" {
+		return true
+	}
+	for _, field := range fields {
+		if strings.Contains(strings.ToLower(field), query) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -53,14 +53,13 @@ func filterKeybindingSectionsByID(sections []keybindings.Section, section string
 }
 
 func filterKeybindingSections(sections []keybindings.Section, filter string) []keybindings.Section {
-	query := strings.TrimSpace(strings.ToLower(filter))
-	if query == "" {
+	if textFilterMatches(filter) {
 		return sections
 	}
 
 	var out []keybindings.Section
 	for _, section := range sections {
-		if keybindingSectionMatches(section, query) {
+		if keybindingSectionMatches(section, filter) {
 			out = append(out, section)
 			continue
 		}
@@ -68,8 +67,7 @@ func filterKeybindingSections(sections []keybindings.Section, filter string) []k
 		filtered := section
 		filtered.Bindings = nil
 		for _, binding := range section.Bindings {
-			if strings.Contains(strings.ToLower(binding.Key), query) ||
-				strings.Contains(strings.ToLower(binding.Action), query) {
+			if textFilterMatches(filter, binding.Key, binding.Action) {
 				filtered.Bindings = append(filtered.Bindings, binding)
 			}
 		}
@@ -81,9 +79,7 @@ func filterKeybindingSections(sections []keybindings.Section, filter string) []k
 }
 
 func keybindingSectionMatches(section keybindings.Section, query string) bool {
-	return strings.Contains(strings.ToLower(section.ID), query) ||
-		strings.Contains(strings.ToLower(section.Title), query) ||
-		strings.Contains(strings.ToLower(section.Description), query)
+	return textFilterMatches(query, section.ID, section.Title, section.Description)
 }
 
 func printKeybindingSections(cmd *cobra.Command, sections []keybindings.Section, filter string) {

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strings"
 
 	"github.com/jongio/grut/internal/config"
 	"github.com/jongio/grut/internal/git"
@@ -103,16 +102,13 @@ func newMCPToolsCmd() *cobra.Command {
 }
 
 func filterMCPTools(tools []grut_mcp.ToolInfo, filter string) []grut_mcp.ToolInfo {
-	query := strings.TrimSpace(strings.ToLower(filter))
-	if query == "" {
+	if textFilterMatches(filter) {
 		return tools
 	}
 
 	out := []grut_mcp.ToolInfo{}
 	for _, tool := range tools {
-		if strings.Contains(strings.ToLower(tool.Name), query) ||
-			strings.Contains(strings.ToLower(tool.Category), query) ||
-			strings.Contains(strings.ToLower(tool.Description), query) {
+		if textFilterMatches(filter, tool.Name, tool.Category, tool.Description) {
 			out = append(out, tool)
 		}
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,6 +23,7 @@ func newRunCmd() *cobra.Command {
 	var (
 		listFlag     bool
 		describeFlag string
+		filterFlag   string
 		dryRunFlag   bool
 		noConfirm    bool
 		jsonFlag     bool
@@ -66,20 +67,11 @@ Use --list to see all available shortcuts, or --describe <name> to see details.`
 
 			// Handle --list.
 			if listFlag {
-				all := engine.List()
+				all := filterShortcuts(engine.List(), filterFlag)
 				if jsonFlag {
 					return printShortcutListJSON(cmd, all)
 				}
-				if len(all) == 0 {
-					_, _ = fmt.Fprintln(w, "No shortcuts available.")
-					return nil
-				}
-				_, _ = fmt.Fprintln(w, "Available shortcuts:")
-				_, _ = fmt.Fprintln(w)
-				for _, s := range all {
-					src := shortcutSource(s)
-					_, _ = fmt.Fprintf(w, "  %-12s %-8s %s\n", s.Name, "["+src+"]", s.Description)
-				}
+				printShortcutList(cmd, all)
 				return nil
 			}
 
@@ -180,6 +172,7 @@ Use --list to see all available shortcuts, or --describe <name> to see details.`
 
 	runCmd.Flags().BoolVar(&listFlag, "list", false, "List available shortcuts")
 	runCmd.Flags().StringVar(&describeFlag, "describe", "", "Show details for a shortcut")
+	runCmd.Flags().StringVar(&filterFlag, "filter", "", "Only show shortcuts matching this text")
 	runCmd.Flags().BoolVar(&dryRunFlag, "dry-run", false, "Show execution plan without running")
 	runCmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Skip confirmation prompts")
 	runCmd.Flags().BoolVar(&jsonFlag, "json", false, "Print machine-readable JSON for list, describe, or dry-run")
@@ -239,6 +232,34 @@ func printShortcutListJSON(cmd *cobra.Command, shortcuts []shortcuts.Shortcut) e
 		return summaries[i].Name < summaries[j].Name
 	})
 	return writeJSON(cmd, summaries)
+}
+
+func printShortcutList(cmd *cobra.Command, shortcuts []shortcuts.Shortcut) {
+	w := cmd.OutOrStdout()
+	if len(shortcuts) == 0 {
+		_, _ = fmt.Fprintln(w, "No shortcuts available.")
+		return
+	}
+	_, _ = fmt.Fprintln(w, "Available shortcuts:")
+	_, _ = fmt.Fprintln(w)
+	for _, s := range shortcuts {
+		src := shortcutSource(s)
+		_, _ = fmt.Fprintf(w, "  %-12s %-8s %s\n", s.Name, "["+src+"]", s.Description)
+	}
+}
+
+func filterShortcuts(items []shortcuts.Shortcut, filter string) []shortcuts.Shortcut {
+	if textFilterMatches(filter) {
+		return items
+	}
+
+	out := []shortcuts.Shortcut{}
+	for _, s := range items {
+		if textFilterMatches(filter, s.Name, s.Description, shortcutSource(s)) {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func printShortcutJSON(cmd *cobra.Command, s shortcuts.Shortcut) error {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -259,6 +259,7 @@ func TestNewRunCmd_FlagsRegistered(t *testing.T) {
 	}{
 		{"list", "bool"},
 		{"describe", "string"},
+		{"filter", "string"},
 		{"dry-run", "bool"},
 		{"no-confirm", "bool"},
 		{"json", "bool"},
@@ -270,6 +271,15 @@ func TestNewRunCmd_FlagsRegistered(t *testing.T) {
 			assert.Equal(t, tt.flagType, f.Value.Type(), "flag --%s type mismatch", tt.name)
 		}
 	}
+}
+
+func TestNewRunCmd_FilterFlagDescription(t *testing.T) {
+	cmd := newRunCmd()
+
+	f := cmd.Flags().Lookup("filter")
+
+	require.NotNil(t, f)
+	assert.Equal(t, "Only show shortcuts matching this text", f.Usage)
 }
 
 func TestPrintShortcutListJSON_SortedSummaries(t *testing.T) {
@@ -290,6 +300,83 @@ func TestPrintShortcutListJSON_SortedSummaries(t *testing.T) {
 	assert.Equal(t, "builtin", out[0].Source)
 	assert.Equal(t, "zeta", out[1].Name)
 	assert.Equal(t, "custom", out[1].Source)
+}
+
+func TestFilterShortcuts_MatchesNameDescriptionAndSource(t *testing.T) {
+	items := []shortcuts.Shortcut{
+		{Name: "stage-commit", Description: "Stage all changes", Builtin: true},
+		{Name: "ship", Description: "Deploy to production", Builtin: false},
+		{Name: "review", Description: "Inspect pull request", Builtin: true},
+	}
+
+	byName := filterShortcuts(items, "STAGE")
+	require.Len(t, byName, 1)
+	assert.Equal(t, "stage-commit", byName[0].Name)
+
+	byDescription := filterShortcuts(items, "production")
+	require.Len(t, byDescription, 1)
+	assert.Equal(t, "ship", byDescription[0].Name)
+
+	bySource := filterShortcuts(items, "custom")
+	require.Len(t, bySource, 1)
+	assert.Equal(t, "ship", bySource[0].Name)
+}
+
+func TestFilterShortcuts_EmptyFilterReturnsAll(t *testing.T) {
+	items := []shortcuts.Shortcut{
+		{Name: "stage-commit", Description: "Stage all changes", Builtin: true},
+		{Name: "ship", Description: "Deploy to production", Builtin: false},
+	}
+
+	out := filterShortcuts(items, "  ")
+
+	assert.Equal(t, items, out)
+}
+
+func TestPrintShortcutListJSON_FilteredOutput(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	items := []shortcuts.Shortcut{
+		{Name: "stage-commit", Description: "Stage all changes", Builtin: true},
+		{Name: "ship", Description: "Deploy to production", Builtin: false},
+	}
+
+	err := printShortcutListJSON(cmd, filterShortcuts(items, "custom"))
+
+	require.NoError(t, err)
+	var out []shortcutSummaryJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.Equal(t, "ship", out[0].Name)
+	assert.Equal(t, "custom", out[0].Source)
+}
+
+func TestPrintShortcutListJSON_NoFilterMatchesReturnsEmptyArray(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	items := []shortcuts.Shortcut{
+		{Name: "stage-commit", Description: "Stage all changes", Builtin: true},
+	}
+
+	err := printShortcutListJSON(cmd, filterShortcuts(items, "missing"))
+
+	require.NoError(t, err)
+	assert.Equal(t, "[]\n", buf.String())
+}
+
+func TestPrintShortcutList_NoFilterMatchesUsesEmptyListText(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	items := []shortcuts.Shortcut{
+		{Name: "stage-commit", Description: "Stage all changes", Builtin: true},
+	}
+
+	printShortcutList(cmd, filterShortcuts(items, "missing"))
+
+	assert.Equal(t, "No shortcuts available.\n", buf.String())
 }
 
 func TestPrintShortcutJSON_IncludesArgsAndSteps(t *testing.T) {

--- a/docs/specs/shortcuts/spec.md
+++ b/docs/specs/shortcuts/spec.md
@@ -232,6 +232,7 @@ description = "Show me what I committed in the last 24 hours across all branches
 ```
 grut run <shortcut> [args...]       Execute a shortcut
 grut run --list                     List all available shortcuts
+grut run --list --filter <text>     Only show shortcuts matching this text
 grut run --describe <shortcut>      Show what a shortcut will do
 grut run --dry-run <shortcut>       Show execution plan without running
 grut run --no-confirm <shortcut>    Skip confirmation prompt

--- a/web/src/pages/docs/cli.astro
+++ b/web/src/pages/docs/cli.astro
@@ -154,6 +154,9 @@ grut run pr-review
 # List available shortcuts
 grut run --list
 
+# Filter available shortcuts
+grut run --list --filter review
+
 # Describe what a shortcut does
 grut run --describe pr-review
 
@@ -164,6 +167,7 @@ grut run --dry-run pr-review
 grut run --no-confirm pr-review</code></pre>
   <KeybindingTable bindings={[
     { key: '--list', action: 'List all available shortcuts' },
+    { key: '--filter <text>', action: 'Only show shortcuts matching this text' },
     { key: '--describe <name>', action: 'Show what a shortcut does without running it' },
     { key: '--dry-run', action: 'Preview the operations without executing them' },
     { key: '--no-confirm', action: 'Skip confirmation prompts' },


### PR DESCRIPTION
Closes #382

## What

Adds `--filter` to `grut run --list` so users can narrow shortcuts before choosing one.

## Behavior

- `grut run --list --filter <text>` filters built-in and custom shortcuts by name, description, and source.
- Works with `--json`.
- No matches prints the existing empty-list style in text and an empty array in JSON.

## Refactor

Extracts the duplicated `--filter` matching logic from `grut keys` and `grut mcp` into a shared helper in `cmd/filter.go`, so all three commands share one case-insensitive substring implementation rather than three copies.

## Tests

`cmd/run_test.go` covers matching by name, description, and source, plus the no-match case in text and JSON.

## Note

This touches `cmd/keys.go`, which is also changed by the `--sections` work in the PR for #390. Suggest merging #390 first so this refactor absorbs it.