### PR TITLE
refactor(theme): filter theme names via the shared textFilterMatches helper

### DIFF
--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -48,14 +48,15 @@ func newThemeListCmd(list themeListFunc) *cobra.Command {
 }
 
 func filterThemeNames(themes []string, filter string) []string {
-	query := strings.TrimSpace(strings.ToLower(filter))
-	if query == "" {
+	if strings.TrimSpace(filter) == "" {
 		return themes
 	}
 
+	// Initialized rather than nil so `--filter <nomatch> --json` encodes []
+	// instead of null.
 	out := []string{}
 	for _, name := range themes {
-		if strings.Contains(strings.ToLower(name), query) {
+		if textFilterMatches(filter, name) {
 			out = append(out, name)
 		}
 	}


### PR DESCRIPTION
Closes #402

## Problem

`filterThemeNames` duplicated the `TrimSpace` / `ToLower` / `Contains` matching that `textFilterMatches` in `cmd/filter.go` already provides. This happened because `--filter` for `grut theme list` (#389) was built in parallel with the shared-helper extraction (#382), so the two landed independently.

`grut keys`, `grut mcp`, and `grut run` all use the shared helper. Theme was the last remaining copy.

## Fix

Call `textFilterMatches` instead of reimplementing the match.

## Two behaviors deliberately preserved

Both are load-bearing and easy to lose in this refactor, so calling them out:

1. **The initialized empty slice.** `out := []string{}` rather than `var out []string` is what makes `grut theme list --filter <nomatch> --json` encode `[]` rather than `null`. `TestThemeListCommandFilterNoMatchesJSON` asserts exactly `"[]\n"`. I added a comment so the next person does not "simplify" it back to nil.

2. **The empty-filter early return.** `textFilterMatches` returns `true` for an empty query, so dropping the early return would still be functionally correct for matching, but it would return a rebuilt slice instead of the input. For a nil input that flips the JSON output from `null` to `[]`, and it copies for no reason. Kept as-is.

## Verification

- `go test ./cmd/ -run Theme` passes, tests unchanged
- `go test ./...` green
- `go build ./...`, `go vet ./cmd/`, `gofmt` all clean

## Acceptance criteria

- [x] Theme filtering uses `textFilterMatches`; no duplicate matching logic left in `cmd/theme.go`
- [x] `grut theme list --filter nomatch --json` still prints `[]`
- [x] Existing `cmd/theme_test.go` tests pass unchanged
