### PR TITLE
fix(config): remove the socket_auth field that never did anything

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,8 +205,6 @@ outside every listed location — this narrowing applies on top of the always-on
 repository jail. An empty list (the default) leaves the jail as the only
 boundary.
 
-> **Note:** `socket_auth` is reserved and not yet enforced ([#174](https://github.com/jongio/grut/issues/174)); setting it currently has no effect.
-
 ---
 
 ## Example: Full Config

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,12 +220,8 @@ type MCPSecurityConfig struct {
 	MaxAgentProcesses   int      `toml:"max_agent_processes"`
 	AgentTimeout        int      `toml:"agent_timeout"`
 	RequireConfirmation bool     `toml:"require_confirmation"`
-	// TODO(#174): socket_auth is declared but not enforced — no code in internal/mcp/
-	// reads this field. Users setting socket_auth=true get no authentication on the
-	// MCP socket. Wire up enforcement or remove this field in a future release.
-	SocketAuth     bool `toml:"socket_auth"`
-	FollowSymlinks bool `toml:"follow_symlinks"`
-	AuditLog       bool `toml:"audit_log"`
+	FollowSymlinks      bool     `toml:"follow_symlinks"`
+	AuditLog            bool     `toml:"audit_log"`
 }
 
 // ExtensionsConfig controls the extension/plugin system.

--- a/internal/config/defaults.toml
+++ b/internal/config/defaults.toml
@@ -115,7 +115,6 @@ require_confirmation = true
 allowed_write_paths = []
 rate_limit_read = 1000
 rate_limit_write = 100
-socket_auth = true
 follow_symlinks = false
 audit_log = true
 audit_log_path = ""


### PR DESCRIPTION
## Problem

`socket_auth` shipped as a **default of `true`** in `defaults.toml`, and no code read it. The MCP server serves over stdio only (`internal/mcp/server.go:86` calls `ServeStdio`), so there is no socket for it to authenticate.

Nothing was exploitable, because there is no listener to leave exposed. The problem is that it read as a security control. A user seeing `socket_auth = true` in the shipped defaults would reasonably conclude the MCP transport was authenticated.

It was also the odd one out. Every sibling field in `MCPSecurityConfig` is enforced somewhere and range-checked in `validate.go`:

| Field | Enforced |
|---|---|
| `allowed_commands`, `allowed_write_paths`, `rate_limit_*`, `require_confirmation`, `follow_symlinks`, `audit_log*` | yes, in `internal/mcp/` |
| `max_agent_processes`, `agent_timeout` | yes, `panels/agents/register.go:11` |
| `socket_auth` | **no reader, no validation** |

The code already flagged it: *"Wire up enforcement or remove this field in a future release."*

## Fix

Removed rather than implemented. Authentication for a transport that doesn't exist has nothing to protect, and adding a socket transport later should come with its own auth design rather than inheriting a flag that predates it.

## Why now

Config keys become part of the compatibility surface at 1.0. Deleting a no-op key today is a footnote; deleting it after 1.0 is a breaking change to a documented schema.

## Compatibility

Existing configs that set `socket_auth` keep loading. `pelletier/go-toml/v2` ignores unknown keys rather than erroring, which I verified empirically rather than assuming. The key becomes inert, which is what it already was.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean
- `go test ./...` green, including `internal/config` and `internal/mcp`
- zero residual references to `socket_auth` or `SocketAuth` anywhere in the repo
