### PR TITLE
fix(github): give each mock client its own HTTP transport

### DIFF
--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -23,14 +23,20 @@ import (
 
 // urlRewriteTransport redirects all outgoing requests to the test server,
 // preserving the request path so existing mock handlers keep matching.
+//
+// transport is per-instance rather than http.DefaultTransport so that each
+// mock client owns its connection pool. Sharing the process-global default
+// couples every t.Parallel() test in this package to the others' server
+// teardown.
 type urlRewriteTransport struct {
-	base *url.URL
+	base      *url.URL
+	transport http.RoundTripper
 }
 
 func (t *urlRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.URL.Scheme = t.base.Scheme
 	req.URL.Host = t.base.Host
-	return http.DefaultTransport.RoundTrip(req)
+	return t.transport.RoundTrip(req)
 }
 
 // setupMockClient creates a clientImpl backed by an httptest server.
@@ -43,7 +49,14 @@ func setupMockClient(t *testing.T, handler http.HandlerFunc) (*clientImpl, *http
 	baseURL, err := url.Parse(server.URL + "/")
 	require.NoError(t, err)
 
-	httpClient := &http.Client{Transport: &urlRewriteTransport{base: baseURL}}
+	// Clone rather than construct so the transport keeps http.DefaultTransport's
+	// settings while owning its own connection pool. Registering the cleanup
+	// after server.Close means it runs first, draining this client's idle
+	// connections before the server it points at goes away.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	t.Cleanup(transport.CloseIdleConnections)
+
+	httpClient := &http.Client{Transport: &urlRewriteTransport{base: baseURL, transport: transport}}
 	ghClient, err := gh.NewClient(gh.WithHTTPClient(httpClient), gh.WithAuthToken("test-token"))
 	require.NoError(t, err)
 


### PR DESCRIPTION
Closes #401

## Problem

`urlRewriteTransport.RoundTrip` delegated to the process-global `http.DefaultTransport`, so every mock client built by `setupMockClient` shared one connection pool. That coupled all 13 `t.Parallel()` tests in the package to each other's `httptest` server teardown.

The symptom was intermittent race-detector CI failures that looked like real regressions on unrelated PRs, such as this one on #395, which touched only `cmd/clean.go`, `cmd/clean_test.go`, and a docs page:

```
--- FAIL: TestClient_DeleteBranch_Success/long_branch_name
    net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called
```

## Fix

Give each mock client its own transport, and drain it on cleanup.

`http.DefaultTransport.Clone()` rather than a fresh `&http.Transport{}` so the transport keeps the same settings it had before (timeouts, HTTP/2 attempt, proxy resolution) and only the connection pool stops being shared. This keeps the change behavior-preserving apart from the isolation itself.

Cleanup ordering matters and is deliberate: `t.Cleanup` runs LIFO, so registering `transport.CloseIdleConnections` *after* `server.Close` means the transport drains first, before the server it points at goes away.

## Scope

One file, 16 insertions. `setupMockClient` is the single chokepoint for all 125 call sites across 6 test files, so none of them needed changes.

## Verification

- `go test ./internal/github/ -race -count=20` passes
- `go build ./...` clean
- `go vet ./internal/github/` clean
- `gofmt` clean

## Acceptance criteria

- [x] `urlRewriteTransport` uses a per-instance transport, not the global default
- [x] `setupMockClient` closes idle connections for its own transport on cleanup
- [x] `go test ./internal/github/ -race -count=20` passes consistently