### PR TITLE
fix(ai): stop secret redaction from deleting the following line

### DIFF
--- a/internal/ai/redact.go
+++ b/internal/ai/redact.go
@@ -40,7 +40,10 @@ var builtinSecretPatterns = []string{
 
 	// Generic API key / secret assignments
 	// (e.g. api_key = "sk_live_…", API-SECRET: "…").
-	`(?i)(api[_-]?key|apikey|api[_-]?secret)['":\s]*[=:]\s*['"]?[a-zA-Z0-9_\-]{20,}['"]?`,
+	// Separators are restricted to tabs and spaces rather than \s so that a
+	// keyword with an empty value cannot reach across a line break and consume
+	// the following line. See the note on the high-entropy pattern below.
+	`(?i)(api[_-]?key|apikey|api[_-]?secret)['":\t ]*[=:][\t ]*['"]?[a-zA-Z0-9_\-]{20,}['"]?`,
 
 	// PEM private-key blocks, including the BEGIN/END markers.
 	// The optional prefix (e.g. "RSA ", "EC ") uses (?:[A-Z]+ )* so that
@@ -57,7 +60,13 @@ var builtinSecretPatterns = []string{
 	// The value class uses [^\s'"]+ to capture passwords containing special
 	// characters (e.g. @, !, #) that are common in real-world secrets.
 	// Minimum length is 6 (not 16) because passwords can be short.
-	`(?i)(password|passwd|secret|token|access[_-]?key|private[_-]?key|auth[_-]?token)['":\s]*[=:]\s*['"]?[^\s'"]{6,}['"]?`,
+	//
+	// Separators and the value are both confined to a single line. Using \s
+	// here let "DB_PASSWORD=\nJWT_SECRET=change-me" match across the newline,
+	// so an empty value consumed the entire following line and deleted it
+	// rather than redacting a value. Matching must never span lines.
+	`(?i)(password|passwd|secret|token|access[_-]?key|private[_-]?key|auth[_-]?token)['":\t ]*[=:][\t ]*['"]?[^\s'"]{6,}['"]?`,
+	`(?i)(password|passwd|secret|token|access[_-]?key|private[_-]?key|auth[_-]?token)['":\t ]*[=:][\t ]*['"]?[^\s'"]{6,}['"]?`,
 
 	// Credentials embedded in HTTPS URLs (e.g. https://user:token@host).
 	`https?://[a-zA-Z0-9_\-]+:[a-zA-Z0-9_\-]+@[^\s'"]+`,

--- a/internal/ai/redact_test.go
+++ b/internal/ai/redact_test.go
@@ -228,6 +228,77 @@ func TestRedactGenericSecretKeywords(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Redaction must never span newlines
+// ---------------------------------------------------------------------------
+
+// A secret keyword with an empty value must not swallow the following line.
+// The separator class previously used \s, which matches newlines, so
+// "DB_PASSWORD=\nJWT_SECRET=change-me" consumed the newline and the whole
+// next line, deleting it from the content handed back to the model.
+func TestRedactDoesNotSpanNewlines(t *testing.T) {
+	r := NewRedactor(nil)
+
+	input := "DB_PASSWORD=\nJWT_SECRET=change-me\nLOG_LEVEL=info\nPORT=3000"
+	got, _, _ := r.RedactContent(input)
+
+	assert.Equal(t, 4, len(strings.Split(got, "\n")),
+		"no line may be removed by redaction")
+	assert.Contains(t, got, "LOG_LEVEL=info")
+	assert.Contains(t, got, "PORT=3000")
+	assert.True(t, strings.HasPrefix(got, "DB_PASSWORD=\n"),
+		"an empty value must not consume the newline")
+	assert.NotContains(t, got, "change-me", "the real secret must still be redacted")
+}
+
+// Redaction must preserve line count for any input, including one where the
+// keyword line has no value at all.
+func TestRedactPreservesLineCount(t *testing.T) {
+	r := NewRedactor(nil)
+
+	inputs := []string{
+		"secret:\nnext line survives",
+		"token=\nkeep me",
+		"password:\n\nblank line between",
+		"access_key=\nauth_token=\nprivate_key=\ndone",
+	}
+
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			got, _, _ := r.RedactContent(in)
+			assert.Equal(t, strings.Count(in, "\n"), strings.Count(got, "\n"),
+				"redaction changed the number of lines")
+		})
+	}
+}
+
+// Guard against over-correcting the newline fix into a false negative: real
+// secrets on a single line must still be redacted.
+func TestRedactStillCatchesRealSecrets(t *testing.T) {
+	r := NewRedactor(nil)
+
+	tests := []struct {
+		name    string
+		input   string
+		leaked  string
+		survive string
+	}{
+		{"aws key with following line", "AWS_KEY=AKIAIOSFODNN7EXAMPLE\nport: 8080", "AKIAIOSFODNN7EXAMPLE", "port: 8080"},
+		{"password with symbols", "DB_PASSWORD=s3cr3t!@#pass\nport: 8080", "s3cr3t!@#pass", "port: 8080"},
+		{"quoted api key", "api_key: \"sk_live_abcdefghijklmnop\"\nport: 8080", "sk_live_abcdefghijklmnop", "port: 8080"},
+		{"tab separated", "password:\ths3cretvalue\nport: 8080", "hs3cretvalue", "port: 8080"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, count, _ := r.RedactContent(tt.input)
+			assert.GreaterOrEqual(t, count, 1)
+			assert.NotContains(t, got, tt.leaked, "secret leaked through redaction")
+			assert.Contains(t, got, tt.survive, "adjacent line was destroyed")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Non-secret content passes through unchanged
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Both keyword-based patterns in the builtin secret list used `['":\s]*[=:]\s*` as
the separator between the keyword and its value. `\s` matches newlines, so a
keyword line with an empty value matched across the line break and consumed the
entire following line, which was then replaced by the placeholder and lost.

Reproduced against the current redactor:

```
in : "DB_PASSWORD=\nJWT_SECRET=change-me\nLOG_LEVEL=info\nPORT=3000"
out: "DB_[REDACTED]\nLOG_LEVEL=info\nPORT=3000"
```

The `JWT_SECRET` line is not redacted, it is deleted. Content goes in and comes
out with a line missing.

## Why it matters now

This is pre-existing and already affected the chat send path. It became more
dangerous once tool results started being redacted before going back into the
agent loop: a model with `file_write` sees source with lines silently absent,
and any rewrite it produces drops them for real.

## Fix

Confine the separator to tabs and spaces so a match can never cross a line
boundary. An empty value now redacts nothing and the next line survives
untouched.

## Verification

Tested both directions, because the obvious failure mode of a fix like this is
over-correcting into a false negative that leaks secrets.

Still redacted (verified): `AKIA...` keys, `password=hunter2xyz`, quoted
`api_key`, `auth_token: ghp_...`, tab-separated values, values containing
`!@#`.

No longer corrupted (verified): empty-value keyword lines, and line count is
preserved for every input.

Three new tests cover the newline boundary, line-count preservation, and the
real-secret guard.

## Known remaining issue, not in this PR

The keyword patterns also match a keyword as a substring of an identifier, so
ordinary source is still altered:

```
"EnvAWSSessionToken = \"AWS_SESSION_TOKEN\""  ->  "EnvAWSSession[REDACTED]"
"token := os.Getenv(\"X\")"                   ->  "[REDACTED]X\")"
```

A `\b` word boundary does not help, since the boundary sits after `Token`
either way. Fixing this needs a start-anchor on the keyword and carries real
false-negative risk, so it belongs in its own change with dedicated coverage
rather than riding along with a corruption fix.
